### PR TITLE
[KM28] Add support for creating TLS certificates

### DIFF
--- a/pkg/api/certificate.go
+++ b/pkg/api/certificate.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"context"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Certificate contains the state for a certificate
+type Certificate struct {
+	Repository             string
+	Environment            string
+	FQDN                   string
+	Domain                 string
+	HostedZoneID           string
+	CertificateARN         string
+	StackName              string
+	CloudFormationTemplate []byte
+}
+
+// CreateCertificateOpts contains the input required for creating a certificate
+type CreateCertificateOpts struct {
+	Repository   string
+	Environment  string
+	FQDN         string
+	Domain       string
+	HostedZoneID string
+}
+
+// Validate the input
+func (o CreateCertificateOpts) Validate() error {
+	return validation.ValidateStruct(&o,
+		validation.Field(&o.Repository, validation.Required),
+		validation.Field(&o.Environment, validation.Required),
+		validation.Field(&o.FQDN, validation.Required),
+		validation.Field(&o.Domain, validation.Required),
+		validation.Field(&o.HostedZoneID, validation.Required),
+	)
+}
+
+// CertificateService defines the service layer operations
+type CertificateService interface {
+	CreateCertificate(ctx context.Context, opts CreateCertificateOpts) (*Certificate, error)
+}
+
+// CertificateCloudProvider defines the cloud interaction
+type CertificateCloudProvider interface {
+	CreateCertificate(opts CreateCertificateOpts) (*Certificate, error)
+}
+
+// CertificateStore defines the storage operations
+type CertificateStore interface {
+	SaveCertificate(certificate *Certificate) error
+}

--- a/pkg/api/core/cloudprovider/aws/certificate.go
+++ b/pkg/api/core/cloudprovider/aws/certificate.go
@@ -9,52 +9,46 @@ import (
 	"github.com/oslokommune/okctl/pkg/api/okctl.io/v1alpha1"
 	"github.com/oslokommune/okctl/pkg/cfn"
 	"github.com/oslokommune/okctl/pkg/cfn/components"
-	"github.com/oslokommune/okctl/pkg/cfn/components/hostedzone"
 )
 
