### PR TITLE
KM94 feat(declarativecluster) PART 1: Add reconsilers

### DIFF
--- a/cmd/okctl/apply.go
+++ b/cmd/okctl/apply.go
@@ -12,6 +12,7 @@ func buildApplyCommand(o *okctl.Okctl) *cobra.Command {
 	}
 
 	cmd.AddCommand(buildApplyApplicationCommand(o))
+	cmd.AddCommand(buildApplyClusterCommand(o))
 
 	return cmd
 }

--- a/cmd/okctl/applycluster.go
+++ b/cmd/okctl/applycluster.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/config/load"
+	"github.com/oslokommune/okctl/pkg/config/state"
+	"github.com/oslokommune/okctl/pkg/controller"
+	"github.com/oslokommune/okctl/pkg/controller/reconsiler"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/oslokommune/okctl/pkg/spinner"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+	"path/filepath"
+	"sigs.k8s.io/yaml"
+)
+
+type applyClusterOpts struct {
+	File string
+
+	Declaration *v1alpha1.Cluster
+}
+
+// Validate ensures the applyClusterOpts contains the right information
+func (o *applyClusterOpts) Validate() error {
+	return validation.ValidateStruct(o,
+		validation.Field(&o.File, validation.Required),
+	)
+}
+
+func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
+	opts := applyClusterOpts{}
+
+	cmd := &cobra.Command{
+		Use: "cluster -f declaration_file",
+		Example: "okctl apply cluster -f cluster.yaml",
+		Short: "apply a cluster definition to the world",
+		Long: "ensures your cluster reflects the declaration of it",
+		Args: cobra.ExactArgs(0),
+		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			opts.Declaration, err = inferClusterFromStdinOrFile(o.In, opts.File)
+			if err != nil {
+				return fmt.Errorf("error inferring cluster: %w", err)
+			}
+			
+			err = loadNoUserInputUserData(o, cmd)
+			if err != nil {
+				return fmt.Errorf("failed to load application data: %w", err)
+			}
+
+			err = loadNoUserInputRepoData(o, opts.Declaration)
+			if err != nil {
+				return fmt.Errorf("failed to load repo data: %w", err)
+			}
+
+			err = o.InitialiseWithEnvAndAWSAccountID(
+				opts.Declaration.Metadata.Environment,
+				opts.Declaration.Metadata.AccountID,
+			)
+			if err != nil {
+				return fmt.Errorf("error initializing okctl: %w", err)
+			}
+			
+			return nil
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) (err error) {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+			err = opts.Declaration.Validate()
+			if err != nil {
+			    return fmt.Errorf("error validating cluster declaration: %w", err)
+			}
+
+			id := api.ID{
+				Region:       opts.Declaration.Metadata.Region,
+				AWSAccountID: opts.Declaration.Metadata.AccountID,
+				Environment:  opts.Declaration.Metadata.Environment,
+				Repository:   o.RepoStateWithEnv.GetMetadata().Name,
+				ClusterName: o.RepoStateWithEnv.GetClusterName(),
+			}
+
+			spin, err := spinner.New("synchronizing", o.Err)
+			services, err := o.ClientServices(spin)
+			if err != nil {
+			    return fmt.Errorf("error getting services: %w", err)
+			}
+
+			outputDir, _ := o.GetRepoOutputDir(opts.Declaration.Metadata.Environment)
+
+			repoDir, err := o.GetRepoDir()
+			if err != nil {
+				return fmt.Errorf("could not get Repository dir: %w", err)
+			}
+
+			desiredGraph := controller.CreateDesiredStateGraph(opts.Declaration)
+
+			err = controller.ApplyDesiredStateMetadata(desiredGraph, opts.Declaration, repoDir)
+			if err != nil {
+			    return fmt.Errorf("could not apply desired state metadata: %w", err)
+			}
+
+			reconsiliationManager := reconsiler.NewReconsilerManager(&resourcetree.CommonMetadata{
+				Ctx: o.Ctx,
+				Id:  id,
+			})
+
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeZone, reconsiler.NewZoneReconsiler(services.Domain))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeVPC, reconsiler.NewVPCReconsiler(services.Vpc))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeCluster, reconsiler.NewClusterReconsiler(services.Cluster))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeExternalSecrets, reconsiler.NewExternalSecretsReconsiler(services.ExternalSecrets))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeALBIngress, reconsiler.NewALBIngressReconsiler(services.ALBIngressController))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeExternalDNS, reconsiler.NewExternalDNSReconsiler(services.ExternalDNS))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeGithub, reconsiler.NewGithubReconsiler(services.Github))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeIdentityManager, reconsiler.NewIdentityManagerReconsiler(services.IdentityManager))
+			
+			synchronizeOpts := &controller.SynchronizeOpts{
+				DesiredTree:           desiredGraph,
+				ReconsiliationManager: reconsiliationManager,
+				Fs:                    o.FileSystem,
+				OutputDir:             outputDir,
+				GithubGetter:          o.RepoStateWithEnv.GetGithub,
+				GithubSetter:          o.RepoStateWithEnv.SaveGithub,
+				CIDRGetter: func() string { return o.RepoStateWithEnv.GetVPC().CIDR },
+				PrimaryHostedZoneGetter: func() *state.HostedZone { return o.RepoStateWithEnv.GetPrimaryHostedZone() },
+			}
+
+			err = controller.Synchronize(synchronizeOpts)
+			if err != nil {
+			    return fmt.Errorf("error synchronizing declaration with state: %w", err)
+			}
+			
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.File, "file", "f", "", usageApplyClusterFile)
+	
+	cmd.Hidden = true // TODO: remove when feature is complete
+
+	return cmd
+}
+
+const usageApplyClusterFile = `specifies where to read the declaration from. Use "-" for stdin`
+
+
+func inferClusterFromStdinOrFile(stdin io.Reader, path string) (*v1alpha1.Cluster, error) {
+	var (
+		inputReader io.Reader
+		err         error
+	)
+
+	switch path {
+	case "-":
+		inputReader = stdin
+	default:
+		inputReader, err = os.Open(filepath.Clean(path))
+		if err != nil {
+			return nil, fmt.Errorf("unable to read file: %w", err)
+		}
+	}
+
+	var (
+		buffer bytes.Buffer
+		cluster v1alpha1.Cluster
+	)
+	
+	cluster = v1alpha1.NewDefaultCluster("", "", "", "", "", "")
+	
+	_, err = io.Copy(&buffer, inputReader)
+	if err != nil {
+	    return nil, fmt.Errorf("error copying reader data: %w", err)
+	}
+
+	err = yaml.Unmarshal(buffer.Bytes(), &cluster)
+	if err != nil {
+	    return nil, fmt.Errorf("error unmarshalling buffer: %w", err)
+	}
+	
+	return &cluster, nil
+}
+
+func loadNoUserInputUserData(o *okctl.Okctl, cmd *cobra.Command) error {
+	userDataNotFound := load.CreateOnUserDataNotFoundWithNoInput()
+
+	if o.NoInput {
+		userDataNotFound = load.ErrOnUserDataNotFound()
+	}
+
+	o.UserDataLoader = load.UserDataFromFlagsEnvConfigDefaults(cmd, userDataNotFound)
+
+	return o.LoadUserData()
+}
+
+func loadNoUserInputRepoData(o *okctl.Okctl, declaration *v1alpha1.Cluster) error {
+	repoDataNotFound := load.CreateOnRepoDataNotFoundWithNoUserInput(declaration)
+
+	o.RepoDataLoader = load.RepoDataFromConfigFile(repoDataNotFound)
+
+	return o.LoadRepoData()
+}

--- a/cmd/okctl/main.go
+++ b/cmd/okctl/main.go
@@ -22,7 +22,7 @@ func main() {
 	}
 }
 
