### PR TITLE
KM94 feat(declarativecluster) PART 3: Add controller pkg API and usage

### DIFF
--- a/cmd/okctl/apply.go
+++ b/cmd/okctl/apply.go
@@ -12,6 +12,7 @@ func buildApplyCommand(o *okctl.Okctl) *cobra.Command {
 	}
 
 	cmd.AddCommand(buildApplyApplicationCommand(o))
+	cmd.AddCommand(buildApplyClusterCommand(o))
 
 	return cmd
 }

--- a/cmd/okctl/applycluster.go
+++ b/cmd/okctl/applycluster.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/config/load"
+	"github.com/oslokommune/okctl/pkg/config/state"
+	"github.com/oslokommune/okctl/pkg/controller"
+	"github.com/oslokommune/okctl/pkg/controller/reconsiler"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/oslokommune/okctl/pkg/spinner"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+	"path/filepath"
+	"sigs.k8s.io/yaml"
+)
+
+type applyClusterOpts struct {
+	File string
+
+	Declaration *v1alpha1.Cluster
+}
+
+// Validate ensures the applyClusterOpts contains the right information
+func (o *applyClusterOpts) Validate() error {
+	return validation.ValidateStruct(o,
+		validation.Field(&o.File, validation.Required),
+	)
+}
+
+func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
+	opts := applyClusterOpts{}
+
+	cmd := &cobra.Command{
+		Use: "cluster -f declaration_file",
+		Example: "okctl apply cluster -f cluster.yaml",
+		Short: "apply a cluster definition to the world",
+		Long: "ensures your cluster reflects the declaration of it",
+		Args: cobra.ExactArgs(0),
+		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			opts.Declaration, err = inferClusterFromStdinOrFile(o.In, opts.File)
+			if err != nil {
+				return fmt.Errorf("error inferring cluster: %w", err)
+			}
+			
+			err = loadNoUserInputUserData(o, cmd)
+			if err != nil {
+				return fmt.Errorf("failed to load application data: %w", err)
+			}
+
+			err = loadNoUserInputRepoData(o, opts.Declaration)
+			if err != nil {
+				return fmt.Errorf("failed to load repo data: %w", err)
+			}
+
+			err = o.InitialiseWithEnvAndAWSAccountID(
+				opts.Declaration.Metadata.Environment,
+				opts.Declaration.Metadata.AccountID,
+			)
+			if err != nil {
+				return fmt.Errorf("error initializing okctl: %w", err)
+			}
+			
+			return nil
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) (err error) {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+			err = opts.Declaration.Validate()
+			if err != nil {
+			    return fmt.Errorf("error validating cluster declaration: %w", err)
+			}
+
+			id := api.ID{
+				Region:       opts.Declaration.Metadata.Region,
+				AWSAccountID: opts.Declaration.Metadata.AccountID,
+				Environment:  opts.Declaration.Metadata.Environment,
+				Repository:   o.RepoStateWithEnv.GetMetadata().Name,
+				ClusterName: o.RepoStateWithEnv.GetClusterName(),
+			}
+
+			spin, err := spinner.New("synchronizing", o.Err)
+			services, err := o.ClientServices(spin)
+			if err != nil {
+			    return fmt.Errorf("error getting services: %w", err)
+			}
+
+			outputDir, _ := o.GetRepoOutputDir(opts.Declaration.Metadata.Environment)
+
+			repoDir, err := o.GetRepoDir()
+			if err != nil {
+				return fmt.Errorf("could not get Repository dir: %w", err)
+			}
+
+			desiredGraph := controller.CreateDesiredStateGraph(opts.Declaration)
+
+			err = controller.ApplyDesiredStateMetadata(desiredGraph, opts.Declaration, repoDir)
+			if err != nil {
+			    return fmt.Errorf("could not apply desired state metadata: %w", err)
+			}
+
+			reconsiliationManager := reconsiler.NewReconsilerManager(&resourcetree.CommonMetadata{
+				Ctx: o.Ctx,
+				Id:  id,
+			})
+
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeZone, reconsiler.NewZoneReconsiler(services.Domain))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeVPC, reconsiler.NewVPCReconsiler(services.Vpc))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeCluster, reconsiler.NewClusterReconsiler(services.Cluster))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeExternalSecrets, reconsiler.NewExternalSecretsReconsiler(services.ExternalSecrets))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeALBIngress, reconsiler.NewALBIngressReconsiler(services.ALBIngressController))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeExternalDNS, reconsiler.NewExternalDNSReconsiler(services.ExternalDNS))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeGithub, reconsiler.NewGithubReconsiler(services.Github))
+			reconsiliationManager.AddReconsiler(resourcetree.ResourceNodeTypeIdentityManager, reconsiler.NewIdentityManagerReconsiler(services.IdentityManager))
+			
+			synchronizeOpts := &controller.SynchronizeOpts{
+				DesiredTree:           desiredGraph,
+				ReconsiliationManager: reconsiliationManager,
+				Fs:                    o.FileSystem,
+				OutputDir:             outputDir,
+				GithubGetter:          o.RepoStateWithEnv.GetGithub,
+				GithubSetter:          o.RepoStateWithEnv.SaveGithub,
+				CIDRGetter: func() string { return o.RepoStateWithEnv.GetVPC().CIDR },
+				PrimaryHostedZoneGetter: func() *state.HostedZone { return o.RepoStateWithEnv.GetPrimaryHostedZone() },
+			}
+
+			err = controller.Synchronize(synchronizeOpts)
+			if err != nil {
+			    return fmt.Errorf("error synchronizing declaration with state: %w", err)
+			}
+			
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.File, "file", "f", "", usageApplyClusterFile)
+	
+	cmd.Hidden = true // TODO: remove when feature is complete
+
+	return cmd
+}
+
+const usageApplyClusterFile = `specifies where to read the declaration from. Use "-" for stdin`
+
+
+func inferClusterFromStdinOrFile(stdin io.Reader, path string) (*v1alpha1.Cluster, error) {
+	var (
+		inputReader io.Reader
+		err         error
+	)
+
+	switch path {
+	case "-":
+		inputReader = stdin
+	default:
+		inputReader, err = os.Open(filepath.Clean(path))
+		if err != nil {
+			return nil, fmt.Errorf("unable to read file: %w", err)
+		}
+	}
+
+	var (
+		buffer bytes.Buffer
+		cluster v1alpha1.Cluster
+	)
+	
+	cluster = v1alpha1.NewDefaultCluster("", "", "", "", "", "")
+	
+	_, err = io.Copy(&buffer, inputReader)
+	if err != nil {
+	    return nil, fmt.Errorf("error copying reader data: %w", err)
+	}
+
+	err = yaml.Unmarshal(buffer.Bytes(), &cluster)
+	if err != nil {
+	    return nil, fmt.Errorf("error unmarshalling buffer: %w", err)
+	}
+	
+	return &cluster, nil
+}
+
+func loadNoUserInputUserData(o *okctl.Okctl, cmd *cobra.Command) error {
+	userDataNotFound := load.CreateOnUserDataNotFoundWithNoInput()
+
+	if o.NoInput {
+		userDataNotFound = load.ErrOnUserDataNotFound()
+	}
+
+	o.UserDataLoader = load.UserDataFromFlagsEnvConfigDefaults(cmd, userDataNotFound)
+
+	return o.LoadUserData()
+}
+
+func loadNoUserInputRepoData(o *okctl.Okctl, declaration *v1alpha1.Cluster) error {
+	repoDataNotFound := load.CreateOnRepoDataNotFoundWithNoUserInput(declaration)
+
+	o.RepoDataLoader = load.RepoDataFromConfigFile(repoDataNotFound)
+
+	return o.LoadRepoData()
+}