-type domain struct {
+type certificate struct {
 	provider v1alpha1.CloudProvider
 }
 
-func (d *domain) CreateDomain(opts api.CreateDomainOpts) (*api.Domain, error) {
-	b := cfn.New(components.NewHostedZoneComposer(opts.FQDN, "A public hosted zone for creating ingresses with"))
+func (c *certificate) CreateCertificate(opts api.CreateCertificateOpts) (*api.Certificate, error) {
+	b := cfn.New(components.NewPublicCertificateComposer(opts.FQDN, opts.HostedZoneID))
 
 	parts := strings.SplitN(opts.Domain, ".", 2)
 	if len(parts) != 2 { // nolint: gomnd
 		return nil, fmt.Errorf("failed to extract sub domain")
 	}
 
-	stackName := cfn.NewStackNamer().Domain(opts.Repository, opts.Environment, parts[0])
+	stackName := cfn.NewStackNamer().Certificate(opts.Repository, opts.Environment, parts[0])
 
 	template, err := b.Build()
 	if err != nil {
 		return nil, errors.E(err, "failed to build cloud formation template")
 	}
 
-	template, err = hostedzone.PatchYAML(template)
-	if err != nil {
-		return nil, errors.E(err, "failed to patch template body")
-	}
-
-	r := cfn.NewRunner(d.provider)
+	r := cfn.NewRunner(c.provider)
 
 	err = r.CreateIfNotExists(stackName, template, nil, defaultTimeOut)
 	if err != nil {
 		return nil, errors.E(err, "failed to create cloud formation template")
 	}
 
-	p := &api.Domain{
+	p := &api.Certificate{
 		Repository:             opts.Repository,
 		Environment:            opts.Environment,
 		FQDN:                   opts.FQDN,
 		Domain:                 opts.Domain,
+		HostedZoneID:           opts.HostedZoneID,
 		StackName:              stackName,
 		CloudFormationTemplate: template,
 	}
 
 	err = r.Outputs(stackName, map[string]cfn.ProcessOutputFn{
-		"PublicHostedZone": cfn.String(&p.HostedZoneID),
-		"NameServers":      cfn.StringSlice(&p.NameServers),
+		"Certificate": cfn.String(&p.CertificateARN),
 	})
 	if err != nil {
 		return nil, errors.E(err, "failed to process outputs")
@@ -63,9 +57,9 @@ func (d *domain) CreateDomain(opts api.CreateDomainOpts) (*api.Domain, error) {
 	return p, nil
 }
 
-// NewDomainCloudProvider returns an initialised cloud provider for domains
-func NewDomainCloudProvider(provider v1alpha1.CloudProvider) api.DomainCloudProvider {
-	return &domain{
+// NewCertificateCloudProvider returns an initialised cloud provider
+func NewCertificateCloudProvider(provider v1alpha1.CloudProvider) api.CertificateCloudProvider {
+	return &certificate{
 		provider: provider,
 	}
 }

--- a/pkg/api/core/endpoint_certificate.go
+++ b/pkg/api/core/endpoint_certificate.go
@@ -1,0 +1,14 @@
+package core
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/oslokommune/okctl/pkg/api"
+)
+
+func makeCreateCertificateEndpoint(s api.CertificateService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return s.CreateCertificate(ctx, request.(api.CreateCertificateOpts))
+	}
+}

--- a/pkg/api/core/handler.go
+++ b/pkg/api/core/handler.go
@@ -29,6 +29,7 @@ type Endpoints struct {
 	CreateExternalDNSServiceAccount          endpoint.Endpoint
 	CreateExternalDNSKubeDeployment          endpoint.Endpoint
 	CreateDomain                             endpoint.Endpoint
+	CreateCertificate                        endpoint.Endpoint
 }
 
 // MakeEndpoints returns the endpoints initialised with their
@@ -49,6 +50,7 @@ func MakeEndpoints(s Services) Endpoints {
 		CreateExternalDNSServiceAccount:          makeCreateExternalDNSServiceAccountEndpoint(s.ServiceAccount),
 		CreateExternalDNSKubeDeployment:          makeCreateExternalDNSKubeDeploymentEndpoint(s.Kube),
 		CreateDomain:                             makeCreateDomainEndpoint(s.Domain),
+		CreateCertificate:                        makeCreateCertificateEndpoint(s.Certificate),
 	}
 }
 
@@ -68,6 +70,7 @@ type Handlers struct {
 	CreateExternalDNSServiceAccount          http.Handler
 	CreateExternalDNSKubeDeployment          http.Handler
 	CreateDomain                             http.Handler
+	CreateCertificate                        http.Handler
 }
 
 // EncodeResponseType defines a type for responses
@@ -114,6 +117,7 @@ func MakeHandlers(responseType EncodeResponseType, endpoints Endpoints) *Handler
 		CreateExternalDNSServiceAccount:          newServer(endpoints.CreateExternalDNSServiceAccount, decodeCreateExternalDNSServiceAccount),
 		CreateExternalDNSKubeDeployment:          newServer(endpoints.CreateExternalDNSKubeDeployment, decodeCreateExternalDNSKubeDeployment),
 		CreateDomain:                             newServer(endpoints.CreateDomain, decodeCreateDomain),
+		CreateCertificate:                        newServer(endpoints.CreateCertificate, decodeCreateCertificate),
 	}
 }
 
@@ -168,6 +172,9 @@ func AttachRoutes(handlers *Handlers) http.Handler {
 		r.Route("/domains", func(r chi.Router) {
 			r.Method(http.MethodPost, "/", handlers.CreateDomain)
 		})
+		r.Route("/certificates", func(r chi.Router) {
+			r.Method(http.MethodPost, "/", handlers.CreateCertificate)
+		})
 	})
 
 	return r
@@ -182,6 +189,7 @@ type Services struct {
 	Helm           api.HelmService
 	Kube           api.KubeService
 	Domain         api.DomainService
+	Certificate    api.CertificateService
 }
 
 // EndpointOption makes it easy to enable and disable the endpoint
@@ -199,6 +207,7 @@ const (
 	externalDNSTag          = "externaldns"
 	kubeTag                 = "kube"
 	domainTag               = "domain"
+	certificateTag          = "certificate"
 )
 
 // InstrumentEndpoints adds instrumentation to the endpoints
@@ -220,6 +229,7 @@ func InstrumentEndpoints(logger *logrus.Logger) EndpointOption {
 			CreateExternalDNSServiceAccount:          middleware.Logging(logger, strings.Join([]string{serviceAccountsTag, externalDNSTag}, "/"), "create")(endpoints.CreateExternalDNSServiceAccount),
 			CreateExternalDNSKubeDeployment:          middleware.Logging(logger, strings.Join([]string{kubeTag, externalDNSTag}, "/"), "create")(endpoints.CreateExternalDNSKubeDeployment),
 			CreateDomain:                             middleware.Logging(logger, domainTag, "create")(endpoints.CreateDomain),
+			CreateCertificate:                        middleware.Logging(logger, certificateTag, "create")(endpoints.CreateCertificate),
 		}
 	}
 }

