### PR TITLE
Unify userdoc with the same bash code layout for example commands

### DIFF
--- a/userdocs/src/components/cloud.md
+++ b/userdocs/src/components/cloud.md
@@ -3,7 +3,7 @@
 ## Cloud components
 
 Cloud providers offer a vast array of functionality for:
- 
+
  - Networking
  - Computation
  - DNS
@@ -11,14 +11,14 @@ Cloud providers offer a vast array of functionality for:
  - Databases
  - Block storage
  - Artificial intelligence
- 
+
  In `okctl` we use a subset of this functionality to provide a platform for running production workloads:
 
 - [Amazon Web Services](#amazon-web-services-aws) as the cloud provider
 - [Virtual Private Cloud](#virtual-private-cloud-vpc) for network isolation
 - [Elastic Kubernetes Service](#elastic-kubernetes-service-eks) for deploying and running applications
 - [Route53](#aws-route53-route53) for DNS
-- [Certificate Manager](#aws-certificate-manager-acm) for issuing SSL/TLS certificates for secure communication 
+- [Certificate Manager](#aws-certificate-manager-acm) for issuing SSL/TLS certificates for secure communication
 - [Systems Manager Parameter Store](#aws-systems-manager-amazon-ssm-parameter-store) for storing secrets
 
 ### Amazon Web Services (AWS)
@@ -41,7 +41,7 @@ K8s is an open-source system for automating deployment, scaling, and management 
 [AWS Route53](https://aws.amazon.com/route53/) (Route53) is a highly available and scalable [Domain Name System](https://en.wikipedia.org/wiki/Domain_Name_System) (DNS) web service. It is designed to give developers and businesses an extremely reliable and cost effective way to route end users to Internet applications by translating names like www.example.com into the numeric IP addresses like 192.0.2.1 that computers use to connect to each other.
 
 ```bash
-$ dig test.oslo.systems NS +short
+dig test.oslo.systems NS +short
 
 ns-327.awsdns-40.com.
 ns-612.awsdns-12.net.
@@ -54,7 +54,7 @@ ns-1322.awsdns-37.org.
 [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) (ACM) lets you easily provision, manage, and deploy public and private Secure Sockets Layer/Transport Layer Security (SSL/TLS) certificates for use with AWS services, and your internal connected resources. SSL/TLS certificates secure network communication and establish the identity of websites over the Internet as well as resources on private networks.
 
 ```bash
-$ curl -vvI https://argocd.veiviser.oslo.systems
+curl -vvI https://argocd.veiviser.oslo.systems
 
 <snip>
 * Server certificate:

--- a/userdocs/src/components/kubernetes.md
+++ b/userdocs/src/components/kubernetes.md
@@ -19,7 +19,7 @@ We have installed external secrets and configured it to use [SSM Parameter store
 Create an SSM parameter:
 
 ```bash
-$ aws ssm put-parameter --name "/postgres/adminpass" --value "P@sSwW)rd" --type "SecureString"
+aws ssm put-parameter --name "/postgres/adminpass" --value "P@sSwW)rd" --type "SecureString"
 ```
 
 Kubernetes External Secrets adds a [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRD). We use this CRD to make use of the correct backend; SSM (systemManager) in this case and the path to the SSM secret.
@@ -57,7 +57,7 @@ We have configured AWS ALB Ingress Controller to work with a cluster, which mean
 #### Example
 
 The following ingress resource will result in the creation of a public ALB. In this example, we only use a subset of the [available annotations](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/), but they demonstrate how you can:
- 
+
  1. Configure HTTP to HTTPS redirect
     ```
         alb.ingress.kubernetes.io/actions.ssl-redirect: \

--- a/userdocs/src/index.md
+++ b/userdocs/src/index.md
@@ -44,8 +44,8 @@ Now, run:
 ```bash
 
 # Clone the repository you just made
-$ git clone git@github.com:oslokommune/<the new repository>.git
-$ cd <the new repository>
+git clone git@github.com:oslokommune/<the new repository>.git
+cd <the new repository>
 ```
 
 ### 2. Create a cluster
@@ -72,7 +72,7 @@ after logging in to [AWS](https://login.oslo.kommune.no/auth/realms/AD/protocol/
 # <AWS account ID>      is the account ID described in the above
 #
 # Example:
-$ okctl create cluster prod 123456789012
+okctl create cluster prod 123456789012
 ```
 
 Follow the instructions.
@@ -80,8 +80,8 @@ Follow the instructions.
 When done, verify that you have a working cluster by running
 
 ```bash
-$ okctl venv
-$ kubectl get service
+okctl venv
+kubectl get service
 
 ```
 
@@ -96,24 +96,24 @@ kubernetes   ClusterIP   10.100.0.1   <none>        443/TCP   1h
 
 ```bash
 # Get help for any command
-$ okctl --help
-$ okctl create cluster --help
+okctl --help
+okctl create cluster --help
 
 # Show credentials for cluster
-$ okctl show credentials prod
+okctl show credentials prod
 
 # Run a sub shell with environment variables from the above command and a custom command prompt (PS1)
-$ okctl venv
+okctl venv
 
 # Delete the cluster
-$ okctl delete cluster prod
+okctl delete cluster prod
 ```
 
 ## Compare and contrast
 
 With `okctl` we are attempting to solve the production environment setup problem. What we include within the definition of a production environment, we can see below.
 
-| Functionality | okctl | [eksctl](https://eksctl.io) | [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) | [serverless.tf](https://serverless.tf) | 
+| Functionality | okctl | [eksctl](https://eksctl.io) | [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) | [serverless.tf](https://serverless.tf) |
 |---|---|---|---|---|
 |Provide authentication and authorisation|✓||?||
 |Define a continuous integration pipeline|?||||
@@ -156,14 +156,19 @@ If you are unable to complete device authentication against github, you need to 
 This is because github token is stored in a encrypted keyring on your device.
 
 Linux
-`apt-get install pass`
+```bash
+apt-get install pass
+```
 
 Mac
-`brew install pass`
+```bash
+brew install pass
+```
 
 **On `okctl delete cluster`, some resources are not deleted (automatic deletion is coming in a later version)**
 
 Workaround: manually deleted the following resources:
+
 * SMM Parameter
 * ACM certificate (in your cluster-region, but also one in us-east-1 that was used in cloud formation and cognito)
 * Deploy key in IAC repo
@@ -175,13 +180,16 @@ Workaround: manually deleted the following resources:
 This is due to an authorization bug.
 
 Workaround:
+```bash
 kubectl edit configmap argocd-rbac-cm --namespace argocd
+```
 
 Add a new line after `g, admins, role:admin`, so it becomes something like this:
+```
 policy.csv: |
   g, admins, role:admin
   g, my.email@mail.com, role:admin
-
+```
 **Reuse of hosted zone might fail if old NS servers for the same domain are cached in DNS**
 
 Workaround: wait 2 days for it to expire (default hosted zone NS record TTL)

--- a/userdocs/src/usage/adduser.md
+++ b/userdocs/src/usage/adduser.md
@@ -1,8 +1,8 @@
 
-Add users into identitypool that will be used to loging to ArgoCD and other services 
+Add users into identitypool that will be used to loging to ArgoCD and other services
 
 ## Command
 
 ```bash
-$ okctl adduser {env} {email}
+okctl adduser {env} {email}
 ```

--- a/userdocs/src/usage/applicationyaml.md
+++ b/userdocs/src/usage/applicationyaml.md
@@ -17,13 +17,17 @@ declaration to resources understood by Kubernetes and ArgoCD.
 
 To create an application.yaml template, run the following command:
 
-`okctl create application ENV`
+```bash
+okctl create application ENV
+```
 
 This creates an application declaration in ./application.yaml.
 
 After configuring the application.yaml file, you turn it into Kubernetes and ArgoCD resources by running:
 
-`okctl apply application prod -f application.yaml`
+```bash
+okctl apply application prod -f application.yaml
+```
 
 This command will create the following files in the ./infrastructure folder:
 
@@ -33,10 +37,11 @@ This command will create the following files in the ./infrastructure folder:
 2. ./infrastructure/<env>/certificates/<application.url>
     * The certificate declaration for the URL specified in the application.yaml.
 
-Both files in 1. is needed by ArgoCD to deploy your application or service. Read more about ArgoCD 
+Both files in 1. is needed by ArgoCD to deploy your application or service. Read more about ArgoCD
 [here](https://okctl.io/deployment/argocd/).
 
 After that, the following manual steps remain:
+
 1. (optional) Create the namespace you specified in the application declaration(application.yaml), i.e.:
 `kubectl create namespace <name of namespace>`. This is only needed if the namespace you specified in the application
 declaration is not pre-existing.

--- a/userdocs/src/usage/testcluster.md
+++ b/userdocs/src/usage/testcluster.md
@@ -5,7 +5,7 @@ Sometimes it can be useful to setup a minimal cluster for testing or experimenta
 To create a `testcluster` run the following command and follow the guide:
 
 ```bash
-$ okctl create testcluster exp 123456789012
+okctl create testcluster exp 123456789012
 ```
 
 ## Details
@@ -92,7 +92,7 @@ spec:
 Then you can fetch your credentials using `okctl`:
 
 ```bash
-$ okctl show credentials {env}
+okctl show credentials {env}
 ```
 
 This command will output a number of environment variables you can export. You need to use the ones for `AWS` and `KUBECONFIG` and export them in a shell.
@@ -100,7 +100,7 @@ This command will output a number of environment variables you can export. You n
 Then you can apply the manifest you saved earlier to the cluster:
 
 ```bash
-$ kubectl apply -f experiments/2048/2048-game.yml
+kubectl apply -f experiments/2048/2048-game.yml
 ```
 
 Give `AWS ALB Ingress Controller` and `ExternalDNS` some time to work their magic, and eventually you should be able to access and play your game at the URL: `2048-game.{hosted_zone}.oslo.systems`.
@@ -108,11 +108,11 @@ Give `AWS ALB Ingress Controller` and `ExternalDNS` some time to work their magi
 When you are done, simply delete the manifest:
 
 ```bash
-$ kubectl delete -f experiments/2048/2048-game.yml
+kubectl delete -f experiments/2048/2048-game.yml
 ```
 
 And delete the cluster, if you feel done:
 
 ```bash
-$ okctl delete testcluster {env}
+okctl delete testcluster {env}
 ```

--- a/userdocs/src/usage/venv.md
+++ b/userdocs/src/usage/venv.md
@@ -41,8 +41,8 @@ Any occurence `%env` in `OKCTL_PS1` will be replaced by the okctl environment. T
 environment in your custom OKCTL_PS1. A use case for this can be when combining with the `venv_ps1` built-in:
 
 ```bash
-$ export OKCTL_PS1="\w \$(venv_ps1 %env) $"
-$ okctl venv myenv
+export OKCTL_PS1="\w \$(venv_ps1 %env) $"
+okctl venv myenv
 ```
 
 The command prompt will then be like this


### PR DESCRIPTION
## Description
Removes all `$` instances to avoid copying this into terminal when following step-by-step. Ensure that we use the same way of presenting bash code throught the userdocumentation

Correct layout of lists when generating userdoc

## Motivation and Context
When copying with the supplied `copy to clipboard` or selecting a entire line of code the `$` is included, and then have to be deleted before executing the command

## How Has This Been Tested?
`mkdocs serve`


