### PR TITLE
[NOTASK] Finalise EKS create and delete

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,8 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+  status:
+    patch: no
 
 parsers:
   gcov:

--- a/cmd/okctl/create.go
+++ b/cmd/okctl/create.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/oslokommune/okctl/pkg/cloud"
 	"github.com/oslokommune/okctl/pkg/credentials"
 	"github.com/oslokommune/okctl/pkg/credentials/login"
 	"github.com/oslokommune/okctl/pkg/okctl"
@@ -17,7 +18,7 @@ const (
 func buildCreateCommand(o *okctl.Okctl) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "CreateIfNotExists commands",
+		Short: "Create commands",
 	}
 
 	cmd.AddCommand(buildCreateClusterCommand(o))
@@ -30,7 +31,7 @@ func buildCreateClusterCommand(o *okctl.Okctl) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "cluster [env] [AWS account id]",
-		Short: "CreateIfNotExists a cluster",
+		Short: "Create a cluster",
 		Long: `Fetch all tasks required to get an EKS cluster up and running on AWS.
 This includes creating an EKS compatible VPC with private, public
 and database subnets.`,
@@ -54,6 +55,13 @@ and database subnets.`,
 			}
 
 			o.CredentialsProvider = credentials.New(l)
+
+			c, err := cloud.New(o.Region(), o.CredentialsProvider)
+			if err != nil {
+				return err
+			}
+
+			o.CloudProvider = c.Provider
 
 			return nil
 		},

--- a/cmd/okctl/delete.go
+++ b/cmd/okctl/delete.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/oslokommune/okctl/pkg/cloud"
+	"github.com/oslokommune/okctl/pkg/credentials"
+	"github.com/oslokommune/okctl/pkg/credentials/login"
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/spf13/cobra"
+)
+
+const (
+	deleteClusterArgs = 1
+)
+
+func buildDeleteCommand(o *okctl.Okctl) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete commands",
+	}
+
+	cmd.AddCommand(buildDeleteClusterCommand(o))
+
+	return cmd
+}
+
+func buildDeleteClusterCommand(o *okctl.Okctl) *cobra.Command {
+	var opts okctl.DeleteClusterOpts
+
+	cmd := &cobra.Command{
+		Use:   "cluster [env]",
+		Short: "Delete a cluster",
+		Long: `Delete all resources related to an EKS cluster,
+including VPC, this is a highly destructive operation.`,
+		Args: cobra.ExactArgs(deleteClusterArgs),
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			opts.Environment = args[0]
+
+			err := opts.Valid()
+			if err != nil {
+				return err
+			}
+
+			if o.NoInput {
+				return fmt.Errorf("delete cluster requires user input for now")
+			}
+
+			awsAccountID, err := o.AWSAccountID(opts.Environment)
+			if err != nil {
+				return err
+			}
+
+			l, err := login.Interactive(awsAccountID, o.Region(), o.Username())
+			if err != nil {
+				return err
+			}
+
+			o.CredentialsProvider = credentials.New(l)
+
+			c, err := cloud.New(o.Region(), o.CredentialsProvider)
+			if err != nil {
+				return err
+			}
+
+			o.CloudProvider = c.Provider
+
+			return nil
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return o.DeleteCluster(opts)
+		},
+		PostRunE: func(_ *cobra.Command, args []string) error {
+			return o.WriteCurrentRepoData()
+		},
+	}
+
+	return cmd
+}

--- a/cmd/okctl/main.go
+++ b/cmd/okctl/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oslokommune/okctl/pkg/config/load"
 	"github.com/oslokommune/okctl/pkg/okctl"
 	"github.com/oslokommune/okctl/pkg/storage"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -78,17 +79,17 @@ being captured. Together with slack and slick.`,
 
 			err = appDataLoader(o, cmd)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "failed to load application data")
 			}
 
 			err = repoDataLoader(o, cmd)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "failed to load repository data")
 			}
 
 			err = binariesProvider(o)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "failed to create binaries provider")
 			}
 
 			o.Out = cmd.OutOrStdout()

