### PR TITLE
Use venv_ps1 from okctl

### DIFF
--- a/docs/release_notes/0.0.16.md
+++ b/docs/release_notes/0.0.16.md
@@ -1,6 +1,8 @@
 # Release 0.0.16
 
 ## Features
+- OKCTL_PS1 can now refer to `%env` which will be replaced with okctl environment. This is useful if you want to get
+the part of "myenv:mynamespace" in your custom OKCTL_PS1.
 
 ## Bugfixes
 - Setting OKCTL_PS1 in `okctl venv` didn't work properly because of missing quotes in the resulting subshell's PS1. This

--- a/docs/release_notes/0.0.16.md
+++ b/docs/release_notes/0.0.16.md
@@ -1,8 +1,7 @@
 # Release 0.0.16
 
 ## Features
-- OKCTL_PS1 can now refer to `%env` which will be replaced with okctl environment. This is useful if you want to get
-the part of "myenv:mynamespace" in your custom OKCTL_PS1.
+- OKCTL_PS1 can now refer to `%env` which will be replaced with okctl environment.
 
 ## Bugfixes
 - Setting OKCTL_PS1 in `okctl venv` didn't work properly because of missing quotes in the resulting subshell's PS1. This

--- a/docs/release_notes/0.0.16.md
+++ b/docs/release_notes/0.0.16.md
@@ -3,5 +3,7 @@
 ## Features
 
 ## Bugfixes
+- Setting OKCTL_PS1 in `okctl venv` didn't work properly because of missing quotes in the resulting subshell's PS1. This
+is now fixed.
 
 ## Other

