### PR TITLE
Add get team members from github

### DIFF
--- a/pkg/client/core/api/rest/github.go
+++ b/pkg/client/core/api/rest/github.go
@@ -20,6 +20,15 @@ type githubAPI struct {
 	out          io.Writer
 }
 
+func (a *githubAPI) GetGithubTeamMembers(opts client.GetGithubTeamMembers) (*[]client.GithubTeamMember, error) {
+	members, err := a.client.ListTeamMembers(*opts.Team)
+	if err != nil {
+		return nil, err
+	}
+
+	return &members, nil
+}
+
 func (a *githubAPI) SelectGithubInfrastructureRepository(opts client.SelectGithubInfrastructureRepositoryOpts) (*client.SelectedGithubRepository, error) {
 	repos, err := a.client.Repositories(opts.Organisation)
 	if err != nil {
@@ -90,6 +99,7 @@ func (a *githubAPI) SelectGithubTeam(opts client.SelectGithubTeam) (*client.Gith
 		ID:           opts.ID,
 		Organisation: opts.Organisation,
 		Name:         team.GetName(),
+		TeamID:       *team.ID,
 	}, nil
 }
 

--- a/pkg/client/core/service_github.go
+++ b/pkg/client/core/service_github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oslokommune/okctl/pkg/api"
 	"github.com/oslokommune/okctl/pkg/spinner"
 
 	"github.com/oslokommune/okctl/pkg/client"
@@ -162,6 +163,32 @@ func (s *githubService) CreateGithubOauthApp(_ context.Context, opts client.Crea
 	}
 
 	return a, nil
+}
+
+// GetTeam in organization
+func (s *githubService) GetTeam(id api.ID, organisation string) (*client.GithubTeam, error) {
+	team, err := s.api.SelectGithubTeam(client.SelectGithubTeam{
+		ID:           id,
+		Organisation: organisation,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return team, nil
+}
+
+// GetGithubTeamMembers returns members of a team on github
+func (s *githubService) GetGithubTeamMembers(team *client.GithubTeam, organisation string) (*[]client.GithubTeamMember, error) {
+	members, err := s.api.GetGithubTeamMembers(client.GetGithubTeamMembers{
+		Team:         team,
+		Organisation: organisation,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return members, nil
 }
 
 // NewGithubService returns an initialised service

--- a/pkg/client/github.go
+++ b/pkg/client/github.go
@@ -130,11 +130,27 @@ type GithubTeam struct {
 	ID           api.ID
 	Organisation string
 	Name         string
+	TeamID       int64
 }
 
 // Validate the data
 func (t GithubTeam) Validate() error {
 	return validation.ValidateStruct(&t,
+		validation.Field(&t.Name, validation.Required),
+	)
+}
+
+// GithubTeamMember info about
+type GithubTeamMember struct {
+	Name  string
+	Email string
+	Login string
+}
+
+// Validate the github team memmber
+func (t GithubTeamMember) Validate() error {
+	return validation.ValidateStruct(&t,
+		validation.Field(&t.Login, validation.Required),
 		validation.Field(&t.Name, validation.Required),
 	)
 }
@@ -176,10 +192,19 @@ type CreateGithubDeployKey struct {
 	Title        string
 }
 
+// GetGithubTeamMembers options object to get github team members
+type GetGithubTeamMembers struct {
+	TeamID       string
+	Organisation string
+	Team         *GithubTeam
+}
+
 // GithubService is a business logic implementation
 type GithubService interface {
 	ReadyGithubInfrastructureRepository(ctx context.Context, opts ReadyGithubInfrastructureRepositoryOpts) (*GithubRepository, error)
 	CreateGithubOauthApp(ctx context.Context, opts CreateGithubOauthAppOpts) (*GithubOauthApp, error)
+	GetTeam(id api.ID, organization string) (*GithubTeam, error)
+	GetGithubTeamMembers(teamID *GithubTeam, organization string) (*[]GithubTeamMember, error)
 }
 
 // GithubAPI invokes the Github API
@@ -187,6 +212,7 @@ type GithubAPI interface {
 	SelectGithubInfrastructureRepository(opts SelectGithubInfrastructureRepositoryOpts) (*SelectedGithubRepository, error)
 	CreateGithubDeployKey(opts CreateGithubDeployKey) (*GithubDeployKey, error)
 	SelectGithubTeam(opts SelectGithubTeam) (*GithubTeam, error)
+	GetGithubTeamMembers(opts GetGithubTeamMembers) (*[]GithubTeamMember, error)
 	CreateGithubOauthApp(opts CreateGithubOauthAppOpts) (*GithubOauthApp, error)
 }
 


### PR DESCRIPTION
## Description
Get team members using github api

## Motivation and Context
We need to be able to sync identitypool-users with github teams, this is a standalone step 
that just fetches the users from giyhub

## How Has This Been Tested?
Tested manually

## Screenshots (if appropriate):

## Types of changes
- [X] Non breaking new functionality that will be used later


## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