--- a/cmd/okctl/main.go
+++ b/cmd/okctl/main.go
@@ -99,6 +99,7 @@ being captured. Together with slack and slick.`,
 	}
 
 	cmd.AddCommand(buildCreateCommand(o))
+	cmd.AddCommand(buildDeleteCommand(o))
 
 	return cmd
 }

--- a/docs/release_notes/0.0.4.md
+++ b/docs/release_notes/0.0.4.md
@@ -1,13 +1,13 @@
 # Release 0.0.4
 
-It is now possible to create an [AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/clusters.html) cluster.
+It is now possible to create and delete a [AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/clusters.html) cluster using okctl. The functionality isn't stable, which means that you might get surprising error messages. Primarily, this is due to a lock of testing, which is why testing will be a focus in the next few releases. This includes nightly integration tests to verify that things still work. 
 
 ## Features
 
 - Implemented a wrapper around the `eksctl` cli
 - Provide ability to delete an EKS cluster and VPC
 - Provide ability to create an EKS cluster and VPC
-- Added outputs to the VPC cloud formation template; we use these outputs when creating the EKS cluster
+- Added outputs to the VPC cloud formation template; we use these outputs when creating the EKS cluster with eksctl
 
 ## Fixes
 

--- a/docs/release_notes/0.0.4.md
+++ b/docs/release_notes/0.0.4.md
@@ -4,8 +4,15 @@ It is now possible to create an [AWS EKS](https://docs.aws.amazon.com/eks/latest
 
 ## Features
 
-- Implemented a wrapper around the `eksctl` cli so we can create the EKS cluster
-- Added outputs to the VPC cloud formation template; these outputs are needed for creating the EKS cluster
+- Implemented a wrapper around the `eksctl` cli
+- Provide ability to delete an EKS cluster and VPC
+- Provide ability to create an EKS cluster and VPC
+- Added outputs to the VPC cloud formation template; we use these outputs when creating the EKS cluster
+
+## Fixes
+
+- Resolved all static analysis issues
+- Turned on more aggressive go linting and resolved all issues
 
 ## Other
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b
 	github.com/sebdah/goldie/v2 v2.5.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/smartystreets/assertions v1.0.0 // indirect

--- a/pkg/cfn/builder/output/output.go
+++ b/pkg/cfn/builder/output/output.go
@@ -30,7 +30,7 @@ func (j *Joined) NamedOutputs() map[string]map[string]interface{} {
 // Outputs returns the outputs only
 func (j *Joined) Outputs() map[string]interface{} {
 	return map[string]interface{}{
-		"NewValue": cloudformation.Join(",", j.Values),
+		"Value": cloudformation.Join(",", j.Values),
 	}
 }
 
@@ -72,7 +72,7 @@ func (v *Value) NamedOutputs() map[string]map[string]interface{} {
 // Outputs returns only the cloud formation outputs
 func (v *Value) Outputs() map[string]interface{} {
 	return map[string]interface{}{
-		"NewValue": v.Value,
+		"Value": v.Value,
 	}
 }
 

--- a/pkg/cfn/builder/vpc/vpc.go
+++ b/pkg/cfn/builder/vpc/vpc.go
@@ -53,7 +53,7 @@ func (b *Builder) Outputs() []cfn.Outputer {
 
 // StackName returns the name of the stack
 func (b *Builder) StackName() string {
-	return fmt.Sprintf("%s-%s-okctl-vpc", b.Name, b.Env)
+	return StackName(b.Name, b.Env)
 }
 
 // Build all resources needed for creating a cloud formation VPC
@@ -113,4 +113,9 @@ func (b *Builder) Build() error {
 	b.resources = append(b.resources, dsg, cpsg)
 
 	return nil
+}
+
+// StackName returns a consistent stack name for a VPC
+func StackName(name, env string) string {
+	return fmt.Sprintf("%s-%s-okctl-vpc", name, env)
 }

--- a/pkg/cfn/process/process.go
+++ b/pkg/cfn/process/process.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 	"github.com/oslokommune/okctl/pkg/cfn/manager"
+	"github.com/pkg/errors"
 )
 
 // Subnets knows how to process the output from a subnet creation
@@ -17,7 +18,7 @@ func Subnets(p v1alpha1.CloudProvider, to map[string]v1alpha1.ClusterNetwork) ma
 			SubnetIds: aws.StringSlice(strings.Split(v, ",")),
 		})
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to describe subnet outputs")
 		}
 
 		for _, s := range got.Subnets {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/mitchellh/go-homedir"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 	"github.com/oslokommune/okctl/pkg/config/application"
 	"github.com/oslokommune/okctl/pkg/config/repository"
 	"github.com/oslokommune/okctl/pkg/context"
 	"github.com/oslokommune/okctl/pkg/storage"
 	"github.com/pkg/errors"
+	"github.com/sanathkr/go-yaml"
 )
 
 const (
@@ -287,7 +289,75 @@ func (c *Config) WriteToOutputDir(env, filePath string, b []byte) error {
 	return nil
 }
 
+// DeleteFromOutputDir removes everything for a given env from path
+func (c *Config) DeleteFromOutputDir(env, filepath string) error {
+	outDir, err := c.GetRepoOutputDir(env)
+	if err != nil {
+		return err
+	}
+
+	store := storage.NewFileSystemStorage(outDir)
+
+	return store.RemoveAll(filepath)
+}
+
+// WriteClusterConfig stores the cluster config
+func (c *Config) WriteClusterConfig(env string, cfg *v1alpha1.ClusterConfig) error {
+	b, err := cfg.YAML()
+	if err != nil {
+		return err
+	}
+
+	return c.WriteToOutputDir(env, path.Join("cluster", "config.yml"), b)
+}
+
+// DeleteClusterConfig deletes the cluster config for a given environment
+func (c *Config) DeleteClusterConfig(env string) error {
+	return c.DeleteFromOutputDir(env, path.Join("cluster", "config.yml"))
+}
+
+// ClusterConfig loads the cluster configuration for the given environment
+func (c *Config) ClusterConfig(env string) (*v1alpha1.ClusterConfig, error) {
+	outDir, err := c.GetRepoOutputDir(env)
+	if err != nil {
+		return nil, err
+	}
+
+	store := storage.NewFileSystemStorage(outDir)
+
+	b, err := store.ReadAll(path.Join("cluster", "config.yml"))
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := v1alpha1.NewClusterConfig()
+
+	return cfg, yaml.Unmarshal(b, cfg)
+}
+
 // ClusterName returns a consistent cluster name
 func (c *Config) ClusterName(env string) string {
 	return fmt.Sprintf("%s-%s", c.RepoData.Name, env)
+}
+
+// AWSAccountID returns the aws account ID for the given env
+func (c *Config) AWSAccountID(env string) (string, error) {
+	for _, cluster := range c.RepoData.Clusters {
+		if cluster.Environment == env {
+			return cluster.AWS.AccountID, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find configuration for cluster: %s", env)
+}
+
+// HasCluster returns true if we can find the cluster in the repo data
+func (c *Config) HasCluster(env string) bool {
+	for _, c := range c.RepoData.Clusters {
+		if c.Environment == env {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,11 @@ const (
 	// DefaultRepositoryConfigType is the default type of the okctl repository config
 	DefaultRepositoryConfigType = "yml"
 
+	// DefaultClusterConfig is the default filename of the eksctl cluster config
+	DefaultClusterConfig = "cluster.yml"
+	// DefaultClusterBaseDir is the default directory name of the eksctl cluster config
+	DefaultClusterBaseDir = "cluster"
+
 	// EnvPrefix of environment variables that will be processed by okctl
 	EnvPrefix = "OKCTL"
 	// EnvHome is the default env var parsed for determining the application home
@@ -321,12 +326,12 @@ func (c *Config) WriteClusterConfig(env string, cfg *v1alpha1.ClusterConfig) err
 		return err
 	}
 
-	return c.WriteToOutputDir(env, path.Join("cluster", "config.yml"), b)
+	return c.WriteToOutputDir(env, path.Join(DefaultClusterBaseDir, DefaultClusterConfig), b)
 }
 
 // DeleteClusterConfig deletes the cluster config for a given environment
 func (c *Config) DeleteClusterConfig(env string) error {
-	return c.DeleteFromOutputDir(env, path.Join("cluster", "config.yml"))
+	return c.DeleteFromOutputDir(env, path.Join(DefaultClusterBaseDir, DefaultClusterConfig))
 }
 
 // ClusterConfig loads the cluster configuration for the given environment
@@ -338,7 +343,7 @@ func (c *Config) ClusterConfig(env string) (*v1alpha1.ClusterConfig, error) {
 
 	store := storage.NewFileSystemStorage(outDir)
 
-	b, err := store.ReadAll(path.Join("cluster", "config.yml"))
+	b, err := store.ReadAll(path.Join(DefaultClusterBaseDir, DefaultClusterConfig))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,6 +123,15 @@ func (c *Config) WriteAppData(b []byte) error {
 	return nil
 }
 
+func (c *Config) WriteCurrentAppData() error {
+	b, err := c.AppData.YAML()
+	if err != nil {
+		return err
+	}
+
+	return c.WriteAppData(b)
+}
+
 // GetRepoDir will return the currently active repository directory
 func (c *Config) GetRepoDir() (string, error) {
 	if len(c.repoDir) != 0 {
@@ -170,6 +179,8 @@ func (c *Config) WriteCurrentRepoData() error {
 	if err != nil {
 		return err
 	}
+
+	c.Logger.Debugf("write current repo data: %s", string(data))
 
 	return c.WriteRepoData(data)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,6 +123,8 @@ func (c *Config) WriteAppData(b []byte) error {
 	return nil
 }
 
+// WriteCurrentAppData writes the current app data state
+// to disk
 func (c *Config) WriteCurrentAppData() error {
 	b, err := c.AppData.YAML()
 	if err != nil {

--- a/pkg/config/load/application.go
+++ b/pkg/config/load/application.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/oslokommune/okctl/pkg/config"
 	"github.com/oslokommune/okctl/pkg/config/application"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -57,20 +58,15 @@ func CreateOnAppDataNotFound() DataNotFoundFn {
 
 		data, err := application.New().Survey()
 		if err != nil {
-			return err
-		}
-
-		b, err := yaml.Marshal(data)
-		if err != nil {
-			return err
-		}
-
-		err = c.WriteAppData(b)
-		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to get interactive user data")
 		}
 
 		c.AppData = data
+
+		err = c.WriteCurrentAppData()
+		if err != nil {
+			return errors.Wrap(err, "failed to write current app data")
+		}
 
 		c.Logger.WithFields(logrus.Fields{
 			"configuration_file": appDataPath,

--- a/pkg/config/load/repository.go
+++ b/pkg/config/load/repository.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/oslokommune/okctl/pkg/config"
 	"github.com/oslokommune/okctl/pkg/config/repository"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"sigs.k8s.io/yaml"
 )
 
 // ErrOnRepoDataNotFound will simply error if no
@@ -50,17 +50,12 @@ func CreateOnRepoDataNotFound() DataNotFoundFn {
 			return err
 		}
 
-		b, err := yaml.Marshal(data)
-		if err != nil {
-			return err
-		}
-
-		err = c.WriteRepoData(b)
-		if err != nil {
-			return err
-		}
-
 		c.RepoData = data
+
+		err = c.WriteCurrentRepoData()
+		if err != nil {
+			return errors.Wrap(err, "failed to write current repo data")
+		}
 
 		c.Logger.WithFields(logrus.Fields{
 			"configuration_file": repoDataPath,

--- a/pkg/config/repository/repository.go
+++ b/pkg/config/repository/repository.go
@@ -134,7 +134,7 @@ func (d *Data) Survey() (*Data, error) {
 	d.Region = answers.Region
 	d.OutputDir = answers.BaseDir
 
-	return nil, errors.Wrap(d.Validate(), "failed to validate repository data")
+	return d, errors.Wrap(d.Validate(), "failed to validate repository data")
 }
 
 // YAML returns the state of the data object in YAML

--- a/pkg/okctl/cluster.go
+++ b/pkg/okctl/cluster.go
@@ -161,10 +161,7 @@ func (o *Okctl) CreateCluster(opts CreateClusterOpts) error {
 
 	ctxLogger.Info("Starting EKS cluster creation process")
 
-	exists := o.HasCluster(opts.Environment)
-	if exists {
-		return fmt.Errorf("cluster for env: %s, already exists", opts.Environment)
-	}
+	ctxLogger.Debugf("known repository data: %s", o.RepoData)
 
 	m := manager.New(o.Logger, o.CloudProvider).
 		WithBuilder(vpc.New(o.RepoData.Name, opts.Environment, opts.Cidr, o.Region()))
@@ -173,6 +170,8 @@ func (o *Okctl) CreateCluster(opts CreateClusterOpts) error {
 	if err != nil {
 		return err
 	}
+
+	o.RepoData.Clusters = remove(opts.Environment, o.RepoData.Clusters)
 
 	o.RepoData.Clusters = append(o.RepoData.Clusters, repository.Cluster{
 		Environment: opts.Environment,
@@ -196,6 +195,8 @@ func (o *Okctl) CreateCluster(opts CreateClusterOpts) error {
 	if err != nil {
 		return err
 	}
+
+	ctxLogger.Debugf("cluster config: %s", clusterConfig)
 
 	err = eksctl.CreateCluster(o.Err, clusterConfig)
 	if err != nil {

--- a/pkg/okctl/cluster.go
+++ b/pkg/okctl/cluster.go
@@ -10,15 +10,19 @@ import (
 	"github.com/oslokommune/okctl/pkg/cfn/builder/vpc"
 	"github.com/oslokommune/okctl/pkg/cfn/manager"
 	"github.com/oslokommune/okctl/pkg/cfn/process"
-	"github.com/oslokommune/okctl/pkg/cloud"
+	"github.com/oslokommune/okctl/pkg/config/repository"
 	eksctlPkg "github.com/oslokommune/okctl/pkg/run/eksctl"
 	"github.com/sirupsen/logrus"
 )
 
-const defaultTimeOut = 5
+const (
+	defaultTimeOut = 5
+	envMinLength   = 3
+	envMaxLength   = 10
+)
 
 // CreateClusterOpts defines the inputs required for creating a
-// new cluster
+// new EKS cluster
 type CreateClusterOpts struct {
 	AWSAccountID string
 	Environment  string
@@ -38,10 +42,6 @@ func (o *CreateClusterOpts) LoggerContext(logger *logrus.Logger) *logrus.Entry {
 
 // Valid determines if the provided cluster inputs are valid
 func (o *CreateClusterOpts) Valid() error {
-	const minLength = 3
-
-	const maxLength = 10
-
 	return val.ValidateStruct(o,
 		val.Field(&o.AWSAccountID,
 			val.Required,
@@ -50,10 +50,33 @@ func (o *CreateClusterOpts) Valid() error {
 		),
 		val.Field(&o.Environment,
 			val.Required,
-			val.Length(minLength, maxLength),
+			val.Length(envMinLength, envMaxLength),
 		),
 		val.Field(&o.Cidr,
 			val.Required,
+		),
+	)
+}
+
+// DeleteClusterOpts defines the inputs required for removing an
+// existing EKS cluster
+type DeleteClusterOpts struct {
+	Environment string
+}
+
+// LoggerContext creates a log context based on the provided inputs
+func (o *DeleteClusterOpts) LoggerContext(logger *logrus.Logger) *logrus.Entry {
+	return logger.WithFields(logrus.Fields{
+		"environment": o.Environment,
+	})
+}
+
+// Valid determines if the delete cluster opts are correct
+func (o *DeleteClusterOpts) Valid() error {
+	return val.ValidateStruct(o,
+		val.Field(&o.Environment,
+			val.Required,
+			val.Length(envMinLength, envMaxLength),
 		),
 	)
 }
@@ -75,32 +98,89 @@ func ClusterConfig(name, region, cidr, awsAccountID string, m *manager.Manager, 
 	})
 }
 
-// CreateCluster starts the creation of all resources related to an EKS cluster
-// such as a VPC, etc.
-func (o *Okctl) CreateCluster(opts CreateClusterOpts) error {
+// DeleteCluster removes an EKS cluster and all related resources
+func (o *Okctl) DeleteCluster(opts DeleteClusterOpts) error {
 	ctxLogger := opts.LoggerContext(o.Logger)
 
-	ctxLogger.Info("Starting EKS cluster creation process")
+	ctxLogger.Info("Started EKS cluster deletion process")
 
-	for _, c := range o.RepoData.Clusters {
-		if c.Environment == opts.Environment && c.AWS.AccountID == opts.AWSAccountID {
-			return fmt.Errorf("cluster: %s, already exists", opts.Environment)
-		}
+	exists := o.HasCluster(opts.Environment)
+	if !exists {
+		return fmt.Errorf("couldn't find cluster for env: %s", opts.Environment)
 	}
 
-	builder := vpc.New(o.RepoData.Name, opts.Environment, opts.Cidr, o.Region())
-
-	prov, err := cloud.New(o.Region(), o.CredentialsProvider)
+	eksctl, err := eksctlPkg.New(o.Logger, o.CredentialsProvider, o.BinariesProvider)
 	if err != nil {
 		return err
 	}
 
-	m := manager.New(o.Logger, builder, prov.Provider)
+	clusterConfig, err := o.ClusterConfig(opts.Environment)
+	if err != nil {
+		return err
+	}
+
+	err = eksctl.DeleteCluster(o.Err, clusterConfig)
+	if err != nil {
+		return err
+	}
+
+	err = o.DeleteClusterConfig(opts.Environment)
+	if err != nil {
+		return err
+	}
+
+	m := manager.New(o.Logger, o.CloudProvider)
+
+	err = m.Delete(vpc.StackName(o.RepoData.Name, opts.Environment))
+	if err != nil {
+		return err
+	}
+
+	o.RepoData.Clusters = remove(opts.Environment, o.RepoData.Clusters)
+
+	return nil
+}
+
+func remove(env string, clusters []repository.Cluster) []repository.Cluster {
+	for i, c := range clusters {
+		if c.Environment == env {
+			clusters[i] = clusters[len(clusters)-1]
+			return clusters[:len(clusters)-1]
+		}
+	}
+
+	return clusters
+}
+
+// CreateCluster starts the creation of all resources related to an EKS cluster
+// such as a VPC, etc.
+func (o *Okctl) CreateCluster(opts CreateClusterOpts) error {
+	var err error
+
+	ctxLogger := opts.LoggerContext(o.Logger)
+
+	ctxLogger.Info("Starting EKS cluster creation process")
+
+	exists := o.HasCluster(opts.Environment)
+	if exists {
+		return fmt.Errorf("cluster for env: %s, already exists", opts.Environment)
+	}
+
+	m := manager.New(o.Logger, o.CloudProvider).
+		WithBuilder(vpc.New(o.RepoData.Name, opts.Environment, opts.Cidr, o.Region()))
 
 	err = m.CreateIfNotExists(defaultTimeOut)
 	if err != nil {
 		return err
 	}
+
+	o.RepoData.Clusters = append(o.RepoData.Clusters, repository.Cluster{
+		Environment: opts.Environment,
+		AWS: repository.AWS{
+			AccountID: opts.AWSAccountID,
+			Cidr:      opts.Cidr,
+		},
+	})
 
 	err = o.WriteCurrentRepoData()
 	if err != nil {
@@ -112,7 +192,7 @@ func (o *Okctl) CreateCluster(opts CreateClusterOpts) error {
 		return err
 	}
 
-	clusterConfig, err := ClusterConfig(o.ClusterName(opts.Environment), o.Region(), opts.Cidr, opts.AWSAccountID, m, prov.Provider)
+	clusterConfig, err := ClusterConfig(o.ClusterName(opts.Environment), o.Region(), opts.Cidr, opts.AWSAccountID, m, o.CloudProvider)
 	if err != nil {
 		return err
 	}
@@ -122,12 +202,8 @@ func (o *Okctl) CreateCluster(opts CreateClusterOpts) error {
 		return err
 	}
 
-	yaml, err := clusterConfig.YAML()
-	if err != nil {
-		return err
-	}
-
-	err = o.WriteToOutputDir(opts.Environment, "cluster.yml", yaml)
+	// Move these storage operations into cobra and PostRunE
+	err = o.WriteClusterConfig(opts.Environment, clusterConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -1,6 +1,7 @@
 package okctl
 
 import (
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 	"github.com/oslokommune/okctl/pkg/binaries"
 	"github.com/oslokommune/okctl/pkg/config"
 	"github.com/oslokommune/okctl/pkg/credentials"
@@ -10,6 +11,7 @@ import (
 type Okctl struct {
 	*config.Config
 
+	CloudProvider       v1alpha1.CloudProvider
 	BinariesProvider    binaries.Provider
 	CredentialsProvider credentials.Provider
 }

--- a/pkg/run/eksctl/eksctl.go
+++ b/pkg/run/eksctl/eksctl.go
@@ -17,6 +17,8 @@ const (
 	Name = "eksctl"
 	// Version sets the currently used version of the binary/cli
 	Version = "0.21.0"
+
+	defaultClusterConfig = "cluster-config.yml"
 )
 
 // Eksctl stores state for working with the eksctl cli
@@ -61,7 +63,7 @@ func (e *Eksctl) writeTemporaryClusterConfig(cfg *v1alpha1.ClusterConfig) error 
 		return err
 	}
 
-	file, err := e.Store.Create("", "cluster-config.yml", 0644)
+	file, err := e.Store.Create("", defaultClusterConfig, 0644)
 	if err != nil {
 		return err
 	}
@@ -96,7 +98,7 @@ func (e *Eksctl) DeleteCluster(progress io.Writer, cfg *v1alpha1.ClusterConfig) 
 		"delete",
 		"cluster",
 		"--config-file",
-		e.Store.Abs("cluster-config.yml"),
+		e.Store.Abs(defaultClusterConfig),
 	}
 
 	_, err = e.Runner.Run(progress, args)
@@ -125,7 +127,7 @@ func (e *Eksctl) CreateCluster(progress io.Writer, cfg *v1alpha1.ClusterConfig) 
 		"cluster",
 		"--write-kubeconfig=false",
 		"--config-file",
-		e.Store.Abs("cluster-config.yml"),
+		e.Store.Abs(defaultClusterConfig),
 	}
 
 	_, err = e.Runner.Run(progress, args)

--- a/pkg/run/eksctl/eksctl.go
+++ b/pkg/run/eksctl/eksctl.go
@@ -95,7 +95,6 @@ func (e *Eksctl) DeleteCluster(progress io.Writer, cfg *v1alpha1.ClusterConfig) 
 	args := []string{
 		"delete",
 		"cluster",
-		"--write-kubeconfig=false",
 		"--config-file",
 		e.Store.Abs("cluster-config.yml"),
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -28,6 +28,8 @@ type Cleaner interface {
 // and directories
 type Storer interface {
 	Create(dir, name string, perms os.FileMode) (afero.File, error)
+	RemoveAll(path string) error
+	ReadAll(path string) ([]byte, error)
 	MkdirAll(dir string) error
 	Exists(name string) (bool, error)
 	Abs(name string) string
@@ -37,6 +39,22 @@ type Storer interface {
 type Storage struct {
 	Path string
 	Fs   afero.Fs
+}
+
+// ReadAll returns all the content of a file
+func (s *Storage) ReadAll(path string) ([]byte, error) {
+	f, err := s.Fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return ioutil.ReadAll(f)
+}
+
+// RemoveAll returns no error if it successfully remove everything
+// under the given path
+func (s *Storage) RemoveAll(path string) error {
+	return s.Fs.RemoveAll(path)
 }
 
 // MkdirAll creates a directory and all preceding directories

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -76,7 +76,7 @@ func (s *Storage) Create(dir, file string, perms os.FileMode) (afero.File, error
 
 // Recreate will delete a file and then recreate it
 func (s *Storage) Recreate(dir, file string, perms os.FileMode) (afero.File, error) {
-	err := s.Fs.Remove(path.Join(dir, file))
+	err := s.Fs.RemoveAll(path.Join(dir, file))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We now have the functionality we need to create an EKS cluster with okctl. It builds a VPC and creates it using cloud formation. The VPC is, in turn, added to the configuration of an eksctl compatible cluster configuration. We then invoke eksctl to do the rest of the heavy lifting.