-func loadRepoData(o *okctl.Okctl, cmd *cobra.Command) error {
+func loadRepoData(o *okctl.Okctl, _ *cobra.Command) error {
 	repoDataNotFound := load.CreateOnRepoDataNotFound()
 
 	if o.NoInput {
@@ -34,7 +34,7 @@ func loadRepoData(o *okctl.Okctl, cmd *cobra.Command) error {
 	// not want the configuration to be overridden by env
 	// vars or similar.
 	// We can drop sending *cobra.Command on here.
-	o.RepoDataLoader = load.RepoDataFromConfigFile(cmd, repoDataNotFound)
+	o.RepoDataLoader = load.RepoDataFromConfigFile(repoDataNotFound)
 
 	return o.LoadRepoData()
 }
@@ -102,13 +102,14 @@ being captured. Together with slack and slick.`,
 		},
 	}
 
-	cmd.AddCommand(buildVenvCommand(o))
+	cmd.AddCommand(buildAddUserCommand(o))
+	cmd.AddCommand(buildApplyCommand(o))
 	cmd.AddCommand(buildCreateCommand(o))
 	cmd.AddCommand(buildDeleteCommand(o))
-	cmd.AddCommand(buildApplyCommand(o))
+	cmd.AddCommand(buildScaffoldCommand(o))
 	cmd.AddCommand(buildShowCommand(o))
+	cmd.AddCommand(buildVenvCommand(o))
 	cmd.AddCommand(buildVersionCommand(o))
-	cmd.AddCommand(buildAddUserCommand(o))
 
 	f := cmd.Flags()
 	f.StringVarP(&outputFormat, "output", "o", "text",

--- a/cmd/okctl/scaffold.go
+++ b/cmd/okctl/scaffold.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/spf13/cobra"
+)
+
+func buildScaffoldCommand(o *okctl.Okctl) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scaffold",
+		Short: "scaffold templates for different resources",
+	}
+
+	cmd.AddCommand(buildScaffoldClusterCommand(o))
+
+	return cmd
+}

--- a/cmd/okctl/scaffoldcluster.go
+++ b/cmd/okctl/scaffoldcluster.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+const scaffoldClusterArgumentQuantity = 2
+
+type scaffoldClusterOpts struct {
+	Name string
+	
+	AWSAccountID string
+	Environment string
+	Organization string
+	RepositoryName string
+	Team string
+}
+
+func buildScaffoldClusterCommand(o *okctl.Okctl) *cobra.Command {
+	opts := scaffoldClusterOpts{}
+	
+	cmd := &cobra.Command{
+		Use: "cluster CLUSTER_NAME ENVIRONMENT",
+		Example: exampleUsage,
+		Short: "Scaffold cluster resource template",
+		Long: "Scaffolds a cluster resource which can be used to control cluster resources",
+		Args: cobra.ExactArgs(scaffoldClusterArgumentQuantity),
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Name = args[0]
+			opts.Environment = args[1]
+			
+			clusterResource := v1alpha1.NewDefaultCluster(
+				opts.Name,
+				opts.Environment,
+				opts.Organization,
+				opts.RepositoryName,
+				opts.Team,
+				opts.AWSAccountID,
+			)
+
+			result, err := yaml.Marshal(clusterResource)
+			if err != nil {
+			    return fmt.Errorf("error marshalling yaml: %w", err)
+			}
+			
+			_, err = o.Out.Write(result)
+			if err != nil {
+			    return fmt.Errorf("error writing cluster: %w", err)
+			}
+			
+			return nil
+		},
+	}
+	
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Organization, "github-organization", "o", "oslokommune", usageOrganization)
+	flags.StringVarP(&opts.RepositoryName, "repository-name", "r", "my_iac_repo_name", usageRepository)
+	flags.StringVarP(&opts.Team, "github-team", "t", "my_team", usageTeam)
+	flags.StringVarP(&opts.AWSAccountID, "aws-account-id", "i", "123456789123", usageAWSAccountID)
+	
+	return cmd
+}
+
+const usageAWSAccountID = `the aws account where the resources provisioned by okctl should reside`
+const usageOrganization = `the organization that owns the infrastructure-as-code repository`
+const usageRepository = `the name of the repository that will contain infrastructure-as-code`
+const usageTeam = `the team that is responsible and has access rights to the infrastructure-as-code repository`
+const exampleUsage = `okctl scaffold cluster utviklerportalen production > cluster.yaml`

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3d/v3 v3.0.1
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
+	github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b
 	github.com/sanity-io/litter v1.3.0
 	github.com/sebdah/goldie/v2 v2.5.1
 	github.com/sirupsen/logrus v1.7.0

--- a/pkg/apis/okctl.io/v1alpha1/cluster.go
+++ b/pkg/apis/okctl.io/v1alpha1/cluster.go
@@ -1,7 +1,11 @@
 package v1alpha1
 
 import (
+	"errors"
 	"fmt"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+	"regexp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,6 +29,11 @@ type Cluster struct {
 	// this cluster will integrate with.
 	Github ClusterGithub `json:"github"`
 
+	// PrimaryDNSZone defines the main primary zone to associate with this
+	// cluster. This will be the zone that we will use to create domains
+	// for auth, ArgoCD, etc.
+	PrimaryDNSZone ClusterDNSZone `json:"primaryDNSZone"`
+
 	// VPC defines how we configure the VPC for the cluster
 	// +optional
 	VPC *ClusterVPC `json:"vpc,omitempty"`
@@ -38,6 +47,19 @@ type Cluster struct {
 	// this cluster.
 	// +optional
 	DNSZones []ClusterDNSZone `json:"dnsZones,omitempty"`
+}
+
+// Validate calls each members Validate function
+func (c Cluster) Validate() error {
+	result := validation.ValidateStruct(&c,
+		validation.Field(&c.Metadata),
+		validation.Field(&c.Github),
+		validation.Field(&c.PrimaryDNSZone),
+		validation.Field(&c.VPC),
+		validation.Field(&c.Integrations),
+	)
+	
+	return result
 }
 
 // ClusterMeta describes a unique cluster
@@ -56,13 +78,23 @@ type ClusterMeta struct {
 
 	// AccountID specifies the AWS Account ID
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html
-	AccountID int `json:"accountID"`
+	AccountID string `json:"accountID"`
+}
+
+// Validate ensures ClusterMeta contains the right information
+func (receiver ClusterMeta) Validate() error {
+	return validation.ValidateStruct(&receiver,
+		validation.Field(&receiver.Name, validation.Required),
+		validation.Field(&receiver.Environment, validation.Required, validation.Match(regexp.MustCompile("^[a-zA-Z]{3,64}$")).Error("must consist of 3-64 characters (a-z, A-Z)")),
+		validation.Field(&receiver.Region, validation.Required, validation.In("eu-west-1").Error("for now, only \"eu-west-1\" is supported")),
+		validation.Field(&receiver.AccountID, validation.Required, validation.Match(regexp.MustCompile("^[0-9]{12}$")).Error("must consist of 12 digits")),
+	)
 }
 
 // String returns a unique identifier for a cluster
 // Not sure about this..
-func (c *ClusterMeta) String() string {
-	return fmt.Sprintf("%s-%s.%s.okctl.io/%d", c.Name, c.Environment, c.Region, c.AccountID)
+func (receiver *ClusterMeta) String() string {
+	return fmt.Sprintf("%s-%s.%s.okctl.io/%d", receiver.Name, receiver.Environment, receiver.Region, receiver.AccountID)
 }
 
 // ClusterVPC is a definition of the VPC we create for the EKS cluster
@@ -80,6 +112,14 @@ type ClusterVPC struct {
 	HighAvailability bool `json:"highAvailability,omitempty"`
 }
 
+// Validate ensures ClusterVPC contains the right information
+func (c ClusterVPC) Validate() error {
+	return validation.ValidateStruct(&c,
+		validation.Field(&c.CIDR, validation.Required),
+		validation.Field(&c.HighAvailability, validation.Required),
+	)
+}
+
 // ClusterDNSZone is analogous to a DNS Zone file (https://en.wikipedia.org/wiki/Zone_file).
 // A DNS Zone represents a subset, in form of a single parent domain, of the hierarchical
 // domain name structure. In AWS, we map this data to a Route53 HostedZone.
@@ -92,6 +132,12 @@ type ClusterDNSZone struct {
 	// or create a new one. If set to true, we will not attempt to create a
 	// new DNS zone.
 	ReuseExisting bool `json:"managedZone"`
+}
+
+func (c ClusterDNSZone) Validate() error {
+	return validation.ValidateStruct(&c,
+		validation.Field(&c.ParentDomain, validation.Required, is.Domain),
+	)
 }
 
 // ClusterGithub identifies a repository and path on github.com where
@@ -111,6 +157,15 @@ type ClusterGithub struct {
 	// Team name on github.com, e.g., "kjøremiljø". The team you
 	// specify here must be owned by the organisation specified above.
 	Team string `json:"team"`
+}
+
+func (c ClusterGithub) Validate() error {
+	return validation.ValidateStruct(&c,
+		validation.Field(&c.Organisation, validation.Required),
+		validation.Field(&c.Repository, validation.Required),
+		validation.Field(&c.OutputPath, validation.Required),
+		validation.Field(&c.Team, validation.Required),
+	)
 }
 
 // ClusterIntegrations ...
@@ -140,6 +195,15 @@ type ClusterIntegrations struct {
 	ArgoCD bool `json:"argoCD,omitempty"`
 }
 
+// Validate ensures there is no conflicting options
+func (c ClusterIntegrations) Validate() error {
+	if c.ArgoCD && !c.Cognito {
+		return errors.New("the identity provider cognito is required when using ArgoCD")
+	}
+	
+	return nil
+}
+
 // ClusterTypeMeta returns an initialised TypeMeta object
 // for a Cluster
 func ClusterTypeMeta() metav1.TypeMeta {
@@ -150,7 +214,7 @@ func ClusterTypeMeta() metav1.TypeMeta {
 }
 
 // NewDefaultCluster returns a cluster definition with sensible defaults
-func NewDefaultCluster(name, env, org, repo, team string, accountID int) Cluster {
+func NewDefaultCluster(name, env, org, repo, team, accountID string) Cluster {
 	return Cluster{
 		TypeMeta: ClusterTypeMeta(),
 		Metadata: ClusterMeta{
@@ -158,6 +222,10 @@ func NewDefaultCluster(name, env, org, repo, team string, accountID int) Cluster
 			Environment: env,
 			Region:      "eu-west-1",
 			AccountID:   accountID,
+		},
+		PrimaryDNSZone: ClusterDNSZone{
+			ParentDomain:  "",
+			ReuseExisting: false,
 		},
 		Github: ClusterGithub{
 			Organisation: org,

--- a/pkg/client/core/api/rest/github.go
+++ b/pkg/client/core/api/rest/github.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"fmt"
+	"github.com/mishudark/errors"
 	"io"
 	"strings"
 
@@ -29,6 +30,26 @@ func (a *githubAPI) SelectGithubInfrastructureRepository(opts client.SelectGithu
 	repo, err := a.ask.SelectInfrastructureRepository(opts.Repository, repos)
 	if err != nil {
 		return nil, err
+	}
+
+	return &client.SelectedGithubRepository{
+		ID:           opts.ID,
+		Organisation: opts.Organisation,
+		Repository:   repo.GetName(),
+		FullName:     repo.GetFullName(),
+		GitURL:       fmt.Sprintf("git@github.com:%s", strings.TrimPrefix(repo.GetGitURL(), "git://github.com/")),
+	}, nil
+}
+
+func (a *githubAPI) GetGithubInfrastructureRepository(opts client.SelectGithubInfrastructureRepositoryOpts) (*client.SelectedGithubRepository, error) {
+	repos, err := a.client.Repositories(opts.Organisation)
+	if err != nil {
+		return nil, err
+	}
+	
+	repo, err := inferRepository(opts.Repository, repos)
+	if err != nil {
+	    return nil, err
 	}
 
 	return &client.SelectedGithubRepository{
@@ -127,6 +148,18 @@ func (a *githubAPI) CreateGithubOauthApp(opts client.CreateGithubOauthAppOpts) (
 		},
 		Team: opts.Team,
 	}, nil
+}
+
+func inferRepository(fullName string, repositories []*github.Repository) (*github.Repository, error) {
+	for _, repo := range repositories {
+		repo := *repo
+		
+		if fullName == *repo.FullName {
+			return &repo, nil
+		}
+	}
+	
+	return nil, errors.New("could not find relevant repository")
 }
 
 // NewGithubAPI returns an instantiated github API client

--- a/pkg/client/core/service_domain.go
+++ b/pkg/client/core/service_domain.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/oslokommune/okctl/pkg/api"
@@ -147,6 +148,52 @@ func (s *domainService) CreatePrimaryHostedZone(_ context.Context, opts client.C
 	}
 
 	zone.IsDelegated = delegated
+
+	r1, err := s.store.SaveHostedZone(zone)
+	if err != nil {
+		return nil, err
+	}
+
+	r2, err := s.state.SaveHostedZone(zone)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.report.ReportCreatePrimaryHostedZone(zone, []*store.Report{r1, r2})
+	if err != nil {
+		return nil, err
+	}
+
+	return zone, nil
+}
+
+func (s *domainService) CreatePrimaryHostedZoneWithoutUserinput(_ context.Context, opts client.CreatePrimaryHostedZoneOpts) (*client.HostedZone, error) {
+	err := s.spinner.Start("domain")
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err = s.spinner.Stop()
+	}()
+
+	for _, z := range s.state.GetHostedZones() {
+		if z.Primary {
+			return s.store.GetHostedZone(z.Domain)
+		}
+	}
+	
+	if opts.Domain == "" || opts.FQDN == "" {
+		return nil, errors.New("missing required primary hosted zone information domain and FQDN")
+	}
+
+	zone, err := s.api.CreatePrimaryHostedZone(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: here we need to pass the nameservers to the okctl team, so they can add it to the oslo.systems domain
+	zone.IsDelegated = true
 
 	r1, err := s.store.SaveHostedZone(zone)
 	if err != nil {

--- a/pkg/client/core/service_github.go
+++ b/pkg/client/core/service_github.go
@@ -93,6 +93,82 @@ func (s *githubService) ReadyGithubInfrastructureRepository(_ context.Context, o
 	return repo, nil
 }
 
+func (s *githubService) ReadyGithubInfrastructureRepositoryWithoutUserinput(_ context.Context, opts client.ReadyGithubInfrastructureRepositoryOpts) (*client.GithubRepository, error) {
+	err := s.spinner.Start("github")
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err = s.spinner.Stop()
+	}()
+
+	err = opts.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	r := s.state.GetGithubInfrastructureRepository(opts.ID)
+	if r.Validate() == nil {
+		return &client.GithubRepository{
+			ID:           opts.ID,
+			Organisation: opts.Organisation,
+			Repository:   r.Name,
+			FullName:     r.FullName,
+			GitURL:       r.GitURL,
+			DeployKey: &client.GithubDeployKey{
+				ID:           opts.ID,
+				Organisation: opts.Organisation,
+				Repository:   r.Name,
+				Identifier:   r.DeployKey.ID,
+				Title:        r.DeployKey.Title,
+				PublicKey:    r.DeployKey.PublicKey,
+				PrivateKeySecret: &client.GithubSecret{
+					Name:    r.DeployKey.PrivateKeySecret.Name,
+					Path:    r.DeployKey.PrivateKeySecret.Path,
+					Version: r.DeployKey.PrivateKeySecret.Version,
+				},
+			},
+		}, nil
+	}
+
+	selected, err := s.api.GetGithubInfrastructureRepository(client.SelectGithubInfrastructureRepositoryOpts(opts))
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := s.api.CreateGithubDeployKey(client.CreateGithubDeployKey{
+		ID:           opts.ID,
+		Organisation: opts.Organisation,
+		Repository:   selected.Repository,
+		Title:        fmt.Sprintf("okctl-iac-%s", opts.ID.ClusterName),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	repo := &client.GithubRepository{
+		ID:           selected.ID,
+		Organisation: selected.Organisation,
+		Repository:   selected.Repository,
+		GitURL:       selected.GitURL,
+		FullName:     selected.FullName,
+		DeployKey:    key,
+	}
+
+	report, err := s.state.SaveGithubInfrastructureRepository(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.report.ReadyGithubInfrastructureRepository(repo, report)
+	if err != nil {
+		return nil, err
+	}
+
+	return repo, nil
+}
+
 // nolint: funlen
 func (s *githubService) CreateGithubOauthApp(_ context.Context, opts client.CreateGithubOauthAppOpts) (*client.GithubOauthApp, error) {
 	err := s.spinner.Start("github")

--- a/pkg/client/domain.go
+++ b/pkg/client/domain.go
@@ -31,6 +31,7 @@ type DeletePrimaryHostedZoneOpts struct {
 // DomainService orchestrates the creation of a hosted zone
 type DomainService interface {
 	CreatePrimaryHostedZone(ctx context.Context, opts CreatePrimaryHostedZoneOpts) (*HostedZone, error)
+	CreatePrimaryHostedZoneWithoutUserinput(ctx context.Context, opts CreatePrimaryHostedZoneOpts) (*HostedZone, error)
 	GetPrimaryHostedZone(ctx context.Context, id api.ID) (*HostedZone, error)
 	DeletePrimaryHostedZone(ctx context.Context, opts DeletePrimaryHostedZoneOpts) error
 }

--- a/pkg/client/github.go
+++ b/pkg/client/github.go
@@ -179,12 +179,14 @@ type CreateGithubDeployKey struct {
 // GithubService is a business logic implementation
 type GithubService interface {
 	ReadyGithubInfrastructureRepository(ctx context.Context, opts ReadyGithubInfrastructureRepositoryOpts) (*GithubRepository, error)
+	ReadyGithubInfrastructureRepositoryWithoutUserinput(ctx context.Context, opts ReadyGithubInfrastructureRepositoryOpts) (*GithubRepository, error)
 	CreateGithubOauthApp(ctx context.Context, opts CreateGithubOauthAppOpts) (*GithubOauthApp, error)
 }
 
 // GithubAPI invokes the Github API
 type GithubAPI interface {
 	SelectGithubInfrastructureRepository(opts SelectGithubInfrastructureRepositoryOpts) (*SelectedGithubRepository, error)
+	GetGithubInfrastructureRepository(opts SelectGithubInfrastructureRepositoryOpts) (*SelectedGithubRepository, error)
 	CreateGithubDeployKey(opts CreateGithubDeployKey) (*GithubDeployKey, error)
 	SelectGithubTeam(opts SelectGithubTeam) (*GithubTeam, error)
 	CreateGithubOauthApp(opts CreateGithubOauthAppOpts) (*GithubOauthApp, error)

--- a/pkg/config/load/user.go
+++ b/pkg/config/load/user.go
@@ -50,6 +50,35 @@ all the time, if you so choose.
 
 `
 
+func CreateOnUserDataNotFoundWithNoInput() DataNotFoundFn {
+	return func(c *config.Config) (err error) {
+		userDir, err := c.GetUserDataDir()
+		if err != nil {
+			return fmt.Errorf("getting user data dir: %w", err)
+		}
+
+		userDataPath, err := c.GetUserDataPath()
+		if err != nil {
+			return fmt.Errorf("getting user data path: %w", err)
+		}
+
+		data := state.NewUser()
+
+		c.UserState = data
+
+		_, err = store.NewFileSystem(userDir, c.FileSystem).
+			StoreStruct(config.DefaultConfig, c.UserState, store.ToYAML()).
+			Do()
+
+		c.Logger.WithFields(logrus.Fields{
+			"configuration_file": userDataPath,
+		}).Info("cli configuration completed")
+
+		return nil
+	}
+}
+
+
 // CreateOnUserDataNotFound will start an interactive survey
 // that allows the end user to configure okctl for their
 // use

--- a/pkg/controller/convert.go
+++ b/pkg/controller/convert.go
@@ -1,0 +1,171 @@
+package controller
+
+import (
+	"fmt"
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/config"
+	"github.com/oslokommune/okctl/pkg/config/state"
+	"github.com/oslokommune/okctl/pkg/controller/reconsiler"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+	"github.com/oslokommune/okctl/pkg/git"
+	"github.com/spf13/afero"
+	"path"
+)
+
+type existingServices struct {
+	hasALBIngressController bool
+	hasCluster bool
+	hasExternalDNS bool
+	hasExternalSecrets bool
+	hasGithubSetup bool
+	hasIdentityManager bool
+	hasPrimaryHostedZone bool
+	hasVPC bool
+}
+
+// NewCreateCurrentStateGraphOpts creates an initialized existingServices struct
+func NewCreateCurrentStateGraphOpts(fs *afero.Afero, outputDir string, githubGetter reconsiler.GithubGetter) (*existingServices, error) {
+	return &existingServices{
+		hasGithubSetup: 		 githubTester(githubGetter()),
+		hasPrimaryHostedZone:    directoryTester(fs, outputDir, config.DefaultDomainBaseDir),
+		hasVPC:                  directoryTester(fs, outputDir, config.DefaultVpcBaseDir),
+		hasCluster:              directoryTester(fs, outputDir, config.DefaultClusterBaseDir),
+		hasExternalSecrets:      directoryTester(fs, outputDir, config.DefaultExternalSecretsBaseDir),
+		hasALBIngressController: directoryTester(fs, outputDir, config.DefaultAlbIngressControllerBaseDir),
+		hasExternalDNS:          directoryTester(fs, outputDir, config.DefaultExternalDNSBaseDir),
+		hasIdentityManager: 	 directoryTester(fs, outputDir, config.DefaultIdentityPoolBaseDir),
+	}, nil
+}
+
+// CreateCurrentStateGraph knows how to generate a ResourceNode tree based on the current state
+func CreateCurrentStateGraph(opts *existingServices) (root *resourcetree.ResourceNode) {
+	root = createNode(nil, resourcetree.ResourceNodeTypeGroup, true)
+	
+	var (
+		vpcNode,
+		clusterNode *resourcetree.ResourceNode
+	)
+
+	createNode(root, resourcetree.ResourceNodeTypeGithub, opts.hasGithubSetup)
+
+	primaryHostedZoneNode := createNode(root, resourcetree.ResourceNodeTypeZone, opts.hasPrimaryHostedZone)
+	vpcNode = createNode(primaryHostedZoneNode, resourcetree.ResourceNodeTypeVPC, opts.hasVPC)
+
+	clusterNode = createNode(vpcNode, resourcetree.ResourceNodeTypeCluster, opts.hasCluster)
+
+	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalSecrets, opts.hasExternalSecrets)
+	createNode(clusterNode, resourcetree.ResourceNodeTypeALBIngress, opts.hasALBIngressController)
+	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalDNS, opts.hasExternalDNS)
+
+	return root
+}
+
+// CreateDesiredStateGraph knows how to create a ResourceNode tree based on a cluster declaration
+func CreateDesiredStateGraph(cluster *v1alpha1.Cluster) (root *resourcetree.ResourceNode) {
+	root = createNode(nil, resourcetree.ResourceNodeTypeGroup, true)
+
+	var (
+		vpcNode,
+		clusterNode *resourcetree.ResourceNode
+	)
+
+	createNode(root, resourcetree.ResourceNodeTypeGithub, true)
+
+	primaryHostedZoneNode := createNode(root, resourcetree.ResourceNodeTypeZone, true)
+	vpcNode = createNode(primaryHostedZoneNode, resourcetree.ResourceNodeTypeVPC, true)
+
+	clusterNode = createNode(vpcNode, resourcetree.ResourceNodeTypeCluster, true)
+
+	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalSecrets, cluster.Integrations.ExternalSecrets)
+	createNode(clusterNode, resourcetree.ResourceNodeTypeALBIngress, cluster.Integrations.ALBIngressController)
+	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalDNS, cluster.Integrations.ExternalDNS)
+
+	return root
+}
+
+// ApplyDesiredStateMetadata applies metadata from a cluster definition to the nodes
+func ApplyDesiredStateMetadata(graph *resourcetree.ResourceNode, cluster *v1alpha1.Cluster, repoDir string) error {
+	primaryHostedZoneNode := graph.GetNode(&resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeZone})
+	if primaryHostedZoneNode == nil {
+		return errors.New("expected primary hosted zone node was not found")
+	}
+
+	primaryHostedZoneNode.Metadata = reconsiler.HostedZoneMetadata{Domain: cluster.PrimaryDNSZone.ParentDomain}
+
+	vpcNode := graph.GetNode(&resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeVPC})
+	if vpcNode == nil {
+		return errors.New("expected vpc node was not found")
+	}
+	
+	vpcNode.Metadata = reconsiler.VPCMetadata{
+		Cidr:             cluster.VPC.CIDR,
+		HighAvailability: cluster.VPC.HighAvailability,
+	}
+	
+	githubNode := graph.GetNode(&resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeGithub})
+	if githubNode == nil {
+		return errors.New("expected github node was not found")
+	}
+
+	repo, err := git.GithubRepoFullName(cluster.Github.Organisation, repoDir)
+	if err != nil {
+			  return fmt.Errorf("error fetching full git repo name: %w", err)
+			  }
+
+	githubNode.Metadata = reconsiler.GithubMetadata{
+		Organization: cluster.Github.Organisation,
+		Repository:   repo,
+	}
+
+	argocdNode := graph.GetNode(&resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeArgoCD})
+	if argocdNode != nil {
+		argocdNode.Metadata = reconsiler.ArgocdMetadata{Organization: cluster.Github.Organisation }
+	}
+
+	return nil
+}
+
+func createNode(parent *resourcetree.ResourceNode, nodeType resourcetree.ResourceNodeType, present bool) (child *resourcetree.ResourceNode) {
+	child = &resourcetree.ResourceNode{
+		Type:           nodeType,
+		Children:       make([]*resourcetree.ResourceNode, 0),
+	}
+	
+	if present {
+		child.State = resourcetree.ResourceNodeStatePresent
+	} else {
+		child.State = resourcetree.ResourceNodeStateAbsent
+	}
+	
+	if parent != nil {
+		parent.Children = append(parent.Children, child)
+	}
+
+	return child
+}
+
+func directoryTester(fs *afero.Afero, outputDir string, target string) bool {
+	baseDir := path.Join(outputDir, target)
+
+	exists, _ := fs.DirExists(baseDir)
+
+	return exists
+}
+
+func githubTester(github state.Github) bool {
+	if len(github.Repositories) == 0 {
+		return false
+	}
+
+	for _, repo := range github.Repositories {
+		err := repo.Validate()
+		if err != nil {
+			return false
+		}
+
+		break
+	}
+
+	return true
+}

