### PR TITLE
Fix ArgoCD not showing applications

### DIFF
--- a/docs/release_notes/0.0.27.md
+++ b/docs/release_notes/0.0.27.md
@@ -11,7 +11,10 @@ By using the following commands, one can now create a cluster using a declaratio
 `okctl apply cluster` applies a cluster declaration that defines what parts of the cluster should exist
 
 For now, only resources that don't require a certificate will be created. 
+
 ## Bugfixes
+
+Fixed: ArgoCD didn't show the user's applications, which should appear after creating ArgoCD application CRDs.
 
 ## Other
 

--- a/pkg/helm/charts/argocd/argocd.go
+++ b/pkg/helm/charts/argocd/argocd.go
@@ -108,7 +108,7 @@ func NewDefaultValues(opts ValuesOpts) *Values {
 			Name:    "dex-server",
 			Image: image{
 				Repository: "quay.io/dexidp/dex",
-				Tag:        "v2.22.0",
+				Tag:        "v2.26.0",
 				PullPolicy: "IfNotPresent",
 			},
 			ServiceAccount: serviceAccount{
@@ -350,6 +350,11 @@ const repositoriesConfig = `- url: %s
 const policyCSV = `g, %s, role:admin
 `
 
+// Configuration documentation: https://dexidp.io/docs/connectors/oidc/
+// As stated in the documentation, the default oidc connector (used here) doesn't allow for groups claim, as they can
+// be stale, and thus, insecure. However, we need the groups claim to be able to give the user permission to see
+// his/her application in ArgoCD. Removing a user takes will take hours to take effect, but we consider this secure
+// enough.
 const dexConfig = `connectors:
 - type: oidc
   id: cognito
@@ -363,6 +368,7 @@ const dexConfig = `connectors:
     - openid
     - email
     - profile
+    insecureEnableGroups: true
     claimMapping:
       groups: "cognito:groups"
       name: "cognito:username"

--- a/pkg/helm/charts/argocd/argocd.go
+++ b/pkg/helm/charts/argocd/argocd.go
@@ -269,7 +269,7 @@ func NewDefaultValues(opts ValuesOpts) *Values {
 			},
 			RBACConfig: rbacConfig{
 				PolicyCSV: fmt.Sprintf(policyCSV, "admins"),
-				Scopes:    `[email, group]`,
+				Scopes:    `[email, groups]`,
 			},
 			ClusterAdminAccess: clusterAdminAccess{
 				Enabled: true,

--- a/pkg/helm/charts/argocd/testdata/argocd-values.yaml.golden
+++ b/pkg/helm/charts/argocd/testdata/argocd-values.yaml.golden
@@ -197,7 +197,7 @@ server:
     rbacConfig:
         policy.csv: |
             g, admins, role:admin
-        scopes: '[email, group]'
+        scopes: '[email, groups]'
     clusterAdminAccess:
         enabled: true
 repoServer:

--- a/pkg/helm/charts/argocd/testdata/argocd-values.yaml.golden
+++ b/pkg/helm/charts/argocd/testdata/argocd-values.yaml.golden
@@ -49,7 +49,7 @@ dex:
     name: dex-server
     image:
         repository: quay.io/dexidp/dex
-        tag: v2.22.0
+        tag: v2.26.0
         imagePullPolicy: IfNotPresent
     serviceAccount:
         create: true
@@ -183,6 +183,7 @@ server:
                 - openid
                 - email
                 - profile
+                insecureEnableGroups: true
                 claimMapping:
                   groups: "cognito:groups"
                   name: "cognito:username"


### PR DESCRIPTION
ArgoCD doesn't show the user's applications, which should appear after creating ArgoCD application CRDs.

## Description
* RBAC config contained invalid configuration
* Dex config didn't work. The groups claim was being ignored because of a missing setting.

For more details, see long explanation in PR changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Manually. Created a cluster and verifyed that new applications appear in argocd.

Also patched an existing cluster works with:

```bash
kubectl patch --namespace=argocd deployment argocd-dex-server -p '{"spec":{"template":{"spec":{"containers":[{"name":"dex-server","image":"quay.io/dexidp/dex:v2.26.0"}]}}}}'
kubectl patch --namespace=argocd configmap argocd-rbac-cm -p '{"data":{"scopes": "[email, groups]" }}}'
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