--- a/pkg/virtualenv/commandlineprompter/prompter_bash.go
+++ b/pkg/virtualenv/commandlineprompter/prompter_bash.go
@@ -1,6 +1,9 @@
 package commandlineprompter
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type bashPrompter struct {
 	environment string
@@ -10,7 +13,8 @@ type bashPrompter struct {
 func (p *bashPrompter) CreatePrompt() (CommandLinePrompt, error) {
 	ps1, overridePs1 := p.osEnvVars["OKCTL_PS1"]
 	if overridePs1 {
-		p.osEnvVars["PROMPT_COMMAND"] = fmt.Sprintf(`PS1="%s"`, ps1)
+		withEnv := strings.ReplaceAll(ps1, "%env", p.environment)
+		p.osEnvVars["PROMPT_COMMAND"] = fmt.Sprintf(`PS1="%s"`, withEnv)
 	} else {
 		p.osEnvVars["PROMPT_COMMAND"] = fmt.Sprintf(`PS1="\[\e[0;31m\]\w \[\e[0;34m\](\$(venv_ps1 %s)) \[\e[0m\]\$ "`, p.environment)
 	}

--- a/pkg/virtualenv/commandlineprompter/prompter_bash.go
+++ b/pkg/virtualenv/commandlineprompter/prompter_bash.go
@@ -10,7 +10,7 @@ type bashPrompter struct {
 func (p *bashPrompter) CreatePrompt() (CommandLinePrompt, error) {
 	ps1, overridePs1 := p.osEnvVars["OKCTL_PS1"]
 	if overridePs1 {
-		p.osEnvVars["PROMPT_COMMAND"] = fmt.Sprintf("PS1=%s", ps1)
+		p.osEnvVars["PROMPT_COMMAND"] = fmt.Sprintf(`PS1="%s"`, ps1)
 	} else {
 		p.osEnvVars["PROMPT_COMMAND"] = fmt.Sprintf(`PS1="\[\e[0;31m\]\w \[\e[0;34m\](\$(venv_ps1 %s)) \[\e[0m\]\$ "`, p.environment)
 	}

--- a/pkg/virtualenv/commandlineprompter/prompter_zsh.go
+++ b/pkg/virtualenv/commandlineprompter/prompter_zsh.go
@@ -82,7 +82,7 @@ prompt() {
 
 	ps1, overridePs1 := p.osEnvVars["OKCTL_PS1"]
 	if overridePs1 {
-		zshrcBuilder.WriteString(fmt.Sprintf("PS1=%s", ps1))
+		zshrcBuilder.WriteString(fmt.Sprintf(`PS1="%s"`, ps1))
 	} else {
 		zshrcBuilder.WriteString(fmt.Sprint(`PS1="%F{red}%~ %f%F{blue}($(venv_ps1 ` + p.environment + `)%f) $ "`))
 	}

--- a/pkg/virtualenv/commandlineprompter/prompter_zsh.go
+++ b/pkg/virtualenv/commandlineprompter/prompter_zsh.go
@@ -82,7 +82,8 @@ prompt() {
 
 	ps1, overridePs1 := p.osEnvVars["OKCTL_PS1"]
 	if overridePs1 {
-		zshrcBuilder.WriteString(fmt.Sprintf(`PS1="%s"`, ps1))
+		withEnv := strings.ReplaceAll(ps1, "%env", p.environment)
+		zshrcBuilder.WriteString(fmt.Sprintf(`PS1="%s"`, withEnv))
 	} else {
 		zshrcBuilder.WriteString(fmt.Sprint(`PS1="%F{red}%~ %f%F{blue}($(venv_ps1 ` + p.environment + `)%f) $ "`))
 	}

--- a/pkg/virtualenv/testdata/zshrc_custom_ps1_with_env.golden
+++ b/pkg/virtualenv/testdata/zshrc_custom_ps1_with_env.golden
@@ -1,0 +1,6 @@
+setopt PROMPT_SUBST
+autoload -U colors && colors # Enable colors
+prompt() {
+PS1="Dir: %~ | \$(venv_ps1 myenv) \$"
+}
+precmd_functions+=(prompt)

--- a/pkg/virtualenv/virtualenv_test.go
+++ b/pkg/virtualenv/virtualenv_test.go
@@ -128,7 +128,7 @@ func TestCreateVirtualEnvironment(t *testing.T) {
 		{
 			name: "When using zsh and OKCTL_PS1 is set, temp .zshrc should contain the custom PS1",
 			osEnvVars: map[string]string{
-				"OKCTL_PS1": "\"Dir: %~ $\"",
+				"OKCTL_PS1": "Dir: %~ $",
 			},
 			loginShellCmd: "/bin/zsh",
 			assertion: func(opts commandlineprompter.CommandLinePromptOpts, venv *virtualenv.VirtualEnvironment) {

--- a/pkg/virtualenv/virtualenv_test.go
+++ b/pkg/virtualenv/virtualenv_test.go
@@ -37,12 +37,12 @@ func TestCreateVirtualEnvironment(t *testing.T) {
 		{
 			name: "When using bash and OKCTL_PS1, COMMAND_PROMPT should contain contents of OKCTL_PS1",
 			osEnvVars: map[string]string{
-				"OKCTL_PS1": `"Dir: \w $"`,
+				"OKCTL_PS1": `Dir: \w $`,
 			},
 			loginShellCmd: "/bin/bash",
 			assertion: func(opts commandlineprompter.CommandLinePromptOpts, venv *virtualenv.VirtualEnvironment) {
 				expectedOsEnvVars := testHelper.toSlice(map[string]string{
-					"OKCTL_PS1":      `"Dir: \w $"`,
+					"OKCTL_PS1":      `Dir: \w $`,
 					"PATH":           testHelper.ps1Dir,
 					"PROMPT_COMMAND": `PS1="Dir: \w $"`,
 				})

--- a/userdocs/src/usage/venv.md
+++ b/userdocs/src/usage/venv.md
@@ -37,4 +37,16 @@ This command prompt can be turned off or configured, see below.
 | OKCTL_PS1                 | *not set* | If set, `venv` will use this as the PS1 in the executed subshell.      |
 | OKCTL_SHELL               | true      | Override which shell to run. For instance `/bin/sh`.                   |
 
+Any occurence `%env` in `OKCTL_PS1` will be replaced by the okctl environment. This makes it possible to get the okctl
+environment in your custom OKCTL_PS1. A use case for this can be when combining with the `venv_ps1` built-in:
 
+```bash
+$ export OKCTL_PS1="\w \$(venv_ps1 %env) $"
+$ okctl venv myenv
+```
+
+The command prompt will then be like this
+
+```bash
+/tmp myenv:mynamespace $
+```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Dependent on #150. This PR will become smaller when #150 is merged to master.

In OKCTL_PS1, replace `%env` with provided okctl environment.

## Description

OKCTL_PS1 can now refer to `%env` which will be replaced with okctl environment. This is useful if you want to get
the part of "myenv:mynamespace" in your custom OKCTL_PS1.

Example:

```bash
export OKCTL_PS1="\w \$(venv_ps1 %env) $"
```

which will become

```bash
/tmp ykprod:default $
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
