### PR TITLE
Km100 add delete hosted zone flag

### DIFF
--- a/cmd/okctl/delete.go
+++ b/cmd/okctl/delete.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/oslokommune/okctl/pkg/client"
 	"regexp"
+
+	"github.com/oslokommune/okctl/pkg/client"
 
 	"github.com/oslokommune/okctl/pkg/api/core/cleanup"
 
@@ -17,7 +18,7 @@ import (
 )
 
 const (
-	deleteClusterArgs = 1
+	deleteClusterArgs    = 1
 	deleteHostedZoneFlag = "i-know-what-i-am-doing-delete-hosted-zone-and-records"
 )
 
@@ -30,7 +31,7 @@ func buildDeleteCommand(o *okctl.Okctl) *cobra.Command {
 	deleteClusterCommand := buildDeleteClusterCommand(o)
 	cmd.AddCommand(deleteClusterCommand)
 	cmd.AddCommand(buildDeleteTestClusterCommand(o))
-	deleteClusterCommand.Flags().String(deleteHostedZoneFlag,"false", "Delete hosted zone")
+	deleteClusterCommand.Flags().String(deleteHostedZoneFlag, "false", "Delete hosted zone")
 
 	return cmd
 }
@@ -135,7 +136,7 @@ including VPC, this is a highly destructive operation.`,
 				return formatErr(err)
 			}
 
-			if (delzones == "true") {
+			if delzones == "true" {
 				err = services.Domain.DeletePrimaryHostedZone(o.Ctx, o.CloudProvider, client.DeletePrimaryHostedZoneOpts{
 					ID: id,
 				})

--- a/docs/release_notes/0.0.26.md
+++ b/docs/release_notes/0.0.26.md
@@ -1,7 +1,10 @@
 # Release 0.0.26
 
 ## Features
+Give user optional flag to delete hosted zone on cluster deletion
 
 ## Bugfixes
+Don't crash deletion if hosted zone is missing from store
+Don't try and delete default security group when deleting VPC
 
 ## Other

--- a/docs/release_notes/0.0.27.md
+++ b/docs/release_notes/0.0.27.md
@@ -1,0 +1,8 @@
+# Release 0.0.27
+
+## Features
+
+## Bugfixes
+
+## Other
+

--- a/pkg/api/core/cleanup/service_cleanup.go
+++ b/pkg/api/core/cleanup/service_cleanup.go
@@ -59,9 +59,9 @@ func DeleteDanglingSecurityGroups(provider v1alpha1.CloudProvider, vpcID string)
 			_, err = provider.EC2().DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
 				GroupId: group.GroupId,
 			})
-		}
-		if err != nil {
-			return err
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/api/core/cleanup/service_cleanup.go
+++ b/pkg/api/core/cleanup/service_cleanup.go
@@ -55,9 +55,11 @@ func DeleteDanglingSecurityGroups(provider v1alpha1.CloudProvider, vpcID string)
 	}
 
 	for _, group := range groups.SecurityGroups {
-		_, err = provider.EC2().DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
-			GroupId: group.GroupId,
-		})
+		if *group.GroupName != "default" {
+			_, err = provider.EC2().DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+				GroupId: group.GroupId,
+			})
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/client/core/service_identitymanager.go
+++ b/pkg/client/core/service_identitymanager.go
@@ -35,6 +35,10 @@ func (s *identityManagerService) DeleteIdentityPool(ctx context.Context, provide
 
 	pool := s.state.GetIdentityPool()
 
+	if pool.UserPoolID == "" {
+		return nil
+	}
+
 	c := cognito.New(provider)
 
 	err = c.DeleteAuthDomain(pool.UserPoolID, pool.AuthDomain)


### PR DESCRIPTION
## Description
Enable a user to delete hosted zone on delete cluster

## Motivation and Context
Automatically deleting hosted zones are scary, by providing a flag that is hard to misunderstand, we enable powerusers and testers to delete hosted zone on cluster delete.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
