### PR TITLE
fix(venv): Print _to_ o.Err, don't print o.Err

### DIFF
--- a/cmd/okctl/show.go
+++ b/cmd/okctl/show.go
@@ -105,7 +105,7 @@ func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
 				return err
 			}
 
-			_, err = fmt.Print(o.Err, txt)
+			_, err = fmt.Fprint(o.Err, txt)
 			if err != nil {
 				return err
 			}

--- a/docs/release_notes/0.0.16.md
+++ b/docs/release_notes/0.0.16.md
@@ -3,5 +3,6 @@
 ## Features
 
 ## Bugfixes
+- `okctl show credentials` contained weird text `&{0xc0000b0120}`, this is now removed.
 
 ## Other


### PR DESCRIPTION
Fix: `okctl show credentials` contained the pointer address of o.Err instead of printing to o.Err.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