--- a/pkg/api/core/service_certificate.go
+++ b/pkg/api/core/service_certificate.go
@@ -1,0 +1,40 @@
+package core
+
+import (
+	"context"
+
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/api"
+)
+
+type certificateService struct {
+	cloudProvider api.CertificateCloudProvider
+	store         api.CertificateStore
+}
+
+func (c *certificateService) CreateCertificate(ctx context.Context, opts api.CreateCertificateOpts) (*api.Certificate, error) {
+	err := opts.Validate()
+	if err != nil {
+		return nil, errors.E(err, "failed to validate certificate inputs", errors.Invalid)
+	}
+
+	cert, err := c.cloudProvider.CreateCertificate(opts)
+	if err != nil {
+		return nil, errors.E(err, "failed to create certificate", errors.Internal)
+	}
+
+	err = c.store.SaveCertificate(cert)
+	if err != nil {
+		return nil, errors.E(err, "failed to store certificate", errors.IO)
+	}
+
+	return cert, nil
+}
+
+// NewCertificateService returns an initialised certificate service
+func NewCertificateService(cloudProvider api.CertificateCloudProvider, store api.CertificateStore) api.CertificateService {
+	return &certificateService{
+		cloudProvider: cloudProvider,
+		store:         store,
+	}
+}

--- a/pkg/api/core/store/filesystem/certificate.go
+++ b/pkg/api/core/store/filesystem/certificate.go
@@ -1,0 +1,107 @@
+package filesystem
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/config/repository"
+	"github.com/spf13/afero"
+)
+
+type certificateStore struct {
+	paths     Paths
+	repoPaths Paths
+	repoState *repository.Data
+	fs        *afero.Afero
+}
+
+// Certificate contains the data we store to the outputs
+type Certificate struct {
+	Repository     string
+	Environment    string
+	FQDN           string
+	Domain         string
+	HostedZoneID   string
+	CertificateARN string
+	StackName      string
+}
+
+// nolint: funlen
+func (c *certificateStore) SaveCertificate(certificate *api.Certificate) error {
+	cert := Certificate{
+		Repository:     certificate.Repository,
+		Environment:    certificate.Environment,
+		FQDN:           certificate.FQDN,
+		Domain:         certificate.Domain,
+		HostedZoneID:   certificate.HostedZoneID,
+		CertificateARN: certificate.CertificateARN,
+		StackName:      certificate.CertificateARN,
+	}
+
+	data, err := json.Marshal(cert)
+	if err != nil {
+		return fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	err = c.fs.MkdirAll(path.Join(c.paths.BaseDir, certificate.Domain), 0o744)
+	if err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	err = c.fs.WriteFile(path.Join(c.paths.BaseDir, certificate.Domain, c.paths.OutputFile), data, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to write outputs: %w", err)
+	}
+
+	err = c.fs.WriteFile(path.Join(c.paths.BaseDir, certificate.Domain, c.paths.CloudFormationFile), certificate.CloudFormationTemplate, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to write cloud formation template: %w", err)
+	}
+
+	for i, cluster := range c.repoState.Clusters {
+		if cluster.Environment == certificate.Environment {
+			found := false
+
+			for _, storedCert := range cluster.Certificates {
+				if storedCert.ARN == certificate.CertificateARN {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				cluster.Certificates = append(cluster.Certificates, repository.Certificate{
+					ARN:    certificate.CertificateARN,
+					Domain: certificate.Domain,
+					FQDN:   certificate.FQDN,
+				})
+			}
+
+			c.repoState.Clusters[i] = cluster
+		}
+	}
+
+	err = c.fs.MkdirAll(c.repoPaths.BaseDir, 0o744)
+	if err != nil {
+		return err
+	}
+
+	state, err := c.repoState.YAML()
+	if err != nil {
+		return err
+	}
+
+	return c.fs.WriteFile(path.Join(c.repoPaths.BaseDir, c.repoPaths.ConfigFile), state, 0o644)
+}
+
+// NewCertificateStore returns an initialised certificate store
+func NewCertificateStore(repoState *repository.Data, paths, repoPaths Paths, fs *afero.Afero) api.CertificateStore {
+	return &certificateStore{
+		paths:     paths,
+		repoPaths: repoPaths,
+		repoState: repoState,
+		fs:        fs,
+	}
+}

--- a/pkg/api/core/transport_certificate.go
+++ b/pkg/api/core/transport_certificate.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/oslokommune/okctl/pkg/api"
+)
+
+func decodeCreateCertificate(_ context.Context, r *http.Request) (interface{}, error) {
+	var opts api.CreateCertificateOpts
+
+	err := json.NewDecoder(r.Body).Decode(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}

--- a/pkg/cfn/builder_test.go
+++ b/pkg/cfn/builder_test.go
@@ -35,6 +35,11 @@ func TestBuilderAndComposers(t *testing.T) {
 			golden:   "external-dns-cloudformation.yaml",
 			composer: components.NewExternalDNSPolicyComposer("repo", "env"),
 		},
+		{
+			name:     "Builder with PublicCertificate composer",
+			golden:   "public-certificate-cf.yaml",
+			composer: components.NewPublicCertificateComposer("test.oslo.systems.", "AZ12345"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/cfn/components/certificate/certificate.go
+++ b/pkg/cfn/components/certificate/certificate.go
@@ -1,0 +1,53 @@
+// Package certificate creates components for an ACM public certificate
+package certificate
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation"
+	"github.com/awslabs/goformation/v4/cloudformation/certificatemanager"
+	"github.com/oslokommune/okctl/pkg/cfn"
+)
+
+// Certificate contains state for building a cloud formation resource
+type Certificate struct {
+	StoredName   string
+	FQDN         string
+	HostedZoneID string
+}
+
+// NamedOutputs returns the named outputs
+func (c Certificate) NamedOutputs() map[string]map[string]interface{} {
+	return cfn.NewValue(c.Name(), c.Ref()).NamedOutputs()
+}
+
+// Resource returns the cloud formation resource
+func (c *Certificate) Resource() cloudformation.Resource {
+	return &certificatemanager.Certificate{
+		DomainName: c.FQDN,
+		DomainValidationOptions: []certificatemanager.Certificate_DomainValidationOption{
+			{
+				DomainName:   c.FQDN,
+				HostedZoneId: c.HostedZoneID,
+			},
+		},
+		ValidationMethod: "DNS",
+	}
+}
+
+// Name returns the logical identifier
+func (c *Certificate) Name() string {
+	return c.StoredName
+}
+
+// Ref returns an aws intrinsic ref to this resource
+func (c *Certificate) Ref() string {
+	return cloudformation.Ref(c.Name())
+}
+
+// New initialises a new certificate
+func New(fqdn, hostedZoneID string) *Certificate {
+	return &Certificate{
+		StoredName:   "PublicCertificate",
+		FQDN:         fqdn,
+		HostedZoneID: hostedZoneID,
+	}
+}

--- a/pkg/cfn/components/certificate/certificate_test.go
+++ b/pkg/cfn/components/certificate/certificate_test.go
@@ -1,0 +1,46 @@
+package certificate_test
+
+import (
+	"testing"
+
+	"github.com/awslabs/goformation/v4/cloudformation"
+	"github.com/oslokommune/okctl/pkg/cfn/components/certificate"
+	"github.com/sebdah/goldie/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	testCases := []struct {
+		name   string
+		golden string
+		cert   *certificate.Certificate
+	}{
+		{
+			name:   "Valid output",
+			golden: "certificate",
+			cert:   certificate.New("test.oslo.systems.", "AZ12345678"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			template := cloudformation.NewTemplate()
+
+			template.Resources = map[string]cloudformation.Resource{
+				tc.cert.Name(): tc.cert.Resource(),
+			}
+
+			for k, v := range tc.cert.NamedOutputs() {
+				template.Outputs[k] = v
+			}
+
+			got, err := template.YAML()
+			assert.NoError(t, err)
+
+			g := goldie.New(t)
+			g.Assert(t, tc.golden, got)
+		})
+	}
+}

--- a/pkg/cfn/components/certificate/testdata/certificate.golden
+++ b/pkg/cfn/components/certificate/testdata/certificate.golden
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: 2010-09-09
+Outputs:
+  PublicCertificate:
+    Value:
+      Ref: PublicCertificate
+Resources:
+  PublicCertificate:
+    Properties:
+      DomainName: test.oslo.systems.
+      DomainValidationOptions:
+      - DomainName: test.oslo.systems.
+        HostedZoneId: AZ12345678
+      ValidationMethod: DNS
+    Type: AWS::CertificateManager::Certificate

--- a/pkg/cfn/components/composer.go
+++ b/pkg/cfn/components/composer.go
@@ -5,6 +5,8 @@ package components
 import (
 	"fmt"
 
+	"github.com/oslokommune/okctl/pkg/cfn/components/certificate"
+
 	"github.com/awslabs/goformation/v4/cloudformation"
 	"github.com/oslokommune/okctl/pkg/cfn"
 	cidrPkg "github.com/oslokommune/okctl/pkg/cfn/components/cidr"
@@ -456,5 +458,29 @@ func (h *HostedZoneComposer) Compose() (*cfn.Composition, error) {
 	return &cfn.Composition{
 		Outputs:   []cfn.StackOutputer{zone},
 		Resources: []cfn.ResourceNamer{zone},
+	}, nil
+}
+
+// PublicCertificateComposer stores the state for the composer
+type PublicCertificateComposer struct {
+	FQDN         string
+	HostedZoneID string
+}
+
+// NewPublicCertificateComposer returns an initialised composer
+func NewPublicCertificateComposer(fqdn, hostedZoneID string) *PublicCertificateComposer {
+	return &PublicCertificateComposer{
+		FQDN:         fqdn,
+		HostedZoneID: hostedZoneID,
+	}
+}
+
+// Compose returns the resources and outputts for creating a certificate
+func (c *PublicCertificateComposer) Compose() (*cfn.Composition, error) {
+	cert := certificate.New(c.FQDN, c.HostedZoneID)
+
+	return &cfn.Composition{
+		Outputs:   []cfn.StackOutputer{cert},
+		Resources: []cfn.ResourceNamer{cert},
 	}, nil
 }

--- a/pkg/cfn/namer.go
+++ b/pkg/cfn/namer.go
@@ -20,6 +20,8 @@ const (
 	DefaultStackNameExternalDNSPolicyID = "externaldns"
 	// DefaultStackNameDomainID defines an identifier for a domain stack
 	DefaultStackNameDomainID = "domain"
+	// DefaultStackNameCertificateID defines an identifier for a certificate stack
+	DefaultStackNameCertificateID = "certificate"
 )
 
 // StackNamer knows how to name cloud formation stacks
@@ -71,11 +73,21 @@ func (n *StackNamer) ExternalDNSPolicy(repository, env string) string {
 }
 
 // Domain returns the stack name of the domain
-// we probably need to store something more here
 func (n *StackNamer) Domain(repository, env, subdomain string) string {
 	return fmt.Sprintf("%s-%s-%s-%s-%s",
 		DefaultStackNamePrefix,
 		DefaultStackNameDomainID,
+		repository,
+		env,
+		subdomain,
+	)
+}
+
+// Certificate returns the stack name of the certificate
+func (n *StackNamer) Certificate(repository, env, subdomain string) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%s",
+		DefaultStackNamePrefix,
+		DefaultStackNameCertificateID,
 		repository,
 		env,
 		subdomain,

--- a/pkg/cfn/testdata/public-certificate-cf.yaml.golden
+++ b/pkg/cfn/testdata/public-certificate-cf.yaml.golden
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: 2010-09-09
+Outputs:
+  PublicCertificate:
+    Value:
+      Ref: PublicCertificate
+Resources:
+  PublicCertificate:
+    Properties:
+      DomainName: test.oslo.systems.
+      DomainValidationOptions:
+      - DomainName: test.oslo.systems.
+        HostedZoneId: AZ12345
+      ValidationMethod: DNS
+    Type: AWS::CertificateManager::Certificate

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,6 +28,7 @@ const (
 	targetExternalDNSServiceAccount          = "serviceaccounts/externaldns/"
 	targetDomain                             = "domains/"
 	targetKubeExternalDNS                    = "kube/externaldns/"
+	targetCertificate                        = "certificates/"
 )
 
 // Cluster client API calls
@@ -72,6 +73,11 @@ type Domain interface {
 	CreateDomain(opts *api.CreateDomainOpts) (*api.Domain, error)
 }
 
+// Certificate API calls
+type Certificate interface {
+	CreateCertificate(opts *api.CreateCertificateOpts) (*api.Certificate, error)
+}
+
 // Client stores state for invoking API operations
 type Client struct {
 	BaseURL  string
@@ -88,6 +94,12 @@ func New(debug bool, progress io.Writer, serverURL string) *Client {
 		Client:   &http.Client{},
 		Debug:    debug,
 	}
+}
+
+// CreateCertificate invokes the certificate creation operation
+func (c *Client) CreateCertificate(opts *api.CreateCertificateOpts) (*api.Certificate, error) {
+	into := &api.Certificate{}
+	return into, c.DoPost(targetCertificate, opts, into)
 }
 
 // CreateExternalDNSKubeDeployment invokes the external dns kube deployment

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,6 +100,10 @@ const (
 	DefaultDomainOutputsFile = "domains-outputs.json"
 	// DefaultDomainCloudFormationTemplate is the default file name of the cloud formation template
 	DefaultDomainCloudFormationTemplate = "domains-cf.yml"
+	// DefaultCertificateOutputsFile is the default file name of the domain output
+	DefaultCertificateOutputsFile = "certificate-outputs.json"
+	// DefaultCertificateCloudFormationTemplate is the default file name of the cloud formation template
+	DefaultCertificateCloudFormationTemplate = "certificate-cf.yml"
 
 	// DefaultExternalSecretsBaseDir is the default directory of the external secrets resources
 	DefaultExternalSecretsBaseDir = "external-secrets"
@@ -109,6 +113,8 @@ const (
 	DefaultExternalDNSBaseDir = "external-dns"
 	// DefaultDomainBaseDir is the default directory for domains
 	DefaultDomainBaseDir = "domains"
+	// DefaultCertificateBaseDir is the default directory for certificates
+	DefaultCertificateBaseDir = "certificates"
 
 	// EnvPrefix of environment variables that will be processed by okctl
 	EnvPrefix = "OKCTL"

--- a/pkg/config/repository/repository.go
+++ b/pkg/config/repository/repository.go
@@ -46,10 +46,11 @@ func (d *Data) Validate() error {
 // Cluster represents an okctl created
 // cluster
 type Cluster struct {
-	Environment string
-	Domain      string
-	FQDN        string
-	AWS         AWS
+	Environment  string
+	Domain       string
+	FQDN         string
+	AWS          AWS
+	Certificates []Certificate
 }
 
 const (
@@ -67,6 +68,7 @@ func (c Cluster) Validate() error {
 		validation.Field(&c.Domain, validation.Required),
 		validation.Field(&c.FQDN, validation.Required),
 		validation.Field(&c.AWS),
+		validation.Field(&c.Certificates),
 	)
 }
 
@@ -83,6 +85,22 @@ func (a AWS) Validate() error {
 			validation.Required,
 			validation.Match(regexp.MustCompile("^[0-9]{12}$")),
 		),
+	)
+}
+
+// Certificate represents a certificate
+type Certificate struct {
+	ARN    string
+	Domain string
+	FQDN   string
+}
+
+// Validate the certificate data
+func (c Certificate) Validate() error {
+	return validation.ValidateStruct(&c,
+		validation.Field(&c.ARN, validation.Required),
+		validation.Field(&c.Domain, validation.Required),
+		validation.Field(&c.FQDN, validation.Required),
 	)
 }
 

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -174,6 +174,20 @@ func (o *Okctl) Initialise(env, awsAccountID string) error {
 		o.FileSystem,
 	)
 
+	certificateStore := filesystem.NewCertificateStore(
+		o.RepoData,
+		filesystem.Paths{
+			OutputFile:         config.DefaultCertificateOutputsFile,
+			CloudFormationFile: config.DefaultCertificateCloudFormationTemplate,
+			BaseDir:            path.Join(outputDir, config.DefaultCertificateBaseDir),
+		},
+		filesystem.Paths{
+			ConfigFile: config.DefaultRepositoryConfig,
+			BaseDir:    repoDir,
+		},
+		o.FileSystem,
+	)
+
 	vpcService := core.NewVpcService(
 		awsProvider.NewVpcCloud(o.CloudProvider),
 		vpcStore,
@@ -243,6 +257,11 @@ func (o *Okctl) Initialise(env, awsAccountID string) error {
 		domainStore,
 	)
 
+	certificateService := core.NewCertificateService(
+		awsProvider.NewCertificateCloudProvider(o.CloudProvider),
+		certificateStore,
+	)
+
 	services := core.Services{
 		Cluster:        clusterService,
 		Vpc:            vpcService,
@@ -251,6 +270,7 @@ func (o *Okctl) Initialise(env, awsAccountID string) error {
 		Helm:           helmService,
 		Kube:           kubeService,
 		Domain:         domainService,
+		Certificate:    certificateService,
 	}
 
 	endpoints := core.GenerateEndpoints(services, core.InstrumentEndpoints(o.Logger))


### PR DESCRIPTION
Create a public TLS certificate for a subdomain, using Amazon Certificate Manager (ACM) with DNS validation/renewal

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
