### PR TITLE
Rename package, us okct's stdin, stdout and stderr

### DIFF
--- a/cmd/okctl/create.go
+++ b/cmd/okctl/create.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/oslokommune/okctl/pkg/client"
 
-	"github.com/oslokommune/okctl/pkg/cmd"
+	"github.com/oslokommune/okctl/pkg/commands"
 
 	"github.com/oslokommune/okctl/pkg/domain"
 
@@ -455,7 +455,7 @@ and database subnets.`,
 				return formatErr(err)
 			}
 
-			msg := cmd.CreateClusterMsgOpts{
+			msg := commands.CreateClusterMsgOpts{
 				KubernetesCluster:       aurora.Green("kubernetes cluster").String(),
 				Exports:                 exports,
 				Environment:             opts.Environment,
@@ -468,7 +468,7 @@ and database subnets.`,
 				ArgoCD:                  aurora.Green("ArgoCD").String(),
 				ArgoCDURL:               aurora.Green(argoCD.ArgoURL).String(),
 			}
-			txt, err := cmd.GoTemplateToString(cmd.CreateClusterEndMsg, msg)
+			txt, err := commands.GoTemplateToString(commands.CreateClusterEndMsg, msg)
 			_, err = fmt.Print(o.Err, txt)
 			if err != nil {
 				return formatErr(err)

--- a/cmd/okctl/createtestcluster.go
+++ b/cmd/okctl/createtestcluster.go
@@ -23,7 +23,7 @@ import (
 	"github.com/logrusorgru/aurora/v3"
 	"github.com/mishudark/errors"
 	"github.com/oslokommune/okctl/pkg/api"
-	"github.com/oslokommune/okctl/pkg/cmd"
+	"github.com/oslokommune/okctl/pkg/commands"
 	"github.com/oslokommune/okctl/pkg/config"
 	"github.com/oslokommune/okctl/pkg/okctl"
 	"github.com/oslokommune/okctl/pkg/spinner"
@@ -329,7 +329,7 @@ with Github or other production services.
 				return formatErr(err)
 			}
 
-			msg := cmd.CreateClusterMsgOpts{
+			msg := commands.CreateClusterMsgOpts{
 				KubernetesCluster:       aurora.Green("kubernetes cluster").String(),
 				Exports:                 exports,
 				Environment:             opts.Environment,
@@ -340,7 +340,7 @@ with Github or other production services.
 				AwsIamAuthenticatorPath: a.BinaryPath,
 				K8sClusterVersion:       aurora.Green("1.17").String(),
 			}
-			txt, err := cmd.GoTemplateToString(cmd.CreateTestClusterEndMsg, msg)
+			txt, err := commands.GoTemplateToString(commands.CreateTestClusterEndMsg, msg)
 			_, err = fmt.Print(o.Err, txt)
 			if err != nil {
 				return formatErr(err)

--- a/cmd/okctl/show.go
+++ b/cmd/okctl/show.go
@@ -11,7 +11,7 @@ import (
 	"github.com/oslokommune/okctl/pkg/virtualenv"
 
 	"github.com/oslokommune/okctl/pkg/api/okctl.io/v1alpha1"
-	"github.com/oslokommune/okctl/pkg/cmd"
+	"github.com/oslokommune/okctl/pkg/commands"
 
 	"github.com/oslokommune/okctl/pkg/kubeconfig"
 	"sigs.k8s.io/yaml"
@@ -94,7 +94,7 @@ func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
 				return err
 			}
 
-			msg := cmd.ShowMessageOpts{
+			msg := commands.ShowMessageOpts{
 				VenvCmd:                 aurora.Green("okctl venv").String(),
 				KubectlCmd:              aurora.Green("kubectl").String(),
 				AwsIamAuthenticatorCmd:  aurora.Green("aws-iam-authenticator").String(),
@@ -104,7 +104,7 @@ func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
 				ArgoCD:                  aurora.Green("ArgoCD").String(),
 				ArgoCDURL:               o.RepoStateWithEnv.GetArgoCD().SiteURL,
 			}
-			txt, err := cmd.GoTemplateToString(cmd.ShowMsg, msg)
+			txt, err := commands.GoTemplateToString(commands.ShowMsg, msg)
 			if err != nil {
 				return err
 			}

--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -9,7 +9,7 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 
-	cmd "github.com/oslokommune/okctl/pkg/cmd"
+	cmd "github.com/oslokommune/okctl/pkg/commands"
 	"github.com/oslokommune/okctl/pkg/okctl"
 	"github.com/oslokommune/okctl/pkg/virtualenv"
 	"github.com/spf13/cobra"

--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -78,9 +78,9 @@ func buildVenvCommand(o *okctl.Okctl) *cobra.Command {
 			}
 
 			shell.Env = venv
-			shell.Stdout = os.Stdout
-			shell.Stdin = os.Stdin
-			shell.Stderr = os.Stderr
+			shell.Stdout = o.Out
+			shell.Stdin = o.In
+			shell.Stderr = o.Err
 
 			err = shell.Run()
 

--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -1,2 +1,0 @@
-// Package cmd contains helper functionality to run various okctl commands.
-package cmd

--- a/pkg/commands/cmd.go
+++ b/pkg/commands/cmd.go
@@ -1,4 +1,4 @@
-package cmd
+package commands
 
 import (
 	"bytes"

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -1,7 +1,10 @@
-package cmd
+package commands
 
-// ShowMessageOpts contains the fields used by the Go template for the show credentials user message
-type ShowMessageOpts struct {
+// CreateClusterMsgOpts contains the fields used by the Go template for the create cluster end user message
+type CreateClusterMsgOpts struct {
+	KubernetesCluster       string
+	Exports                 string
+	Environment             string
 	VenvCmd                 string
 	KubectlCmd              string
 	KubectlPath             string
@@ -12,8 +15,18 @@ type ShowMessageOpts struct {
 	ArgoCDURL               string
 }
 
-// ShowMsg is the message shown to the user when using show credentials
-const ShowMsg = `
+// CreateClusterEndMsg is the message shown to the user after creating a cluster
+const CreateClusterEndMsg = `Congratulations, your {{ .KubernetesCluster }} is now up and running.
+To get started with some basic interactions, you can paste the
+following exports into a terminal:
+
+{{ .Exports }}
+
+You can retrieve these credentials at any point by issuing the
+command below, from within this repository:
+
+$ okctl show credentials {{ .Environment }}
+
 Tip: Run {{ .VenvCmd }} to run a shell with these environment variables set. Then you
 can avoid using full paths to executables and modifying your PATH.
 
@@ -40,4 +53,6 @@ the UI at this URL by logging in with Github:
 
 {{ .ArgoCDURL }}
 
+It might take 5-10 minutes for the ArgoCD ALB to come up, and
+about 15 minutes for the auth to come up.
 `

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -1,4 +1,4 @@
-package cmd
+package commands
 
 import (
 	"testing"

--- a/pkg/commands/createtestcluster.go
+++ b/pkg/commands/createtestcluster.go
@@ -1,22 +1,7 @@
-package cmd
+package commands
 
-// CreateClusterMsgOpts contains the fields used by the Go template for the create cluster end user message
-type CreateClusterMsgOpts struct {
-	KubernetesCluster       string
-	Exports                 string
-	Environment             string
-	VenvCmd                 string
-	KubectlCmd              string
-	KubectlPath             string
-	AwsIamAuthenticatorCmd  string
-	AwsIamAuthenticatorPath string
-	K8sClusterVersion       string
-	ArgoCD                  string
-	ArgoCDURL               string
-}
-
-// CreateClusterEndMsg is the message shown to the user after creating a cluster
-const CreateClusterEndMsg = `Congratulations, your {{ .KubernetesCluster }} is now up and running.
+// CreateTestClusterEndMsg is the message shown to the user after creating a test cluster
+const CreateTestClusterEndMsg = `Congratulations, your {{ .KubernetesCluster }} is now up and running.
 To get started with some basic interactions, you can paste the
 following exports into a terminal:
 
@@ -47,12 +32,4 @@ system from:
 
 The installed version of kubectl needs to be within 2 versions of the
 kubernetes cluster version, which is: {{ .K8sClusterVersion }}.
-
-We have also setup {{ .ArgoCD }} for continuous deployment, you can access
-the UI at this URL by logging in with Github:
-
-{{ .ArgoCDURL }}
-
-It might take 5-10 minutes for the ArgoCD ALB to come up, and
-about 15 minutes for the auth to come up.
 `

--- a/pkg/commands/createtestcluster_test.go
+++ b/pkg/commands/createtestcluster_test.go
@@ -1,4 +1,4 @@
-package cmd
+package commands
 
 import (
 	"testing"
@@ -8,16 +8,22 @@ import (
 	"github.com/logrusorgru/aurora"
 )
 
-const (
-	kubectlPath             = "/home/johndoe/.okctl/binaries/kubectl/1.16.8/linux/amd64/kubectl"
-	awsIamAuthenticatorPath = "/home/johndoe/.okctl/binaries/aws-iam-authenticator/0.5.1/linux/amd64/aws-iam-authenticator"
-)
-
 // The weird characters in this variable are color codes from the color library.
 // If you need to find out the actual content to put into the expected value, use
-// ioutil.WriteFile("/tmp/create_test.txt", []byte(expectedShowMsg), 0644)
+// ioutil.WriteFile("/tmp/create_test.txt", []byte(createTestClusterExpectedMsg), 0644)
 // nolint:stylecheck
-const expectedShowMsg = `
+const createTestClusterExpectedMsg = `Congratulations, your [32mkubernetes cluster[0m is now up and running.
+To get started with some basic interactions, you can paste the
+following exports into a terminal:
+
+export HELM_CACHE_HOME=/home/johndoe/.okctl/helm
+export KUBECONFIG=/home/johndoe/.okctl/credentials/test/kubeconfig
+
+You can retrieve these credentials at any point by issuing the
+command below, from within this repository:
+
+$ okctl show credentials prod
+
 Tip: Run [32mokctl venv[0m to run a shell with these environment variables set. Then you
 can avoid using full paths to executables and modifying your PATH.
 
@@ -38,17 +44,16 @@ system from:
 
 The installed version of kubectl needs to be within 2 versions of the
 kubernetes cluster version, which is: [32m1.17[0m.
-
-We have also setup [32mArgoCD[0m for continuous deployment, you can access
-the UI at this URL by logging in with Github:
-
-http://argocd
-
 `
 
-func TestShowCredentialsMessage(t *testing.T) {
+func TestCreateTestClusterMessage(t *testing.T) {
 	t.Run("Should get expected output", func(t *testing.T) {
-		data := ShowMessageOpts{
+		exports := `export HELM_CACHE_HOME=/home/johndoe/.okctl/helm
+export KUBECONFIG=/home/johndoe/.okctl/credentials/test/kubeconfig`
+		data := CreateClusterMsgOpts{
+			KubernetesCluster:       aurora.Green("kubernetes cluster").String(),
+			Exports:                 exports,
+			Environment:             "prod",
 			VenvCmd:                 aurora.Green("okctl venv").String(),
 			KubectlCmd:              aurora.Green("kubectl").String(),
 			AwsIamAuthenticatorCmd:  aurora.Green("aws-iam-authenticator").String(),
@@ -59,9 +64,9 @@ func TestShowCredentialsMessage(t *testing.T) {
 			ArgoCDURL:               "http://argocd",
 		}
 
-		msg, err := GoTemplateToString(ShowMsg, data)
+		msg, err := GoTemplateToString(CreateTestClusterEndMsg, data)
 
 		assert.Equal(t, nil, err)
-		assert.Equal(t, expectedShowMsg, msg, diff.LineDiff(expectedShowMsg, msg))
+		assert.Equal(t, createTestClusterExpectedMsg, msg, diff.LineDiff(createTestClusterExpectedMsg, msg))
 	})
 }

--- a/pkg/commands/doc.go
+++ b/pkg/commands/doc.go
@@ -1,0 +1,2 @@
+// Package commands contains helper functionality to run various okctl commands.
+package commands

--- a/pkg/commands/show.go
+++ b/pkg/commands/show.go
@@ -1,17 +1,19 @@
-package cmd
+package commands
 
-// CreateTestClusterEndMsg is the message shown to the user after creating a test cluster
-const CreateTestClusterEndMsg = `Congratulations, your {{ .KubernetesCluster }} is now up and running.
-To get started with some basic interactions, you can paste the
-following exports into a terminal:
+// ShowMessageOpts contains the fields used by the Go template for the show credentials user message
+type ShowMessageOpts struct {
+	VenvCmd                 string
+	KubectlCmd              string
+	KubectlPath             string
+	AwsIamAuthenticatorCmd  string
+	AwsIamAuthenticatorPath string
+	K8sClusterVersion       string
+	ArgoCD                  string
+	ArgoCDURL               string
+}
 
-{{ .Exports }}
-
-You can retrieve these credentials at any point by issuing the
-command below, from within this repository:
-
-$ okctl show credentials {{ .Environment }}
-
+// ShowMsg is the message shown to the user when using show credentials
+const ShowMsg = `
 Tip: Run {{ .VenvCmd }} to run a shell with these environment variables set. Then you
 can avoid using full paths to executables and modifying your PATH.
 
@@ -32,4 +34,10 @@ system from:
 
 The installed version of kubectl needs to be within 2 versions of the
 kubernetes cluster version, which is: {{ .K8sClusterVersion }}.
+
+We have also setup {{ .ArgoCD }} for continuous deployment, you can access
+the UI at this URL by logging in with Github:
+
+{{ .ArgoCDURL }}
+
 `

--- a/pkg/commands/show_test.go
+++ b/pkg/commands/show_test.go
@@ -1,4 +1,4 @@
-package cmd
+package commands
 
 import (
 	"testing"
@@ -8,22 +8,16 @@ import (
 	"github.com/logrusorgru/aurora"
 )
 
+const (
+	kubectlPath             = "/home/johndoe/.okctl/binaries/kubectl/1.16.8/linux/amd64/kubectl"
+	awsIamAuthenticatorPath = "/home/johndoe/.okctl/binaries/aws-iam-authenticator/0.5.1/linux/amd64/aws-iam-authenticator"
+)
+
 // The weird characters in this variable are color codes from the color library.
 // If you need to find out the actual content to put into the expected value, use
-// ioutil.WriteFile("/tmp/create_test.txt", []byte(createTestClusterExpectedMsg), 0644)
+// ioutil.WriteFile("/tmp/create_test.txt", []byte(expectedShowMsg), 0644)
 // nolint:stylecheck
-const createTestClusterExpectedMsg = `Congratulations, your [32mkubernetes cluster[0m is now up and running.
-To get started with some basic interactions, you can paste the
-following exports into a terminal:
-
-export HELM_CACHE_HOME=/home/johndoe/.okctl/helm
-export KUBECONFIG=/home/johndoe/.okctl/credentials/test/kubeconfig
-
-You can retrieve these credentials at any point by issuing the
-command below, from within this repository:
-
-$ okctl show credentials prod
-
+const expectedShowMsg = `
 Tip: Run [32mokctl venv[0m to run a shell with these environment variables set. Then you
 can avoid using full paths to executables and modifying your PATH.
 
@@ -44,16 +38,17 @@ system from:
 
 The installed version of kubectl needs to be within 2 versions of the
 kubernetes cluster version, which is: [32m1.17[0m.
+
+We have also setup [32mArgoCD[0m for continuous deployment, you can access
+the UI at this URL by logging in with Github:
+
+http://argocd
+
 `
 
-func TestCreateTestClusterMessage(t *testing.T) {
+func TestShowCredentialsMessage(t *testing.T) {
 	t.Run("Should get expected output", func(t *testing.T) {
-		exports := `export HELM_CACHE_HOME=/home/johndoe/.okctl/helm
-export KUBECONFIG=/home/johndoe/.okctl/credentials/test/kubeconfig`
-		data := CreateClusterMsgOpts{
-			KubernetesCluster:       aurora.Green("kubernetes cluster").String(),
-			Exports:                 exports,
-			Environment:             "prod",
+		data := ShowMessageOpts{
 			VenvCmd:                 aurora.Green("okctl venv").String(),
 			KubectlCmd:              aurora.Green("kubectl").String(),
 			AwsIamAuthenticatorCmd:  aurora.Green("aws-iam-authenticator").String(),
@@ -64,9 +59,9 @@ export KUBECONFIG=/home/johndoe/.okctl/credentials/test/kubeconfig`
 			ArgoCDURL:               "http://argocd",
 		}
 
-		msg, err := GoTemplateToString(CreateTestClusterEndMsg, data)
+		msg, err := GoTemplateToString(ShowMsg, data)
 
 		assert.Equal(t, nil, err)
-		assert.Equal(t, createTestClusterExpectedMsg, msg, diff.LineDiff(createTestClusterExpectedMsg, msg))
+		assert.Equal(t, expectedShowMsg, msg, diff.LineDiff(expectedShowMsg, msg))
 	})
 }

--- a/pkg/commands/venv.go
+++ b/pkg/commands/venv.go
@@ -1,4 +1,4 @@
-package cmd
+package commands
 
 // GetShell detects which shell to run, and returns the command to run it.
 func GetShell(osLookupEnv func(key string) (string, bool)) string {

--- a/pkg/commands/venv_test.go
+++ b/pkg/commands/venv_test.go
@@ -1,4 +1,4 @@
-package cmd
+package commands
 
 import (
 	"testing"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Based on QA, I've made a few improvements. Feel free to suggest other names for my package rename cmd -> commands. 

## Motivation and Context
* Cmd was sort of a reserved package name, I was told.

## How Has This Been Tested?
Unit tests. Manually tested that okctl venv still works.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This is pure refactoring.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