--- a/cmd/okctl/main.go
+++ b/cmd/okctl/main.go
@@ -22,7 +22,7 @@ func main() {
 	}
 }
 
-func loadRepoData(o *okctl.Okctl, cmd *cobra.Command) error {
+func loadRepoData(o *okctl.Okctl, _ *cobra.Command) error {
 	repoDataNotFound := load.CreateOnRepoDataNotFound()
 
 	if o.NoInput {
@@ -34,7 +34,7 @@ func loadRepoData(o *okctl.Okctl, cmd *cobra.Command) error {
 	// not want the configuration to be overridden by env
 	// vars or similar.
 	// We can drop sending *cobra.Command on here.
-	o.RepoDataLoader = load.RepoDataFromConfigFile(cmd, repoDataNotFound)
+	o.RepoDataLoader = load.RepoDataFromConfigFile(repoDataNotFound)
 
 	return o.LoadRepoData()
 }
@@ -102,13 +102,14 @@ being captured. Together with slack and slick.`,
 		},
 	}
 
-	cmd.AddCommand(buildVenvCommand(o))
+	cmd.AddCommand(buildAddUserCommand(o))
+	cmd.AddCommand(buildApplyCommand(o))
 	cmd.AddCommand(buildCreateCommand(o))
 	cmd.AddCommand(buildDeleteCommand(o))
-	cmd.AddCommand(buildApplyCommand(o))
+	cmd.AddCommand(buildScaffoldCommand(o))
 	cmd.AddCommand(buildShowCommand(o))
+	cmd.AddCommand(buildVenvCommand(o))
 	cmd.AddCommand(buildVersionCommand(o))
-	cmd.AddCommand(buildAddUserCommand(o))
 
 	f := cmd.Flags()
 	f.StringVarP(&outputFormat, "output", "o", "text",

--- a/cmd/okctl/scaffold.go
+++ b/cmd/okctl/scaffold.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/spf13/cobra"
+)
+
+func buildScaffoldCommand(o *okctl.Okctl) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scaffold",
+		Short: "scaffold templates for different resources",
+	}
+
+	cmd.AddCommand(buildScaffoldClusterCommand(o))
+
+	return cmd
+}

--- a/cmd/okctl/scaffoldcluster.go
+++ b/cmd/okctl/scaffoldcluster.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+const scaffoldClusterArgumentQuantity = 2
+
+type scaffoldClusterOpts struct {
+	Name string
+	
+	AWSAccountID string
+	Environment string
+	Organization string
+	RepositoryName string
+	Team string
+}
+
+func buildScaffoldClusterCommand(o *okctl.Okctl) *cobra.Command {
+	opts := scaffoldClusterOpts{}
+	
+	cmd := &cobra.Command{
+		Use: "cluster CLUSTER_NAME ENVIRONMENT",
+		Example: exampleUsage,
+		Short: "Scaffold cluster resource template",
+		Long: "Scaffolds a cluster resource which can be used to control cluster resources",
+		Args: cobra.ExactArgs(scaffoldClusterArgumentQuantity),
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Name = args[0]
+			opts.Environment = args[1]
+			
+			clusterResource := v1alpha1.NewDefaultCluster(
+				opts.Name,
+				opts.Environment,
+				opts.Organization,
+				opts.RepositoryName,
+				opts.Team,
+				opts.AWSAccountID,
+			)
+
+			result, err := yaml.Marshal(clusterResource)
+			if err != nil {
+			    return fmt.Errorf("error marshalling yaml: %w", err)
+			}
+			
+			_, err = o.Out.Write(result)
+			if err != nil {
+			    return fmt.Errorf("error writing cluster: %w", err)
+			}
+			
+			return nil
+		},
+	}
+	
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Organization, "github-organization", "o", "oslokommune", usageOrganization)
+	flags.StringVarP(&opts.RepositoryName, "repository-name", "r", "my_iac_repo_name", usageRepository)
+	flags.StringVarP(&opts.Team, "github-team", "t", "my_team", usageTeam)
+	flags.StringVarP(&opts.AWSAccountID, "aws-account-id", "i", "123456789123", usageAWSAccountID)
+	
+	return cmd
+}
+
+const usageAWSAccountID = `the aws account where the resources provisioned by okctl should reside`
+const usageOrganization = `the organization that owns the infrastructure-as-code repository`
+const usageRepository = `the name of the repository that will contain infrastructure-as-code`
+const usageTeam = `the team that is responsible and has access rights to the infrastructure-as-code repository`
+const exampleUsage = `okctl scaffold cluster utviklerportalen production > cluster.yaml`

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3d/v3 v3.0.1
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
+	github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b
 	github.com/sanity-io/litter v1.3.0
 	github.com/sebdah/goldie/v2 v2.5.1
 	github.com/sirupsen/logrus v1.7.0

--- a/pkg/apis/okctl.io/v1alpha1/cluster.go
+++ b/pkg/apis/okctl.io/v1alpha1/cluster.go
@@ -1,7 +1,11 @@
 package v1alpha1
 
 import (
+	"errors"
 	"fmt"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+	"regexp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,6 +29,11 @@ type Cluster struct {
 	// this cluster will integrate with.
 	Github ClusterGithub `json:"github"`
 
+	// PrimaryDNSZone defines the main primary zone to associate with this
+	// cluster. This will be the zone that we will use to create domains
+	// for auth, ArgoCD, etc.
+	PrimaryDNSZone ClusterDNSZone `json:"primaryDNSZone"`
+
 	// VPC defines how we configure the VPC for the cluster
 	// +optional
 	VPC *ClusterVPC `json:"vpc,omitempty"`
@@ -38,6 +47,19 @@ type Cluster struct {
 	// this cluster.
 	// +optional
 	DNSZones []ClusterDNSZone `json:"dnsZones,omitempty"`
+}
+
+// Validate calls each members Validate function
+func (c Cluster) Validate() error {
+	result := validation.ValidateStruct(&c,
+		validation.Field(&c.Metadata),
+		validation.Field(&c.Github),
+		validation.Field(&c.PrimaryDNSZone),
+		validation.Field(&c.VPC),
+		validation.Field(&c.Integrations),
+	)
+	
+	return result
 }
 
 // ClusterMeta describes a unique cluster
@@ -56,13 +78,23 @@ type ClusterMeta struct {
 
 	// AccountID specifies the AWS Account ID
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html
-	AccountID int `json:"accountID"`
+	AccountID string `json:"accountID"`
+}
+
+// Validate ensures ClusterMeta contains the right information
+func (receiver ClusterMeta) Validate() error {
+	return validation.ValidateStruct(&receiver,
+		validation.Field(&receiver.Name, validation.Required),
+		validation.Field(&receiver.Environment, validation.Required, validation.Match(regexp.MustCompile("^[a-zA-Z]{3,64}$")).Error("must consist of 3-64 characters (a-z, A-Z)")),
+		validation.Field(&receiver.Region, validation.Required, validation.In("eu-west-1").Error("for now, only \"eu-west-1\" is supported")),
+		validation.Field(&receiver.AccountID, validation.Required, validation.Match(regexp.MustCompile("^[0-9]{12}$")).Error("must consist of 12 digits")),
+	)
 }
 
 // String returns a unique identifier for a cluster
 // Not sure about this..
-func (c *ClusterMeta) String() string {
-	return fmt.Sprintf("%s-%s.%s.okctl.io/%d", c.Name, c.Environment, c.Region, c.AccountID)
+func (receiver *ClusterMeta) String() string {
+	return fmt.Sprintf("%s-%s.%s.okctl.io/%d", receiver.Name, receiver.Environment, receiver.Region, receiver.AccountID)
 }
 
 // ClusterVPC is a definition of the VPC we create for the EKS cluster
@@ -80,6 +112,14 @@ type ClusterVPC struct {
 	HighAvailability bool `json:"highAvailability,omitempty"`
 }
 
+// Validate ensures ClusterVPC contains the right information
+func (c ClusterVPC) Validate() error {
+	return validation.ValidateStruct(&c,
+		validation.Field(&c.CIDR, validation.Required),
+		validation.Field(&c.HighAvailability, validation.Required),
+	)
+}
+
 // ClusterDNSZone is analogous to a DNS Zone file (https://en.wikipedia.org/wiki/Zone_file).
 // A DNS Zone represents a subset, in form of a single parent domain, of the hierarchical
 // domain name structure. In AWS, we map this data to a Route53 HostedZone.
@@ -92,6 +132,12 @@ type ClusterDNSZone struct {
 	// or create a new one. If set to true, we will not attempt to create a
 	// new DNS zone.
 	ReuseExisting bool `json:"managedZone"`
+}
+
+func (c ClusterDNSZone) Validate() error {
+	return validation.ValidateStruct(&c,
+		validation.Field(&c.ParentDomain, validation.Required, is.Domain),
+	)
 }
 
 // ClusterGithub identifies a repository and path on github.com where
@@ -111,6 +157,15 @@ type ClusterGithub struct {
 	// Team name on github.com, e.g., "kjøremiljø". The team you
 	// specify here must be owned by the organisation specified above.
 	Team string `json:"team"`
+}
+
+func (c ClusterGithub) Validate() error {
+	return validation.ValidateStruct(&c,
+		validation.Field(&c.Organisation, validation.Required),
+		validation.Field(&c.Repository, validation.Required),
+		validation.Field(&c.OutputPath, validation.Required),
+		validation.Field(&c.Team, validation.Required),
+	)
 }
 
 // ClusterIntegrations ...
@@ -140,6 +195,15 @@ type ClusterIntegrations struct {
 	ArgoCD bool `json:"argoCD,omitempty"`
 }
 
+// Validate ensures there is no conflicting options
+func (c ClusterIntegrations) Validate() error {
+	if c.ArgoCD && !c.Cognito {
+		return errors.New("the identity provider cognito is required when using ArgoCD")
+	}
+	
+	return nil
+}
+
 // ClusterTypeMeta returns an initialised TypeMeta object
 // for a Cluster
 func ClusterTypeMeta() metav1.TypeMeta {
@@ -150,7 +214,7 @@ func ClusterTypeMeta() metav1.TypeMeta {
 }
 
 // NewDefaultCluster returns a cluster definition with sensible defaults
-func NewDefaultCluster(name, env, org, repo, team string, accountID int) Cluster {
+func NewDefaultCluster(name, env, org, repo, team, accountID string) Cluster {
 	return Cluster{
 		TypeMeta: ClusterTypeMeta(),
 		Metadata: ClusterMeta{
@@ -158,6 +222,10 @@ func NewDefaultCluster(name, env, org, repo, team string, accountID int) Cluster
 			Environment: env,
 			Region:      "eu-west-1",
 			AccountID:   accountID,
+		},
+		PrimaryDNSZone: ClusterDNSZone{
+			ParentDomain:  "",
+			ReuseExisting: false,
 		},
 		Github: ClusterGithub{
 			Organisation: org,

--- a/pkg/client/core/api/rest/github.go
+++ b/pkg/client/core/api/rest/github.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"fmt"
+	"github.com/mishudark/errors"
 	"io"
 	"strings"
 
@@ -29,6 +30,26 @@ func (a *githubAPI) SelectGithubInfrastructureRepository(opts client.SelectGithu
 	repo, err := a.ask.SelectInfrastructureRepository(opts.Repository, repos)
 	if err != nil {
 		return nil, err
+	}
+
+	return &client.SelectedGithubRepository{
+		ID:           opts.ID,
+		Organisation: opts.Organisation,
+		Repository:   repo.GetName(),
+		FullName:     repo.GetFullName(),
+		GitURL:       fmt.Sprintf("git@github.com:%s", strings.TrimPrefix(repo.GetGitURL(), "git://github.com/")),
+	}, nil
+}
+
+func (a *githubAPI) GetGithubInfrastructureRepository(opts client.SelectGithubInfrastructureRepositoryOpts) (*client.SelectedGithubRepository, error) {
+	repos, err := a.client.Repositories(opts.Organisation)
+	if err != nil {
+		return nil, err
+	}
+	
+	repo, err := inferRepository(opts.Repository, repos)
+	if err != nil {
+	    return nil, err
 	}
 
 	return &client.SelectedGithubRepository{
@@ -127,6 +148,18 @@ func (a *githubAPI) CreateGithubOauthApp(opts client.CreateGithubOauthAppOpts) (
 		},
 		Team: opts.Team,
 	}, nil
+}
+
+func inferRepository(fullName string, repositories []*github.Repository) (*github.Repository, error) {
+	for _, repo := range repositories {
+		repo := *repo
+		
+		if fullName == *repo.FullName {
+			return &repo, nil
+		}
+	}
+	
+	return nil, errors.New("could not find relevant repository")
 }
 
 // NewGithubAPI returns an instantiated github API client

--- a/pkg/client/core/service_domain.go
+++ b/pkg/client/core/service_domain.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/oslokommune/okctl/pkg/api"
@@ -147,6 +148,52 @@ func (s *domainService) CreatePrimaryHostedZone(_ context.Context, opts client.C
 	}
 
 	zone.IsDelegated = delegated
+
+	r1, err := s.store.SaveHostedZone(zone)
+	if err != nil {
+		return nil, err
+	}
+
+	r2, err := s.state.SaveHostedZone(zone)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.report.ReportCreatePrimaryHostedZone(zone, []*store.Report{r1, r2})
+	if err != nil {
+		return nil, err
+	}
+
+	return zone, nil
+}
+
+func (s *domainService) CreatePrimaryHostedZoneWithoutUserinput(_ context.Context, opts client.CreatePrimaryHostedZoneOpts) (*client.HostedZone, error) {
+	err := s.spinner.Start("domain")
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err = s.spinner.Stop()
+	}()
+
+	for _, z := range s.state.GetHostedZones() {
+		if z.Primary {
+			return s.store.GetHostedZone(z.Domain)
+		}
+	}
+	
+	if opts.Domain == "" || opts.FQDN == "" {
+		return nil, errors.New("missing required primary hosted zone information domain and FQDN")
+	}
+
+	zone, err := s.api.CreatePrimaryHostedZone(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: here we need to pass the nameservers to the okctl team, so they can add it to the oslo.systems domain
+	zone.IsDelegated = true
 
 	r1, err := s.store.SaveHostedZone(zone)
 	if err != nil {

--- a/pkg/client/core/service_github.go
+++ b/pkg/client/core/service_github.go
@@ -93,6 +93,82 @@ func (s *githubService) ReadyGithubInfrastructureRepository(_ context.Context, o
 	return repo, nil
 }
 
+func (s *githubService) ReadyGithubInfrastructureRepositoryWithoutUserinput(_ context.Context, opts client.ReadyGithubInfrastructureRepositoryOpts) (*client.GithubRepository, error) {
+	err := s.spinner.Start("github")
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err = s.spinner.Stop()
+	}()
+
+	err = opts.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	r := s.state.GetGithubInfrastructureRepository(opts.ID)
+	if r.Validate() == nil {
+		return &client.GithubRepository{
+			ID:           opts.ID,
+			Organisation: opts.Organisation,
+			Repository:   r.Name,
+			FullName:     r.FullName,
+			GitURL:       r.GitURL,
+			DeployKey: &client.GithubDeployKey{
+				ID:           opts.ID,
+				Organisation: opts.Organisation,
+				Repository:   r.Name,
+				Identifier:   r.DeployKey.ID,
+				Title:        r.DeployKey.Title,
+				PublicKey:    r.DeployKey.PublicKey,
+				PrivateKeySecret: &client.GithubSecret{
+					Name:    r.DeployKey.PrivateKeySecret.Name,
+					Path:    r.DeployKey.PrivateKeySecret.Path,
+					Version: r.DeployKey.PrivateKeySecret.Version,
+				},
+			},
+		}, nil
+	}
+
+	selected, err := s.api.GetGithubInfrastructureRepository(client.SelectGithubInfrastructureRepositoryOpts(opts))
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := s.api.CreateGithubDeployKey(client.CreateGithubDeployKey{
+		ID:           opts.ID,
+		Organisation: opts.Organisation,
+		Repository:   selected.Repository,
+		Title:        fmt.Sprintf("okctl-iac-%s", opts.ID.ClusterName),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	repo := &client.GithubRepository{
+		ID:           selected.ID,
+		Organisation: selected.Organisation,
+		Repository:   selected.Repository,
+		GitURL:       selected.GitURL,
+		FullName:     selected.FullName,
+		DeployKey:    key,
+	}
+
+	report, err := s.state.SaveGithubInfrastructureRepository(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.report.ReadyGithubInfrastructureRepository(repo, report)
+	if err != nil {
+		return nil, err
+	}
+
+	return repo, nil
+}
+
 // nolint: funlen
 func (s *githubService) CreateGithubOauthApp(_ context.Context, opts client.CreateGithubOauthAppOpts) (*client.GithubOauthApp, error) {
 	err := s.spinner.Start("github")

--- a/pkg/client/domain.go
+++ b/pkg/client/domain.go
@@ -31,6 +31,7 @@ type DeletePrimaryHostedZoneOpts struct {
 // DomainService orchestrates the creation of a hosted zone
 type DomainService interface {
 	CreatePrimaryHostedZone(ctx context.Context, opts CreatePrimaryHostedZoneOpts) (*HostedZone, error)
+	CreatePrimaryHostedZoneWithoutUserinput(ctx context.Context, opts CreatePrimaryHostedZoneOpts) (*HostedZone, error)
 	GetPrimaryHostedZone(ctx context.Context, id api.ID) (*HostedZone, error)
 	DeletePrimaryHostedZone(ctx context.Context, opts DeletePrimaryHostedZoneOpts) error
 }

--- a/pkg/client/github.go
+++ b/pkg/client/github.go
@@ -179,12 +179,14 @@ type CreateGithubDeployKey struct {
 // GithubService is a business logic implementation
 type GithubService interface {
 	ReadyGithubInfrastructureRepository(ctx context.Context, opts ReadyGithubInfrastructureRepositoryOpts) (*GithubRepository, error)
+	ReadyGithubInfrastructureRepositoryWithoutUserinput(ctx context.Context, opts ReadyGithubInfrastructureRepositoryOpts) (*GithubRepository, error)
 	CreateGithubOauthApp(ctx context.Context, opts CreateGithubOauthAppOpts) (*GithubOauthApp, error)
 }
 
 // GithubAPI invokes the Github API
 type GithubAPI interface {
 	SelectGithubInfrastructureRepository(opts SelectGithubInfrastructureRepositoryOpts) (*SelectedGithubRepository, error)
+	GetGithubInfrastructureRepository(opts SelectGithubInfrastructureRepositoryOpts) (*SelectedGithubRepository, error)
 	CreateGithubDeployKey(opts CreateGithubDeployKey) (*GithubDeployKey, error)
 	SelectGithubTeam(opts SelectGithubTeam) (*GithubTeam, error)
 	CreateGithubOauthApp(opts CreateGithubOauthAppOpts) (*GithubOauthApp, error)

--- a/pkg/config/load/user.go
+++ b/pkg/config/load/user.go
@@ -50,6 +50,35 @@ all the time, if you so choose.
 
 `
 
+func CreateOnUserDataNotFoundWithNoInput() DataNotFoundFn {
+	return func(c *config.Config) (err error) {
+		userDir, err := c.GetUserDataDir()
+		if err != nil {
+			return fmt.Errorf("getting user data dir: %w", err)
+		}
+
+		userDataPath, err := c.GetUserDataPath()
+		if err != nil {
+			return fmt.Errorf("getting user data path: %w", err)
+		}
+
+		data := state.NewUser()
+
+		c.UserState = data
+
+		_, err = store.NewFileSystem(userDir, c.FileSystem).
+			StoreStruct(config.DefaultConfig, c.UserState, store.ToYAML()).
+			Do()
+
+		c.Logger.WithFields(logrus.Fields{
+			"configuration_file": userDataPath,
+		}).Info("cli configuration completed")
+
+		return nil
+	}
+}
+
+
 // CreateOnUserDataNotFound will start an interactive survey
 // that allows the end user to configure okctl for their
 // use

--- a/pkg/controller/convert_test.go
+++ b/pkg/controller/convert_test.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"github.com/bmizerany/assert"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"testing"
+)
+
+func TestTreeCreators(t *testing.T) {
+	testCases := []struct {
+	    name string
+
+	    declaration func() *v1alpha1.Cluster
+	    existingServices existingServices
+	}{
+	    {
+	        name: "Should produce equal trees when all is enabled",
+	        declaration: func() *v1alpha1.Cluster {
+	        	declaration := v1alpha1.NewDefaultCluster("", "", "", "", "", "")
+	        	
+	        	return &declaration
+			},
+			existingServices: existingServices{
+				hasALBIngressController: true,
+				hasCluster:              true,
+				hasExternalDNS:          true,
+				hasExternalSecrets:      true,
+				hasGithubSetup:          true,
+				hasIdentityManager:      true,
+				hasPrimaryHostedZone:    true,
+				hasVPC:                  true,
+			},
+	    },
+		{
+			name: "Should produce equal trees when all but ExternalDNS is enabled",
+			declaration: func() *v1alpha1.Cluster {
+				declaration := v1alpha1.NewDefaultCluster("", "", "", "", "", "")
+				declaration.Integrations.ExternalDNS = false
+				
+				return &declaration
+			},
+			existingServices: existingServices{
+				hasALBIngressController: true,
+				hasCluster:              true,
+				hasExternalDNS:          false,
+				hasExternalSecrets:      true,
+				hasGithubSetup:          true,
+				hasIdentityManager:      true,
+				hasPrimaryHostedZone:    true,
+				hasVPC:                  true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+	    tc := tc
+	    
+	    t.Run(tc.name, func(t *testing.T) {
+	    	desiredTree := CreateDesiredStateGraph(tc.declaration())
+	    	currentStateTree := CreateCurrentStateGraph(&tc.existingServices)
+
+	    	assert.Equal(t, desiredTree.String(), currentStateTree.String())
+	    })
+	}
+}

--- a/pkg/controller/resourcetree/tree_test.go
+++ b/pkg/controller/resourcetree/tree_test.go
@@ -1,0 +1,134 @@
+package resourcetree_test
+
+import (
+	"github.com/bmizerany/assert"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+	"testing"
+)
+
+func TestResourceNode_ApplyFunction(t *testing.T) {
+	testCases := []struct {
+	    name string
+	    expectedCalls int
+	    generateReceiverTree func() *resourcetree.ResourceNode
+	    generateTargetTree func() *resourcetree.ResourceNode
+	}{
+	    {
+	        name: "Applies on all nodes in a tree of 3",
+	        expectedCalls: 3,
+	        generateReceiverTree: func() *resourcetree.ResourceNode {
+				root := &resourcetree.ResourceNode{ 
+					Type: resourcetree.ResourceNodeTypeGroup,
+					Children: []*resourcetree.ResourceNode{},
+				}
+				
+				root.Children = append(root.Children, &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeVPC,
+					Children: []*resourcetree.ResourceNode{
+						{
+							Type: resourcetree.ResourceNodeTypeZone,
+							Children: []*resourcetree.ResourceNode{},
+						},
+					},
+				})
+				
+				return root
+			},
+			generateTargetTree: func() *resourcetree.ResourceNode {
+				root := &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeGroup,
+					Children: []*resourcetree.ResourceNode{},
+				}
+
+				root.Children = append(root.Children, &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeVPC,
+					Children: []*resourcetree.ResourceNode{
+						{
+							Type: resourcetree.ResourceNodeTypeZone,
+							Children: []*resourcetree.ResourceNode{},
+						},
+					},
+				})
+
+				return root
+			},
+		},
+		{
+			name: "Applies to all nodes in a tree of 2",
+			expectedCalls: 2,
+			generateReceiverTree: func() *resourcetree.ResourceNode {
+				root := &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeGroup,
+					Children: []*resourcetree.ResourceNode{},
+				}
+
+				root.Children = append(root.Children, &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeVPC,
+					Children: []*resourcetree.ResourceNode{},
+				})
+
+				return root
+			},
+			generateTargetTree: func() *resourcetree.ResourceNode {
+				root := &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeGroup,
+					Children: []*resourcetree.ResourceNode{},
+				}
+
+				root.Children = append(root.Children, &resourcetree.ResourceNode{
+					Type: resourcetree.ResourceNodeTypeVPC,
+					Children: []*resourcetree.ResourceNode{},
+				})
+
+				return root
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+	    tc := tc
+	    
+	    t.Run(tc.name, func(t *testing.T) {
+	    	desiredTree := tc.generateReceiverTree()
+	    	currentStateTree := tc.generateTargetTree()
+	    	
+	    	numberOfCalls := 0
+	    	desiredTree.ApplyFunction(func(receiver *resourcetree.ResourceNode, target *resourcetree.ResourceNode) {
+	    		numberOfCalls += 1
+			}, currentStateTree)
+
+	    	assert.Equal(t, tc.expectedCalls, numberOfCalls)
+	    })
+	}
+}
+
+func TestResourceNode_Equals(t *testing.T) {
+	testCases := []struct {
+	    name string
+	    nodeA *resourcetree.ResourceNode
+	    nodeB *resourcetree.ResourceNode
+	    
+	    expectEquality bool
+	}{
+	    {
+	        name: "Should be equal",
+	        nodeA: &resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeVPC },
+	        nodeB: &resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeVPC },
+	        expectEquality: true,
+	    },
+	    {
+	    	name: "Should not be equal",
+	    	nodeA: &resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeVPC },
+	    	nodeB: &resourcetree.ResourceNode{ Type: resourcetree.ResourceNodeTypeZone },
+	    	expectEquality: false,
+		},
+	}
+	
+	for _, tc := range testCases {
+	    tc := tc
+	    
+	    t.Run(tc.name, func(t *testing.T) {
+	    	assert.Equal(t, tc.expectEquality, tc.nodeA.Equals(tc.nodeB))
+	    })
+	}
+}

