### PR TITLE
[KM106]: Freeze golangci linter at v1.32.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ GORELEASER     := bin/goreleaser/v.0.147.2/$(OS)/goreleaser
 GOFUMPT        := $(GOBIN)/gofumpt
 
 $(GOLANGCILINT):
+	# To bump, simply change the version at the end to the desired version. The git sha here points to the newest commit
+	# of the install script verified by our team located here: https://github.com/golangci/golangci-lint/blob/master/install.sh
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/b90551cdf9c6214075f2a40d1b5595c6b41ffff0/install.sh | sh -s -- -b ${GOBIN} v1.32.2
 
 $(GOIMPORTS):

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ GORELEASER     := bin/goreleaser/v.0.147.2/$(OS)/goreleaser
 GOFUMPT        := $(GOBIN)/gofumpt
 
 $(GOLANGCILINT):
-	$(GO) get github.com/golangci/golangci-lint/cmd/golangci-lint
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/b90551cdf9c6214075f2a40d1b5595c6b41ffff0/install.sh | sh -s -- -b ${GOBIN} v1.32.2
 
 $(GOIMPORTS):
 	$(GO) get -u golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A bump in github.com/golangci/golangci-lint broke our CI. This PR freezes golang-lint at the last working version.

Changed to downloading binary due to warning about fetching
golangci-lint via `go get` here:
https://golangci-lint.run/usage/install/#install-from-source

To ensure it uses the new binary, it might be necessary to remove the following files:
* `${GOPATH}/bin/golangci-lint`
* `${GOPATH}/pkg/mod/github.com/golangci`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually with `make lint` and with CI by pushing to branch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