--- a/pkg/controller/convert_test.go
+++ b/pkg/controller/convert_test.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"github.com/bmizerany/assert"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"testing"
+)
+
+func TestTreeCreators(t *testing.T) {
+	testCases := []struct {
+	    name string
+
+	    declaration func() *v1alpha1.Cluster
+	    existingServices existingServices
+	}{
+	    {
+	        name: "Should produce equal trees when all is enabled",
+	        declaration: func() *v1alpha1.Cluster {
+	        	declaration := v1alpha1.NewDefaultCluster("", "", "", "", "", "")
+	        	
+	        	return &declaration
+			},
+			existingServices: existingServices{
+				hasALBIngressController: true,
+				hasCluster:              true,
+				hasExternalDNS:          true,
+				hasExternalSecrets:      true,
+				hasGithubSetup:          true,
+				hasIdentityManager:      true,
+				hasPrimaryHostedZone:    true,
+				hasVPC:                  true,
+			},
+	    },
+		{
+			name: "Should produce equal trees when all but ExternalDNS is enabled",
+			declaration: func() *v1alpha1.Cluster {
+				declaration := v1alpha1.NewDefaultCluster("", "", "", "", "", "")
+				declaration.Integrations.ExternalDNS = false
+				
+				return &declaration
+			},
+			existingServices: existingServices{
+				hasALBIngressController: true,
+				hasCluster:              true,
+				hasExternalDNS:          false,
+				hasExternalSecrets:      true,
+				hasGithubSetup:          true,
+				hasIdentityManager:      true,
+				hasPrimaryHostedZone:    true,
+				hasVPC:                  true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+	    tc := tc
+	    
+	    t.Run(tc.name, func(t *testing.T) {
+	    	desiredTree := CreateDesiredStateGraph(tc.declaration())
+	    	currentStateTree := CreateCurrentStateGraph(&tc.existingServices)
+
+	    	assert.Equal(t, desiredTree.String(), currentStateTree.String())
+	    })
+	}
+}

--- a/pkg/controller/reconsiler/albingress.go
+++ b/pkg/controller/reconsiler/albingress.go
@@ -32,14 +32,14 @@ func (z *albIngressReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Reco
 	switch node.State {
 	case resourcetree.ResourceNodeStatePresent:
 		_, err := z.client.CreateALBIngressController(z.commonMetadata.Ctx, client.CreateALBIngressControllerOpts{
-			ID:    z.commonMetadata.Id,
+			ID:    z.commonMetadata.ClusterId,
 			VPCID: state.VpcID,
 		})
 		if err != nil {
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating ALB Ingress controller: %w", err)
 		}
 	case resourcetree.ResourceNodeStateAbsent:
-		err := z.client.DeleteALBIngressController(z.commonMetadata.Ctx, z.commonMetadata.Id)
+		err := z.client.DeleteALBIngressController(z.commonMetadata.Ctx, z.commonMetadata.ClusterId)
 		if err != nil {
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting ALB Ingress controller: %w", err)
 		}

--- a/pkg/controller/reconsiler/albingress.go
+++ b/pkg/controller/reconsiler/albingress.go
@@ -1,0 +1,56 @@
+package reconsiler
+
+import (
+	"errors"
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// AlbIngressControllerResourceState contains runtime data necessary for Reconsile to do its job
+type AlbIngressControllerResourceState struct {
+	VpcID string
+}
+
+type albIngressReconsiler struct {
+	commonMetadata *resourcetree.CommonMetadata
+	client client.ALBIngressControllerService
+}
+
+// SetCommonMetadata stores common metadata for later use
+func (z *albIngressReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+// Reconsile knows how to ensure the desired state is achieved
+func (z *albIngressReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	state, ok := node.ResourceState.(AlbIngressControllerResourceState)
+	if !ok {
+	    return nil, errors.New("error casting ALB Ingress Controller state")
+	}
+
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		_, err := z.client.CreateALBIngressController(z.commonMetadata.Ctx, client.CreateALBIngressControllerOpts{
+			ID:    z.commonMetadata.Id,
+			VPCID: state.VpcID,
+		})
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating ALB Ingress controller: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		err := z.client.DeleteALBIngressController(z.commonMetadata.Ctx, z.commonMetadata.Id)
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting ALB Ingress controller: %w", err)
+		}
+	}
+
+	return &ReconsilationResult{Requeue: false}, nil
+}
+
+// NewALBIngressReconsiler creates a new reconsiler for the ALB Ingress controller resource
+func NewALBIngressReconsiler(client client.ALBIngressControllerService) *albIngressReconsiler {
+	return &albIngressReconsiler{
+		client: client,
+	}
+}

--- a/pkg/controller/reconsiler/albingress.go
+++ b/pkg/controller/reconsiler/albingress.go
@@ -22,7 +22,7 @@ func (z *albIngressReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMe
 	z.commonMetadata = metadata
 }
 
-// Reconsile knows how to ensure the desired state is achieved
+// Reconsile knows how to do what is necessary to ensure the desired state is achieved
 func (z *albIngressReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
 	state, ok := node.ResourceState.(AlbIngressControllerResourceState)
 	if !ok {

--- a/pkg/controller/reconsiler/argocd.go
+++ b/pkg/controller/reconsiler/argocd.go
@@ -1,0 +1,76 @@
+package reconsiler
+
+import (
+	"fmt"
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/config/state"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// ArgocdMetadata contains data known before anything has been done, which is needed in Reconsile()
+type ArgocdMetadata struct {
+	Organization string
+}
+
+// ArgocdResourceState contains runtime data needed in Reconsile()
+type ArgocdResourceState struct {
+	HostedZone *state.HostedZone
+	Repository *client.GithubRepository
+	
+	UserPoolID string
+	AuthDomain string
+}
+
+type argocdReconsiler struct {
+	commonMetadata *resourcetree.CommonMetadata
+
+	client client.ArgoCDService
+}
+
+// SetCommonMetadata saves common metadata for use in Reconsile()
+func (z *argocdReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+/*
+Reconsile knows how to ensure the desired state is achieved.
+Dependent on:
+- Github repo setup
+- Cognito user pool
+- Primary hosted Zone
+ */
+func (z *argocdReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	resourceState, ok := node.ResourceState.(ArgocdResourceState)
+	if !ok {
+		return nil, errors.New("error casting argocd resource resourceState")
+	}
+
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		_, err := z.client.CreateArgoCD(z.commonMetadata.Ctx, client.CreateArgoCDOpts{
+			ID:                 z.commonMetadata.Id,
+			Domain:             resourceState.HostedZone.Domain,
+			FQDN:               resourceState.HostedZone.FQDN,
+			HostedZoneID:       resourceState.HostedZone.ID,
+			GithubOrganisation: resourceState.Repository.Organisation,
+			UserPoolID:         resourceState.UserPoolID,
+			AuthDomain:         resourceState.AuthDomain,
+			Repository:         resourceState.Repository,
+		})
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating argocd: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		return nil, errors.New("deletion of the argocd resource is not implemented")
+	}
+
+	return &ReconsilationResult{Requeue: false}, nil
+}
+
+// NewArgocdReconsiler creates a new reconsiler for the ArgoCD resource
+func NewArgocdReconsiler(client client.ArgoCDService) *argocdReconsiler {
+	return &argocdReconsiler{
+		client: client,
+	}
+}

--- a/pkg/controller/reconsiler/argocd.go
+++ b/pkg/controller/reconsiler/argocd.go
@@ -34,7 +34,7 @@ func (z *argocdReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetada
 }
 
 /*
-Reconsile knows how to ensure the desired state is achieved.
+Reconsile knows how to do what is necessary to ensure the desired state is achieved
 Dependent on:
 - Github repo setup
 - Cognito user pool

--- a/pkg/controller/reconsiler/argocd.go
+++ b/pkg/controller/reconsiler/argocd.go
@@ -49,7 +49,7 @@ func (z *argocdReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Reconsil
 	switch node.State {
 	case resourcetree.ResourceNodeStatePresent:
 		_, err := z.client.CreateArgoCD(z.commonMetadata.Ctx, client.CreateArgoCDOpts{
-			ID:                 z.commonMetadata.Id,
+			ID:                 z.commonMetadata.ClusterId,
 			Domain:             resourceState.HostedZone.Domain,
 			FQDN:               resourceState.HostedZone.FQDN,
 			HostedZoneID:       resourceState.HostedZone.ID,

--- a/pkg/controller/reconsiler/cluster.go
+++ b/pkg/controller/reconsiler/cluster.go
@@ -24,7 +24,7 @@ func (z *clusterReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetad
 	z.commonMetadata = metadata
 }
 
-// Reconsile knows how to ensure the desired state is achieved
+// Reconsile knows how to do what is necessary to ensure the desired state is achieved
 func (z *clusterReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
 	resourceState, ok := node.ResourceState.(ClusterResourceState)
 	if !ok {

--- a/pkg/controller/reconsiler/cluster.go
+++ b/pkg/controller/reconsiler/cluster.go
@@ -34,7 +34,7 @@ func (z *clusterReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Reconsi
 	switch node.State {
 	case resourcetree.ResourceNodeStatePresent:
 		_, err := z.client.CreateCluster(z.commonMetadata.Ctx, api.ClusterCreateOpts{
-			ID:                z.commonMetadata.Id,
+			ID:                z.commonMetadata.ClusterId,
 			Cidr:              resourceState.VPC.Cidr,
 			VpcID:             resourceState.VPC.VpcID,
 			VpcPrivateSubnets: resourceState.VPC.PrivateSubnets,
@@ -44,7 +44,7 @@ func (z *clusterReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Reconsi
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating cluster: %w", err)
 		}
 	case resourcetree.ResourceNodeStateAbsent:
-		err := z.client.DeleteCluster(z.commonMetadata.Ctx, api.ClusterDeleteOpts{ID: z.commonMetadata.Id})
+		err := z.client.DeleteCluster(z.commonMetadata.Ctx, api.ClusterDeleteOpts{ID: z.commonMetadata.ClusterId})
 		if err != nil {
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting cluster: %w", err)
 		}

--- a/pkg/controller/reconsiler/cluster.go
+++ b/pkg/controller/reconsiler/cluster.go
@@ -1,0 +1,62 @@
+package reconsiler
+
+import (
+	"errors"
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// ClusterResourceState contains runtime data needed in Reconsile()
+type ClusterResourceState struct {
+	VPC api.Vpc
+}
+
+type clusterReconsiler struct {
+	commonMetadata *resourcetree.CommonMetadata
+
+	client client.ClusterService
+}
+
+// SetCommonMetadata saves common metadata for use in Reconsile()
+func (z *clusterReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+// Reconsile knows how to ensure the desired state is achieved
+func (z *clusterReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	resourceState, ok := node.ResourceState.(ClusterResourceState)
+	if !ok {
+		return nil, errors.New("error casting cluster resourceState")
+	}
+
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		_, err := z.client.CreateCluster(z.commonMetadata.Ctx, api.ClusterCreateOpts{
+			ID:                z.commonMetadata.Id,
+			Cidr:              resourceState.VPC.Cidr,
+			VpcID:             resourceState.VPC.VpcID,
+			VpcPrivateSubnets: resourceState.VPC.PrivateSubnets,
+			VpcPublicSubnets:  resourceState.VPC.PublicSubnets,
+		})
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating cluster: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		err := z.client.DeleteCluster(z.commonMetadata.Ctx, api.ClusterDeleteOpts{ID: z.commonMetadata.Id})
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting cluster: %w", err)
+		}
+	}
+
+	return &ReconsilationResult{Requeue: false}, nil
+}
+
+// NewClusterReconsiler creates a new reconsiler for the cluster resource
+func NewClusterReconsiler(client client.ClusterService) *clusterReconsiler {
+	return &clusterReconsiler{
+		client: client,
+	}
+}
+

--- a/pkg/controller/reconsiler/externaldns.go
+++ b/pkg/controller/reconsiler/externaldns.go
@@ -1,0 +1,60 @@
+package reconsiler
+
+import (
+	"errors"
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// ExternalDNSResourceState contains runtime data needed in Reconsile()
+type ExternalDNSResourceState struct {
+	HostedZoneID string
+	Domain string
+}
+
+type externalDNSReconsiler struct {
+	commonMetadata *resourcetree.CommonMetadata
+	
+	client client.ExternalDNSService
+}
+
+// SetCommonMetadata saves common metadata for use in Reconsile()
+func (z *externalDNSReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+// Reconsile knows how to ensure the desired state is achieved
+func (z *externalDNSReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	resourceState, ok := node.ResourceState.(ExternalDNSResourceState)
+	if !ok {
+		return nil, errors.New("error casting External DNS resourceState")
+	}
+
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		_, err := z.client.CreateExternalDNS(z.commonMetadata.Ctx, client.CreateExternalDNSOpts{
+			ID:           z.commonMetadata.Id,
+			HostedZoneID: resourceState.HostedZoneID,
+			Domain:       resourceState.Domain,
+		})
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating external DNS: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		err := z.client.DeleteExternalDNS(z.commonMetadata.Ctx, z.commonMetadata.Id)
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting external DNS: %w", err)
+		}
+	}
+
+
+	return &ReconsilationResult{Requeue: false}, nil
+}
+
+// NewExternalDNSReconsiler creates a new reconsiler for the ExternalDNS resource
+func NewExternalDNSReconsiler(client client.ExternalDNSService) *externalDNSReconsiler {
+	return &externalDNSReconsiler{
+		client: client,
+	}
+}

--- a/pkg/controller/reconsiler/externaldns.go
+++ b/pkg/controller/reconsiler/externaldns.go
@@ -34,7 +34,7 @@ func (z *externalDNSReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Rec
 	switch node.State {
 	case resourcetree.ResourceNodeStatePresent:
 		_, err := z.client.CreateExternalDNS(z.commonMetadata.Ctx, client.CreateExternalDNSOpts{
-			ID:           z.commonMetadata.Id,
+			ID:           z.commonMetadata.ClusterId,
 			HostedZoneID: resourceState.HostedZoneID,
 			Domain:       resourceState.Domain,
 		})
@@ -42,7 +42,7 @@ func (z *externalDNSReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Rec
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating external DNS: %w", err)
 		}
 	case resourcetree.ResourceNodeStateAbsent:
-		err := z.client.DeleteExternalDNS(z.commonMetadata.Ctx, z.commonMetadata.Id)
+		err := z.client.DeleteExternalDNS(z.commonMetadata.Ctx, z.commonMetadata.ClusterId)
 		if err != nil {
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting external DNS: %w", err)
 		}

--- a/pkg/controller/reconsiler/externaldns.go
+++ b/pkg/controller/reconsiler/externaldns.go
@@ -24,7 +24,7 @@ func (z *externalDNSReconsiler) SetCommonMetadata(metadata *resourcetree.CommonM
 	z.commonMetadata = metadata
 }
 
-// Reconsile knows how to ensure the desired state is achieved
+// Reconsile knows how to do what is necessary to ensure the desired state is achieved
 func (z *externalDNSReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
 	resourceState, ok := node.ResourceState.(ExternalDNSResourceState)
 	if !ok {

--- a/pkg/controller/reconsiler/externalsecrets.go
+++ b/pkg/controller/reconsiler/externalsecrets.go
@@ -17,7 +17,7 @@ func (z *externalSecretsReconsiler) SetCommonMetadata(metadata *resourcetree.Com
 	z.commonMetadata = metadata
 }
 
-// Reconsile knows how to ensure the desired state is achieved
+// Reconsile knows how to do what is necessary to ensure the desired state is achieved
 func (z *externalSecretsReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
 	switch node.State {
 	case resourcetree.ResourceNodeStatePresent:

--- a/pkg/controller/reconsiler/externalsecrets.go
+++ b/pkg/controller/reconsiler/externalsecrets.go
@@ -1,0 +1,46 @@
+package reconsiler
+
+import (
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+type externalSecretsReconsiler struct {
+	commonMetadata *resourcetree.CommonMetadata
+	
+	client client.ExternalSecretsService
+}
+
+// SetCommonMetadata saves common metadata for use in Reconsile()
+func (z *externalSecretsReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+// Reconsile knows how to ensure the desired state is achieved
+func (z *externalSecretsReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		_, err := z.client.CreateExternalSecrets(z.commonMetadata.Ctx, client.CreateExternalSecretsOpts{ID: z.commonMetadata.Id})
+		
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating external secrets: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		err := z.client.DeleteExternalSecrets(z.commonMetadata.Ctx, z.commonMetadata.Id)
+
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting external secrets: %w", err)
+		}
+	}
+
+	return &ReconsilationResult{Requeue: false}, nil
+}
+
+// NewExternalSecretsReconsiler creates a new reconsiler for the ExternalSecrets resource
+func NewExternalSecretsReconsiler(client client.ExternalSecretsService) *externalSecretsReconsiler {
+	return &externalSecretsReconsiler{
+		client: client,
+	}
+}
+

--- a/pkg/controller/reconsiler/externalsecrets.go
+++ b/pkg/controller/reconsiler/externalsecrets.go
@@ -21,13 +21,13 @@ func (z *externalSecretsReconsiler) SetCommonMetadata(metadata *resourcetree.Com
 func (z *externalSecretsReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
 	switch node.State {
 	case resourcetree.ResourceNodeStatePresent:
-		_, err := z.client.CreateExternalSecrets(z.commonMetadata.Ctx, client.CreateExternalSecretsOpts{ID: z.commonMetadata.Id})
+		_, err := z.client.CreateExternalSecrets(z.commonMetadata.Ctx, client.CreateExternalSecretsOpts{ID: z.commonMetadata.ClusterId})
 		
 		if err != nil {
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating external secrets: %w", err)
 		}
 	case resourcetree.ResourceNodeStateAbsent:
-		err := z.client.DeleteExternalSecrets(z.commonMetadata.Ctx, z.commonMetadata.Id)
+		err := z.client.DeleteExternalSecrets(z.commonMetadata.Ctx, z.commonMetadata.ClusterId)
 
 		if err != nil {
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting external secrets: %w", err)

--- a/pkg/controller/reconsiler/github.go
+++ b/pkg/controller/reconsiler/github.go
@@ -52,7 +52,7 @@ func (z *githubReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Reconsil
 	switch node.State {
 	case resourcetree.ResourceNodeStatePresent:
 		_, err := z.client.ReadyGithubInfrastructureRepositoryWithoutUserinput(z.commonMetadata.Ctx, client.ReadyGithubInfrastructureRepositoryOpts{
-			ID:           z.commonMetadata.Id,
+			ID:           z.commonMetadata.ClusterId,
 			Organisation: metadata.Organization,
 			Repository:   metadata.Repository,
 		})

--- a/pkg/controller/reconsiler/github.go
+++ b/pkg/controller/reconsiler/github.go
@@ -37,7 +37,7 @@ func (z *githubReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetada
 	z.commonMetadata = metadata
 }
 
-// Reconsile knows how to ensure the desired state is achieved
+// Reconsile knows how to do what is necessary to ensure the desired state is achieved
 func (z *githubReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
 	metadata, ok := node.Metadata.(GithubMetadata)
 	if !ok {

--- a/pkg/controller/reconsiler/github.go
+++ b/pkg/controller/reconsiler/github.go
@@ -1,0 +1,82 @@
+package reconsiler
+
+import (
+	"fmt"
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/client/store"
+	"github.com/oslokommune/okctl/pkg/config/state"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// GithubMetadata contains data from the desired state
+type GithubMetadata struct {
+	Organization string
+	Repository string
+}
+
+// GithubGetter knows how to get the current state Github
+type GithubGetter func() state.Github
+// GithubSetter knows how to save a state.Github
+type GithubSetter func(github state.Github) (*store.Report, error)
+
+// GithubResourceState contains runtime data needed in Reconsile()
+type GithubResourceState struct {
+	Getter GithubGetter
+	Saver GithubSetter
+}
+
+type githubReconsiler struct {
+	commonMetadata *resourcetree.CommonMetadata
+
+	client client.GithubService
+}
+
+// SetCommonMetadata saves common metadata for use in Reconsile()
+func (z *githubReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+// Reconsile knows how to ensure the desired state is achieved
+func (z *githubReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	metadata, ok := node.Metadata.(GithubMetadata)
+	if !ok {
+		return nil, errors.New("unable to cast Github metadata")
+	}
+
+	resourceState, ok := node.ResourceState.(GithubResourceState)
+	if !ok {
+		return nil, errors.New("unable to cast Github resource state")
+	}
+
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		_, err := z.client.ReadyGithubInfrastructureRepositoryWithoutUserinput(z.commonMetadata.Ctx, client.ReadyGithubInfrastructureRepositoryOpts{
+			ID:           z.commonMetadata.Id,
+			Organisation: metadata.Organization,
+			Repository:   metadata.Repository,
+		})
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating Github resource: %w", err)
+		}
+
+		gh := resourceState.Getter()
+		gh.Organisation = metadata.Organization
+
+		_, err = resourceState.Saver(gh)
+		if err != nil {
+		    return nil, fmt.Errorf("error saving github: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		return nil, errors.New("deleting Github resource is not implemented")
+	}
+
+	return &ReconsilationResult{Requeue: false}, nil
+}
+
+// NewGithubReconsiler creates a new reconsiler for the Github resource
+func NewGithubReconsiler(client client.GithubService) *githubReconsiler {
+	return &githubReconsiler{
+		client: client,
+	}
+}

--- a/pkg/controller/reconsiler/identitymanager.go
+++ b/pkg/controller/reconsiler/identitymanager.go
@@ -1,0 +1,67 @@
+package reconsiler
+
+import (
+	"fmt"
+	"github.com/miekg/dns"
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// IdentityManagerResourceState contains runtime data needed in Reconsile()
+type IdentityManagerResourceState struct {
+	HostedZoneID string
+	Domain string
+}
+
+type identityManagerReconsiler struct {
+	commonMetadata *resourcetree.CommonMetadata
+
+	client client.IdentityManagerService
+}
+
+// SetCommonMetadata saves common metadata for use in Reconsile()
+func (z *identityManagerReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+/*
+Reconsile knows how to ensure the desired state is achieved
+Requires:
+- Hosted Zone
+- Nameservers setup
+ */
+func (z *identityManagerReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	resourceState, ok := node.ResourceState.(IdentityManagerResourceState)
+	if !ok {
+		return nil, errors.New("unable to cast identity manager resourceState")
+	}
+
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		authDomain := fmt.Sprintf("auth.%s", resourceState.Domain)
+		authFQDN := dns.Fqdn(authDomain)
+		
+		_, err := z.client.CreateIdentityPool(z.commonMetadata.Ctx, api.CreateIdentityPoolOpts{
+			ID:           z.commonMetadata.Id,
+			AuthDomain:   authDomain,
+			AuthFQDN:     authFQDN,
+			HostedZoneID: resourceState.HostedZoneID,
+		})
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating identity manager resource: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		return nil, errors.New("deleting identity manager resource is not implemented")
+	}
+
+	return &ReconsilationResult{Requeue: false}, nil
+}
+
+// NewIdentityManagerReconsiler creates a new reconsiler for the Identity Manager resource
+func NewIdentityManagerReconsiler(client client.IdentityManagerService) *identityManagerReconsiler {
+	return &identityManagerReconsiler{
+		client: client,
+	}
+}

--- a/pkg/controller/reconsiler/identitymanager.go
+++ b/pkg/controller/reconsiler/identitymanager.go
@@ -27,7 +27,7 @@ func (z *identityManagerReconsiler) SetCommonMetadata(metadata *resourcetree.Com
 }
 
 /*
-Reconsile knows how to ensure the desired state is achieved
+Reconsile knows how to do what is necessary to ensure the desired state is achieved
 Requires:
 - Hosted Zone
 - Nameservers setup

--- a/pkg/controller/reconsiler/identitymanager.go
+++ b/pkg/controller/reconsiler/identitymanager.go
@@ -44,7 +44,7 @@ func (z *identityManagerReconsiler) Reconsile(node *resourcetree.ResourceNode) (
 		authFQDN := dns.Fqdn(authDomain)
 		
 		_, err := z.client.CreateIdentityPool(z.commonMetadata.Ctx, api.CreateIdentityPoolOpts{
-			ID:           z.commonMetadata.Id,
+			ID:           z.commonMetadata.ClusterId,
 			AuthDomain:   authDomain,
 			AuthFQDN:     authFQDN,
 			HostedZoneID: resourceState.HostedZoneID,

--- a/pkg/controller/reconsiler/noop.go
+++ b/pkg/controller/reconsiler/noop.go
@@ -1,0 +1,42 @@
+package reconsiler
+
+import (
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// noopMetadata contains data known at initialization. Usually information from the desired state
+type noopMetadata struct {}
+
+// noopResourceState contains data that potentially can only be known at runtime. E.g.: state only known after an
+// external resource has been created
+type noopResourceState struct {}
+
+// NoopReconsiler handles reconsiliation for dummy nodes (e.g. the root node) and acts as a template for other
+// reconsilers
+type NoopReconsiler struct {}
+
+// SetCommonMetadata knows how to store common metadata on the reconsiler. This should do nothing if common metadata is
+// not needed
+func (receiver *NoopReconsiler) SetCommonMetadata(_ *resourcetree.CommonMetadata) {}
+
+// Reconsile knows how to create, update and delete the relevant resource
+func (receiver *NoopReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	//metadata, ok := node.Metadata.(noopMetadata)
+	//if !ok {
+	//	return nil, errors.New("could not cast Noop metadata")
+	//}
+	//
+	//state, ok := node.ResourceState.(noopResourceState)
+	//if !ok {
+	//	return nil, errors.New("could not cast Noop resource state")
+	//}
+
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		// Create a resource
+	case resourcetree.ResourceNodeStateAbsent:
+		// Delete a resource
+	}
+
+	return &ReconsilationResult{Requeue: false}, nil
+}

--- a/pkg/controller/reconsiler/reconsiler.go
+++ b/pkg/controller/reconsiler/reconsiler.go
@@ -13,7 +13,7 @@ type ReconsilationResult struct {
 }
 
 type Reconsiler interface {
-	// Reconsile knows how to ensure the desired state is achieved
+	// Reconsile knows how to do what is necessary to ensure the desired state is achieved
 	Reconsile(*resourcetree.ResourceNode) (*ReconsilationResult, error)
 	SetCommonMetadata(metadata *resourcetree.CommonMetadata)
 }

--- a/pkg/controller/reconsiler/reconsiler.go
+++ b/pkg/controller/reconsiler/reconsiler.go
@@ -27,10 +27,10 @@ type ReconsilerManager struct {
 }
 
 // AddReconsiler makes a Reconsiler available in the ReconsilerManager
-func (manager *ReconsilerManager) AddReconsiler(key resourcetree.ResourceNodeType, Reconsiler Reconsiler) {
-	Reconsiler.SetCommonMetadata(manager.commonMetadata)
+func (manager *ReconsilerManager) AddReconsiler(key resourcetree.ResourceNodeType, reconsiler Reconsiler) {
+	reconsiler.SetCommonMetadata(manager.commonMetadata)
 	
-	manager.Reconsilers[key] = Reconsiler
+	manager.Reconsilers[key] = reconsiler
 }
 
 // Reconsile chooses the correct reconsiler to use based on a nodes type

--- a/pkg/controller/reconsiler/reconsiler.go
+++ b/pkg/controller/reconsiler/reconsiler.go
@@ -1,0 +1,51 @@
+package reconsiler
+
+import (
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+/*
+ * Reconsiler
+ */
+
+type ReconsilationResult struct {
+	Requeue bool
+}
+
+type Reconsiler interface {
+	// Reconsile knows how to ensure the desired state is achieved
+	Reconsile(*resourcetree.ResourceNode) (*ReconsilationResult, error)
+	SetCommonMetadata(metadata *resourcetree.CommonMetadata)
+}
+
+/*
+ReconsilerManager provides a simpler way to organize reconsilers
+*/
+type ReconsilerManager struct {
+	commonMetadata *resourcetree.CommonMetadata
+	Reconsilers map[resourcetree.ResourceNodeType]Reconsiler
+}
+
+// AddReconsiler makes a Reconsiler available in the ReconsilerManager
+func (manager *ReconsilerManager) AddReconsiler(key resourcetree.ResourceNodeType, Reconsiler Reconsiler) {
+	Reconsiler.SetCommonMetadata(manager.commonMetadata)
+	
+	manager.Reconsilers[key] = Reconsiler
+}
+
+// Reconsile chooses the correct reconsiler to use based on a nodes type
+func (manager *ReconsilerManager) Reconsile(node *resourcetree.ResourceNode)	(*ReconsilationResult, error)  {
+	node.RefreshState()
+	
+	return manager.Reconsilers[node.Type].Reconsile(node)
+}
+
+// NewReconsilerManager creates a new ReconsilerManager with a NoopReconsiler already installed
+func NewReconsilerManager(metadata *resourcetree.CommonMetadata) *ReconsilerManager {
+	return &ReconsilerManager{
+		commonMetadata: metadata,
+		Reconsilers: map[resourcetree.ResourceNodeType]Reconsiler{
+			resourcetree.ResourceNodeTypeGroup: &NoopReconsiler{},
+		},
+	}
+}

--- a/pkg/controller/reconsiler/reconsiler.go
+++ b/pkg/controller/reconsiler/reconsiler.go
@@ -8,7 +8,9 @@ import (
  * Reconsiler
  */
 
+// ReconsilationResult contains information about the result of a Reconsile() call
 type ReconsilationResult struct {
+	// Requeue indicates if this Reconciliation must be run again
 	Requeue bool
 }
 

--- a/pkg/controller/reconsiler/vpc.go
+++ b/pkg/controller/reconsiler/vpc.go
@@ -35,7 +35,7 @@ func (z *vpcReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Reconsilati
 	switch node.State {
 	case resourcetree.ResourceNodeStatePresent:
 		_, err := z.client.CreateVpc(z.commonMetadata.Ctx, api.CreateVpcOpts{
-			ID:      z.commonMetadata.Id,
+			ID:      z.commonMetadata.ClusterId,
 			Cidr:    metadata.Cidr,
 			Minimal: !metadata.HighAvailability,
 		})
@@ -43,7 +43,7 @@ func (z *vpcReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Reconsilati
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating vpc: %w", err)
 		}
 	case resourcetree.ResourceNodeStateAbsent:
-		err := z.client.DeleteVpc(z.commonMetadata.Ctx, api.DeleteVpcOpts{ ID: z.commonMetadata.Id })
+		err := z.client.DeleteVpc(z.commonMetadata.Ctx, api.DeleteVpcOpts{ ID: z.commonMetadata.ClusterId})
 		if err != nil {
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting vpc: %w", err)
 		}

--- a/pkg/controller/reconsiler/vpc.go
+++ b/pkg/controller/reconsiler/vpc.go
@@ -25,7 +25,7 @@ func (z *vpcReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata)
 	z.commonMetadata = metadata
 }
 
-// Reconsile knows how to ensure the desired state is achieved
+// Reconsile knows how to do what is necessary to ensure the desired state is achieved
 func (z *vpcReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
 	metadata, ok := node.Metadata.(VPCMetadata)
 	if !ok {

--- a/pkg/controller/reconsiler/vpc.go
+++ b/pkg/controller/reconsiler/vpc.go
@@ -1,0 +1,60 @@
+package reconsiler
+
+import (
+	"fmt"
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// VPCMetadata contains data extracted from the desired state
+type VPCMetadata struct {
+	Cidr string
+	HighAvailability bool
+}
+
+type vpcReconsiler struct {
+	commonMetadata *resourcetree.CommonMetadata
+	
+	client client.VPCService
+}
+
+// SetCommonMetadata saves common metadata for use in Reconsile()
+func (z *vpcReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+// Reconsile knows how to ensure the desired state is achieved
+func (z *vpcReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	metadata, ok := node.Metadata.(VPCMetadata)
+	if !ok {
+	    return nil, errors.New("unable to cast VPC metadata")
+	}
+
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		_, err := z.client.CreateVpc(z.commonMetadata.Ctx, api.CreateVpcOpts{
+			ID:      z.commonMetadata.Id,
+			Cidr:    metadata.Cidr,
+			Minimal: !metadata.HighAvailability,
+		})
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating vpc: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		err := z.client.DeleteVpc(z.commonMetadata.Ctx, api.DeleteVpcOpts{ ID: z.commonMetadata.Id })
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting vpc: %w", err)
+		}
+	}
+
+	return &ReconsilationResult{Requeue: false}, nil
+}
+
+// NewVPCReconsiler creates a new reconsiler for the VPC resource
+func NewVPCReconsiler(client client.VPCService) *vpcReconsiler {
+	return &vpcReconsiler{
+		client: client,
+	}
+}

--- a/pkg/controller/reconsiler/zone.go
+++ b/pkg/controller/reconsiler/zone.go
@@ -1,0 +1,62 @@
+package reconsiler
+
+import (
+	"fmt"
+	"github.com/miekg/dns"
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// HostedZoneMetadata contains data extracted from the desired state
+type HostedZoneMetadata struct {
+	Domain string
+}
+
+type zoneReconsiler struct {
+	commonMetadata *resourcetree.CommonMetadata
+	
+	client client.DomainService
+}
+
+// SetCommonMetadata saves common metadata for use in Reconsile()
+func (z *zoneReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+// Reconsile knows how to ensure the desired state is achieved
+func (z *zoneReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
+	metadata, ok := node.Metadata.(HostedZoneMetadata)
+	if !ok {
+		return nil, errors.New("error casting HostedZone metadata")
+	}
+	
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		fqdn := dns.Fqdn(metadata.Domain)
+
+		_, err := z.client.CreatePrimaryHostedZoneWithoutUserinput(z.commonMetadata.Ctx, client.CreatePrimaryHostedZoneOpts{
+			ID:     z.commonMetadata.Id,
+			Domain: metadata.Domain,
+			FQDN: fqdn,
+		})
+		if err != nil {
+			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating hosted zone: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		err := z.client.DeletePrimaryHostedZone(z.commonMetadata.Ctx, client.DeletePrimaryHostedZoneOpts{ID: z.commonMetadata.Id})
+		if err != nil {
+		    return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting hosted zone: %w", err)
+		}
+	}
+
+	return &ReconsilationResult{Requeue: false}, nil
+}
+
+// NewZoneReconsiler creates a new reconsiler for the Hosted Zone resource
+func NewZoneReconsiler(client client.DomainService) *zoneReconsiler {
+	return &zoneReconsiler{
+		client: client,
+	}
+}
+

--- a/pkg/controller/reconsiler/zone.go
+++ b/pkg/controller/reconsiler/zone.go
@@ -36,7 +36,7 @@ func (z *zoneReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Reconsilat
 		fqdn := dns.Fqdn(metadata.Domain)
 
 		_, err := z.client.CreatePrimaryHostedZoneWithoutUserinput(z.commonMetadata.Ctx, client.CreatePrimaryHostedZoneOpts{
-			ID:     z.commonMetadata.Id,
+			ID:     z.commonMetadata.ClusterId,
 			Domain: metadata.Domain,
 			FQDN: fqdn,
 		})
@@ -44,7 +44,7 @@ func (z *zoneReconsiler) Reconsile(node *resourcetree.ResourceNode) (*Reconsilat
 			return &ReconsilationResult{Requeue: true}, fmt.Errorf("error creating hosted zone: %w", err)
 		}
 	case resourcetree.ResourceNodeStateAbsent:
-		err := z.client.DeletePrimaryHostedZone(z.commonMetadata.Ctx, client.DeletePrimaryHostedZoneOpts{ID: z.commonMetadata.Id})
+		err := z.client.DeletePrimaryHostedZone(z.commonMetadata.Ctx, client.DeletePrimaryHostedZoneOpts{ID: z.commonMetadata.ClusterId})
 		if err != nil {
 		    return &ReconsilationResult{Requeue: true}, fmt.Errorf("error deleting hosted zone: %w", err)
 		}

--- a/pkg/controller/reconsiler/zone.go
+++ b/pkg/controller/reconsiler/zone.go
@@ -24,7 +24,7 @@ func (z *zoneReconsiler) SetCommonMetadata(metadata *resourcetree.CommonMetadata
 	z.commonMetadata = metadata
 }
 
-// Reconsile knows how to ensure the desired state is achieved
+// Reconsile knows how to do what is necessary to ensure the desired state is achieved
 func (z *zoneReconsiler) Reconsile(node *resourcetree.ResourceNode) (*ReconsilationResult, error) {
 	metadata, ok := node.Metadata.(HostedZoneMetadata)
 	if !ok {

--- a/pkg/controller/refreshers.go
+++ b/pkg/controller/refreshers.go
@@ -1,0 +1,100 @@
+package controller
+
+import (
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client/store"
+	"github.com/oslokommune/okctl/pkg/config"
+	"github.com/oslokommune/okctl/pkg/config/state"
+	"github.com/oslokommune/okctl/pkg/controller/reconsiler"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+	"github.com/spf13/afero"
+	"path"
+)
+
+func getVpcState(fs *afero.Afero, outputDir string) api.Vpc {
+	vpc := api.Vpc{}
+
+	baseDir := path.Join(outputDir, "vpc")
+
+	_, err := store.NewFileSystem(baseDir, fs).
+		GetStruct(config.DefaultVpcOutputs, &vpc, store.FromJSON()).
+		Do()
+	if err != nil {
+		panic(fmt.Errorf("error reading from vpc state file: %w", err))
+	}
+
+	return vpc
+}
+
+// StringFetcher defines a function which can be used to delay fetching of strings
+type StringFetcher func() string
+// HostedZoneFetcher defines a function which can be used to delay fetching of a hosted zone
+type HostedZoneFetcher func() *state.HostedZone
+
+// CreateClusterStateRefresher creates a function that gathers required runtime data for a cluster resource
+func CreateClusterStateRefresher(fs *afero.Afero, outputDir string, cidrFn StringFetcher) resourcetree.StateRefreshFn {
+	return func(node *resourcetree.ResourceNode) {
+		vpc := getVpcState(fs, outputDir)
+
+		vpc.Cidr = cidrFn()
+
+		node.ResourceState = reconsiler.ClusterResourceState{VPC: vpc}
+	}
+}
+
+// CreateALBIngressControllerRefresher creates a function that gathers required runtime data for a ALB Ingress
+// Controller resource
+func CreateALBIngressControllerRefresher(fs *afero.Afero, outputDir string) resourcetree.StateRefreshFn {
+	return func(node *resourcetree.ResourceNode) {
+		vpc := getVpcState(fs, outputDir)
+
+		node.ResourceState = reconsiler.AlbIngressControllerResourceState{VpcID: vpc.VpcID}
+	}
+}
+
+// CreateExternalDNSStateRefresher creates a function that gathers required runtime data for a External DNS resource
+func CreateExternalDNSStateRefresher(primaryHostedZoneFetcher HostedZoneFetcher) resourcetree.StateRefreshFn {
+	return func(node *resourcetree.ResourceNode) {
+		hostedZone := primaryHostedZoneFetcher()
+
+		node.ResourceState = reconsiler.ExternalDNSResourceState{
+			HostedZoneID: hostedZone.ID,
+			Domain:       hostedZone.Domain,
+		}
+	}
+}
+
+// CreateIdentityManagerRefresher creates a function that gathers required runtime data for a Identity Manager resource
+func CreateIdentityManagerRefresher(primaryHostedZoneFetcher HostedZoneFetcher) resourcetree.StateRefreshFn {
+	return func(node *resourcetree.ResourceNode) {
+		hostedZone := primaryHostedZoneFetcher()
+
+		node.ResourceState = reconsiler.IdentityManagerResourceState{
+			HostedZoneID: hostedZone.ID,
+			Domain:       hostedZone.Domain,
+		}
+	}
+}
+
+// CreateGithubStateRefresher creates a function that gathers required runtime data for a Github resource
+func CreateGithubStateRefresher(ghGetter reconsiler.GithubGetter, ghSetter reconsiler.GithubSetter) resourcetree.StateRefreshFn {
+	return func(node *resourcetree.ResourceNode) {
+		node.ResourceState = reconsiler.GithubResourceState{
+			Getter: ghGetter,
+			Saver: ghSetter,
+		}
+	}
+}
+
+// CreateArgocdStateRefresher creates a function that gathers required runtime data for a ArgoCD resource
+func CreateArgocdStateRefresher(hostedZoneFetcher HostedZoneFetcher) resourcetree.StateRefreshFn {
+	return func(node *resourcetree.ResourceNode) {
+		node.ResourceState = reconsiler.ArgocdResourceState{
+			HostedZone: hostedZoneFetcher(),
+			Repository: nil,
+			UserPoolID: "",
+			AuthDomain: "",
+		}
+	}
+}

--- a/pkg/controller/resourcetree/tree.go
+++ b/pkg/controller/resourcetree/tree.go
@@ -1,0 +1,184 @@
+package resourcetree
+
+import (
+	"bytes"
+	"context"
+	"github.com/oslokommune/okctl/pkg/api"
+	"io"
+)
+
+// ResourceNodeType defines what type of resource a ResourceNode represents
+type ResourceNodeType int
+const (
+	// ResourceNodeTypeGroup represents a node that has no actions associated with it. For now, only the root node
+	ResourceNodeTypeGroup ResourceNodeType = iota
+	// ResourceNodeTypeZone represents a HostedZone resource
+	ResourceNodeTypeZone
+	// ResourceNodeTypeVPC represents a VPC resource
+	ResourceNodeTypeVPC
+	// ResourceNodeTypeCluster represents a EKS cluster resource
+	ResourceNodeTypeCluster
+	// ResourceNodeTypeExternalSecrets represents an External Secrets resource
+	ResourceNodeTypeExternalSecrets
+	// ResourceNodeTypeALBIngress represents an ALB Ingress resource
+	ResourceNodeTypeALBIngress
+	// ResourceNodeTypeExternalDNS represents an External DNS resource
+	ResourceNodeTypeExternalDNS
+	// ResourceNodeTypeGithub represents a Github setup
+	ResourceNodeTypeGithub
+	// ResourceNodeTypeIdentityManager represents a Identity Manager resource
+	ResourceNodeTypeIdentityManager
+	// ResourceNodeTypeArgoCD represents an ArgoCD resource
+	ResourceNodeTypeArgoCD
+)
+
+func ResourceNodeTypeToString(nodeType ResourceNodeType) string {
+	switch nodeType {
+	case ResourceNodeTypeGroup:
+		return "Group"
+	case ResourceNodeTypeZone:
+		return "Hosted Zone"
+	case ResourceNodeTypeVPC:
+		return "VPC"
+	case ResourceNodeTypeCluster:
+		return "K8s Cluster"
+	case ResourceNodeTypeExternalSecrets:
+		return "External Secrets"
+	case ResourceNodeTypeALBIngress:
+		return "ALB Ingress Controller"
+	case ResourceNodeTypeExternalDNS:
+		return "External DNS"
+	case ResourceNodeTypeGithub:
+		return "Github Setup"
+	case ResourceNodeTypeIdentityManager:
+		return "Identity Manager"
+	case ResourceNodeTypeArgoCD:
+		return "ArgoCD controller"
+	default:
+		return ""
+	}
+}
+
+// ResourceNodeState defines what state the resource is in, used to infer what action to take
+type ResourceNodeState int
+const (
+	// ResourceNodeStateNoop represents a state where no action is needed. E.g.: if the desired state of the
+	// resource conforms with the actual state
+	ResourceNodeStateNoop ResourceNodeState = iota
+	// ResourceNodeStatePresent represents the state where the resource exists
+	ResourceNodeStatePresent
+	// ResourceNodeStateAbsent represents the state where the resource does not exist
+	ResourceNodeStateAbsent
+)
+
+// CommonMetadata represents metadata required by most if not all operations on services
+type CommonMetadata struct {
+	Ctx       context.Context
+	ClusterId api.ID
+}
+
+// StateRefreshFn is a function that attempts to retrieve state potentially can only be retrieved at runtime. E.g.:
+// state that can only exist after an external resource has been created
+type StateRefreshFn func(node *ResourceNode)
+
+// ResourceNode represents a component of the cluster and its dependencies
+type ResourceNode struct {
+	Type  ResourceNodeType
+	State ResourceNodeState
+
+	// Contains metadata regarding the resource known on instance creation
+	Metadata             interface{}
+
+	StateRefresher 		 StateRefreshFn
+	// ResourceState contains data that needs to be retrieved runtime. In other words, data that potentially only exist
+	// after an external resource has been created
+	ResourceState 		 interface{}
+
+	Children []*ResourceNode
+}
+
+// RefreshState calls the stored StateRefreshFn if it exists
+func (node *ResourceNode) RefreshState() {
+	if node.StateRefresher == nil {
+		return
+	}
+
+	node.StateRefresher(node)
+}
+
+// SetStateRefresher stores a StateRefreshFn on the node to be used to retrieve runtime state later
+func (node *ResourceNode) SetStateRefresher(nodeType ResourceNodeType, refresher StateRefreshFn) {
+	targetNode := node.GetNode(&ResourceNode{Type: nodeType})
+
+	if targetNode == nil {
+		return
+	}
+
+	targetNode.StateRefresher = refresher
+}
+
+// Equals knows how to compare two ResourceNodes and determine equality
+func (node *ResourceNode) Equals(targetNode *ResourceNode) bool {
+	if targetNode == nil {
+		return false
+	}
+
+	// P.S.: For now, this is good enough due to all types of resources only existing once
+	return node.Type == targetNode.Type
+}
+
+// GetNode returns an identical node as targetNode from the receiver's tree
+func (node *ResourceNode) GetNode(targetNode *ResourceNode) *ResourceNode {
+	if node.Equals(targetNode) {
+		return node
+	}
+	
+	for _, child := range node.Children {
+		result := child.GetNode(targetNode)
+
+		if result != nil {
+			return result
+		}
+	}
+	
+	return nil
+}
+
+func (node *ResourceNode) treeViewGenerator(writer io.Writer, tabs int) {
+	result := ""
+	for index := 0; index < tabs; index++ {
+		result += "\t"
+	}
+	
+	result += "- " + ResourceNodeTypeToString(node.Type) + "\n"
+	
+	if node.State == ResourceNodeStatePresent {
+		_, _ = writer.Write([]byte(result))
+	}
+
+	for _, child := range node.Children {
+		child.treeViewGenerator(writer, tabs + 1)
+	}
+}
+
+func (node *ResourceNode) String() string {
+	var buf bytes.Buffer
+	
+	node.treeViewGenerator(&buf, 0)
+	
+	return buf.String()
+}
+
+// ApplyFn is a kind of function we can run on all the nodes in a ResourceNode tree with the ApplyFunction() function
+type ApplyFn func(receiver *ResourceNode, target *ResourceNode)
+
+// ApplyFunction will use the supplied ApplyFn on all the nodes in the receiver tree, with an equal node from the target
+// tree
+func (node *ResourceNode) ApplyFunction(fn ApplyFn, targetGraph *ResourceNode) {
+	for _, child := range node.Children {
+		child.ApplyFunction(fn, targetGraph)
+	}
+	
+	targetNode := targetGraph.GetNode(node)
+	fn(node, targetNode)
+}

--- a/pkg/controller/resourcetree/tree_test.go
+++ b/pkg/controller/resourcetree/tree_test.go
@@ -1,0 +1,134 @@
+package resourcetree_test
+
+import (
+	"github.com/bmizerany/assert"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+	"testing"
+)
+
+func TestResourceNode_ApplyFunction(t *testing.T) {
+	testCases := []struct {
+	    name string
+	    expectedCalls int
+	    generateReceiverTree func() *resourcetree.ResourceNode
+	    generateTargetTree func() *resourcetree.ResourceNode
+	}{
+	    {
+	        name: "Applies on all nodes in a tree of 3",
+	        expectedCalls: 3,
+	        generateReceiverTree: func() *resourcetree.ResourceNode {
+				root := &resourcetree.ResourceNode{ 
+					Type: resourcetree.ResourceNodeTypeGroup,
+					Children: []*resourcetree.ResourceNode{},
+				}
+				
+				root.Children = append(root.Children, &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeVPC,
+					Children: []*resourcetree.ResourceNode{
+						{
+							Type: resourcetree.ResourceNodeTypeZone,
+							Children: []*resourcetree.ResourceNode{},
+						},
+					},
+				})
+				
+				return root
+			},
+			generateTargetTree: func() *resourcetree.ResourceNode {
+				root := &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeGroup,
+					Children: []*resourcetree.ResourceNode{},
+				}
+
+				root.Children = append(root.Children, &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeVPC,
+					Children: []*resourcetree.ResourceNode{
+						{
+							Type: resourcetree.ResourceNodeTypeZone,
+							Children: []*resourcetree.ResourceNode{},
+						},
+					},
+				})
+
+				return root
+			},
+		},
+		{
+			name: "Applies to all nodes in a tree of 2",
+			expectedCalls: 2,
+			generateReceiverTree: func() *resourcetree.ResourceNode {
+				root := &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeGroup,
+					Children: []*resourcetree.ResourceNode{},
+				}
+
+				root.Children = append(root.Children, &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeVPC,
+					Children: []*resourcetree.ResourceNode{},
+				})
+
+				return root
+			},
+			generateTargetTree: func() *resourcetree.ResourceNode {
+				root := &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeGroup,
+					Children: []*resourcetree.ResourceNode{},
+				}
+
+				root.Children = append(root.Children, &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeVPC,
+					Children: []*resourcetree.ResourceNode{},
+				})
+
+				return root
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+	    tc := tc
+	    
+	    t.Run(tc.name, func(t *testing.T) {
+	    	desiredTree := tc.generateReceiverTree()
+	    	currentStateTree := tc.generateTargetTree()
+	    	
+	    	numberOfCalls := 0
+	    	desiredTree.ApplyFunction(func(receiver *resourcetree.ResourceNode, target *resourcetree.ResourceNode) {
+	    		numberOfCalls += 1
+			}, currentStateTree)
+
+	    	assert.Equal(t, tc.expectedCalls, numberOfCalls)
+	    })
+	}
+}
+
+func TestResourceNode_Equals(t *testing.T) {
+	testCases := []struct {
+	    name string
+	    nodeA *resourcetree.ResourceNode
+	    nodeB *resourcetree.ResourceNode
+	    
+	    expectEquality bool
+	}{
+	    {
+	        name: "Should be equal",
+	        nodeA: &resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeVPC },
+	        nodeB: &resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeVPC },
+	        expectEquality: true,
+	    },
+	    {
+	    	name: "Should not be equal",
+	    	nodeA: &resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeVPC },
+	    	nodeB: &resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeZone },
+	    	expectEquality: false,
+		},
+	}
+	
+	for _, tc := range testCases {
+	    tc := tc
+	    
+	    t.Run(tc.name, func(t *testing.T) {
+	    	assert.Equal(t, tc.expectEquality, tc.nodeA.Equals(tc.nodeB))
+	    })
+	}
+}

--- a/pkg/controller/synchronize.go
+++ b/pkg/controller/synchronize.go
@@ -1,0 +1,93 @@
+package controller
+
+import (
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/controller/reconsiler"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+	"github.com/spf13/afero"
+)
+
+type SynchronizeOpts struct {
+	DesiredTree *resourcetree.ResourceNode
+	
+	ReconsiliationManager *reconsiler.ReconsilerManager
+	
+	Fs *afero.Afero
+	OutputDir string
+
+	GithubGetter reconsiler.GithubGetter
+	GithubSetter reconsiler.GithubSetter
+
+	CIDRGetter StringFetcher
+	PrimaryHostedZoneGetter HostedZoneFetcher
+}
+
+// Synchronize knows how to discover differences between desired and actual state and rectify them
+func Synchronize(opts *SynchronizeOpts) error {
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeCluster, CreateClusterStateRefresher(
+		opts.Fs,
+		opts.OutputDir,
+		opts.CIDRGetter,
+	))
+	
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeALBIngress, CreateALBIngressControllerRefresher(
+		opts.Fs,
+		opts.OutputDir,
+	))
+
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeExternalDNS, CreateExternalDNSStateRefresher(
+		opts.PrimaryHostedZoneGetter,
+	))
+	
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeIdentityManager, CreateIdentityManagerRefresher(
+		opts.PrimaryHostedZoneGetter,
+	))
+
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeGithub, CreateGithubStateRefresher(
+		opts.GithubGetter,
+		opts.GithubSetter,
+	))
+	
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeArgoCD, CreateArgocdStateRefresher(
+		opts.PrimaryHostedZoneGetter,
+	))
+
+	currentStateGraphOpts, err := NewCreateCurrentStateGraphOpts(opts.Fs, opts.OutputDir, opts.GithubGetter)
+	if err != nil {
+	    return fmt.Errorf("unable to get existing services: %w", err)
+	}
+
+	currentStateTree := CreateCurrentStateGraph(currentStateGraphOpts)
+
+	diffTree := *opts.DesiredTree
+
+	diffTree.ApplyFunction(applyCurrentState, currentStateTree)
+
+	return handleNode(opts.ReconsiliationManager, &diffTree)
+}
+
+// handleNode knows how to run Reconsile() on every node of a ResourceNode tree
+func handleNode(reconsilerManager *reconsiler.ReconsilerManager, currentNode *resourcetree.ResourceNode) error {
+	_, err := reconsilerManager.Reconsile(currentNode)
+	if err != nil {
+	    return fmt.Errorf("error reconsiling node: %w", err)
+	}
+
+	for _, node := range currentNode.Children {
+		err = handleNode(reconsilerManager, node)
+		if err != nil {
+		    return fmt.Errorf("error handling node: %w", err)
+		}
+	}
+	
+	return nil
+}
+
+// applyCurrentState knows how to apply the current state on a desired state ResourceNode tree to produce a diff that
+// knows which resources to create, and which resources is already existing
+func applyCurrentState(receiver *resourcetree.ResourceNode, target *resourcetree.ResourceNode) {
+	if receiver.State == target.State {
+		receiver.State = resourcetree.ResourceNodeStateNoop
+	}
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is the first of several pull requests to implement a declarative way of creating (and later deleting, editing) clusters. 

This part implements a pattern loosely based on Kubernetes controllers. In this PR we define a so called Reconsiler for each resource we want to be able to do CRUD(without the R) operations on. Each reconsiler knows how to create the associated resource based on the information that is available to it. Functionality in following pull requests will handle figuring out which action the reconsiler should do, and how to gather information.

Each reconsiler works on a ResourceNode. Each ResourceNode represents one resource from the cluster. A VPC is a resource. A hosted zone is a resource. Etc.

Godspeed.