### PR TITLE
[KM24] Add a default Fargate profile

### DIFF
--- a/pkg/api/clusterconfig.go
+++ b/pkg/api/clusterconfig.go
@@ -21,10 +21,11 @@ const (
 type ClusterConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Metadata   ClusterMeta `json:"metadata"`
-	IAM        ClusterIAM  `json:"iam"`
-	VPC        ClusterVPC  `json:"vpc"`
-	NodeGroups []NodeGroup `json:"nodeGroups"`
+	Metadata        ClusterMeta      `json:"metadata"`
+	IAM             ClusterIAM       `json:"iam"`
+	VPC             ClusterVPC       `json:"vpc"`
+	FargateProfiles []FargateProfile `json:"fargateProfiles,omitempty"`
+	NodeGroups      []NodeGroup      `json:"nodeGroups"`
 }
 
 // ClusterMeta comes from eksctl and maps up what we need
@@ -66,6 +67,18 @@ type ClusterNetwork struct {
 	CIDR string `json:"cidr"`
 }
 
+// FargateProfile comes from eksctl and maps up what we need
+type FargateProfile struct {
+	Name      string                   `json:"name"`
+	Selectors []FargateProfileSelector `json:"selectors"`
+}
+
+// FargateProfileSelector comes from eksctl and maps up what we need
+type FargateProfileSelector struct {
+	Namespace string            `json:"namespace"`
+	Labels    map[string]string `json:"labels,omitempty"`
+}
+
 // NodeGroup comes from eksctl and maps up what we need
 type NodeGroup struct {
 }
@@ -85,6 +98,15 @@ func NewClusterConfig() *ClusterConfig {
 		TypeMeta: ClusterConfigTypeMeta(),
 		IAM: ClusterIAM{
 			WithOIDC: true,
+		},
+		FargateProfiles: []FargateProfile{
+			{
+				Name: "fp-default",
+				Selectors: []FargateProfileSelector{
+					{Namespace: "default"},
+					{Namespace: "kube-system"},
+				},
+			},
 		},
 		VPC: ClusterVPC{
 			ClusterEndpoints: ClusterEndpoints{

--- a/pkg/api/testdata/clusterConfig.golden
+++ b/pkg/api/testdata/clusterConfig.golden
@@ -1,4 +1,9 @@
 apiVersion: eksctl.io/v1alpha5
+fargateProfiles:
+- name: fp-default
+  selectors:
+  - namespace: default
+  - namespace: kube-system
 iam:
   fargatePodExecutionRolePermissionsBoundary: ""
   serviceRolePermissionsBoundary: ""


### PR DESCRIPTION
This adds a default Fargate profile to the default and kube-system
namespaces.

## Description
Pods created in those namespaces will be scheduled onto
Fargate.

## Motivation and Context
Pods scheduled onto Fargate don't consume resources in a node group, and will most likely lead to more efficient utilisation of resources.

## How Has This Been Tested?
No tests yet

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.