--- a/pkg/controller/synchronize.go
+++ b/pkg/controller/synchronize.go
@@ -59,11 +59,11 @@ func Synchronize(opts *SynchronizeOpts) error {
 
 	currentStateTree := CreateCurrentStateGraph(currentStateGraphOpts)
 
-	diffGraph := *opts.DesiredTree
+	diffTree := *opts.DesiredTree
 
-	diffGraph.ApplyFunction(applyCurrentState, currentStateTree)
+	diffTree.ApplyFunction(applyCurrentState, currentStateTree)
 
-	return handleNode(opts.ReconsiliationManager, &diffGraph)
+	return handleNode(opts.ReconsiliationManager, &diffTree)
 }
 
 // handleNode knows how to run Reconsile() on every node of a ResourceNode tree

--- a/pkg/controller/synchronize.go
+++ b/pkg/controller/synchronize.go
@@ -1,0 +1,93 @@
+package controller
+
+import (
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/controller/reconsiler"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+	"github.com/spf13/afero"
+)
+
+type SynchronizeOpts struct {
+	DesiredTree *resourcetree.ResourceNode
+	
+	ReconsiliationManager *reconsiler.ReconsilerManager
+	
+	Fs *afero.Afero
+	OutputDir string
+
+	GithubGetter reconsiler.GithubGetter
+	GithubSetter reconsiler.GithubSetter
+
+	CIDRGetter StringFetcher
+	PrimaryHostedZoneGetter HostedZoneFetcher
+}
+
+// Synchronize knows how to discover differences between desired and actual state and rectify them
+func Synchronize(opts *SynchronizeOpts) error {
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeCluster, CreateClusterStateRefresher(
+		opts.Fs,
+		opts.OutputDir,
+		opts.CIDRGetter,
+	))
+	
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeALBIngress, CreateALBIngressControllerRefresher(
+		opts.Fs,
+		opts.OutputDir,
+	))
+
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeExternalDNS, CreateExternalDNSStateRefresher(
+		opts.PrimaryHostedZoneGetter,
+	))
+	
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeIdentityManager, CreateIdentityManagerRefresher(
+		opts.PrimaryHostedZoneGetter,
+	))
+
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeGithub, CreateGithubStateRefresher(
+		opts.GithubGetter,
+		opts.GithubSetter,
+	))
+	
+	opts.DesiredTree.SetStateRefresher(resourcetree.ResourceNodeTypeArgoCD, CreateArgocdStateRefresher(
+		opts.PrimaryHostedZoneGetter,
+	))
+
+	currentStateGraphOpts, err := NewCreateCurrentStateGraphOpts(opts.Fs, opts.OutputDir, opts.GithubGetter)
+	if err != nil {
+	    return fmt.Errorf("unable to get existing services: %w", err)
+	}
+
+	currentStateTree := CreateCurrentStateGraph(currentStateGraphOpts)
+
+	diffGraph := *opts.DesiredTree
+
+	diffGraph.ApplyFunction(applyCurrentState, currentStateTree)
+
+	return handleNode(opts.ReconsiliationManager, &diffGraph)
+}
+
+// handleNode knows how to run Reconsile() on every node of a ResourceNode tree
+func handleNode(reconsilerManager *reconsiler.ReconsilerManager, currentNode *resourcetree.ResourceNode) error {
+	_, err := reconsilerManager.Reconsile(currentNode)
+	if err != nil {
+	    return fmt.Errorf("error reconsiling node: %w", err)
+	}
+
+	for _, node := range currentNode.Children {
+		err = handleNode(reconsilerManager, node)
+		if err != nil {
+		    return fmt.Errorf("error handling node: %w", err)
+		}
+	}
+	
+	return nil
+}
+
+// applyCurrentState knows how to apply the current state on a desired state ResourceNode tree to produce a diff that
+// knows which resources to create, and which resources is already existing
+func applyCurrentState(receiver *resourcetree.ResourceNode, target *resourcetree.ResourceNode) {
+	if receiver.State == target.State {
+		receiver.State = resourcetree.ResourceNodeStateNoop
+	}
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR implements the actually API we will use in okctl outside of the pkg/controller (`synchronize.go`) and the actual usage. It also includes the scaffold command that produces a cluster declaration template.