### PR TITLE
bug(venv): Support environment variables with equal sign

### DIFF
--- a/docs/release_notes/0.0.14.md
+++ b/docs/release_notes/0.0.14.md
@@ -2,5 +2,8 @@
 
 ## Features
 
+## Bugfixes
+- `okctl venv` didn't support environment variables that contained equals sign, such as "MYVAR=a=b". This is now fixed.
+
 ## Other
 

--- a/pkg/virtualenv/virtualenv.go
+++ b/pkg/virtualenv/virtualenv.go
@@ -115,7 +115,7 @@ func toMap(slice []string) map[string]string {
 	m := make(map[string]string)
 
 	for _, env := range slice {
-		split := strings.Split(env, "=")
+		split := strings.SplitN(env, "=", 2)
 		key := split[0]
 		val := split[1]
 		m[key] = val

--- a/pkg/virtualenv/virtualenv_test.go
+++ b/pkg/virtualenv/virtualenv_test.go
@@ -30,6 +30,7 @@ func TestGetVirtualEnvironment(t *testing.T) {
 		osEnvVars := []string{
 			"SOME_VAR=A",
 			"PATH=" + userPath,
+			"LS_COLORS=rs=0:di=01;34:ln=01:*.tar=01;31",
 		}
 
 		venv, err := virtualenv.GetVirtualEnvironment(&opts, osEnvVars)
@@ -48,6 +49,7 @@ func TestGetVirtualEnvironment(t *testing.T) {
 			"HELM_REPOSITORY_CACHE=" + path.Join(opts.UserDataDir, config.DefaultHelmBaseDir, config.DefaultHelmRepositoryCache),
 			"HELM_REPOSITORY_CONFIG=" + path.Join(opts.UserDataDir, config.DefaultHelmBaseDir, config.DefaultHelmRepositoryConfig),
 			"KUBECONFIG=" + path.Join(opts.UserDataDir, config.DefaultCredentialsDirName, opts.ClusterName, config.DefaultClusterKubeConfig),
+			"LS_COLORS=rs=0:di=01;34:ln=01:*.tar=01;31",
 			fmt.Sprintf("PATH=%s:%s:%s",
 				mock.DefaultKubectlBinaryDir,
 				mock.DefaultAwsIamAuthenticatorDir,


### PR DESCRIPTION
Support environment variables on the form MYENV=some=val.

## Description

When running

```bash
okctl venv myenv
```

SOME_VAR=a=1:b=2
would incorrectly be set as
SOME_VAR=a

This bug makes `ls` in the Ohmyzsh shell break as it expects a environment variable for LS_COLORS, which looks like this: `rs=0:di=01;34:ln=01;36:...`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Added unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
