### PR TITLE
KM72-Remove base folders in seperate step, that will not fail the run

### DIFF
--- a/pkg/client/core/store/filesystem/albingresscontroller.go
+++ b/pkg/client/core/store/filesystem/albingresscontroller.go
@@ -30,11 +30,14 @@ func (s *albIngressControllerStore) RemoveALBIngressController(_ api.ID) (*store
 		Remove(s.chart.OutputFile).
 		Remove(s.chart.ReleaseFile).
 		Remove(s.chart.ChartFile).
-		Remove("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
+
+	_, _ = store.NewFileSystem(s.policy.BaseDir, s.fs).
+		Remove("").
+		Do()
 
 	return report, nil
 }

--- a/pkg/client/core/store/filesystem/cluster.go
+++ b/pkg/client/core/store/filesystem/cluster.go
@@ -32,11 +32,14 @@ func (s *clusterStore) SaveCluster(c *api.Cluster) (*store.Report, error) {
 func (s *clusterStore) DeleteCluster(_ api.ID) (*store.Report, error) {
 	report, err := store.NewFileSystem(s.paths.BaseDir, s.fs).
 		Remove(s.paths.ConfigFile).
-		Remove("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
+
+	_, _ = store.NewFileSystem(s.paths.BaseDir, s.fs).
+		Remove("").
+		Do()
 
 	_ = s.fs.RemoveAll(path.Join(s.paths.BaseDir, "../argocd"))
 	_ = s.fs.RemoveAll(path.Join(s.paths.BaseDir, "../helm"))

--- a/pkg/client/core/store/filesystem/externalsecrets.go
+++ b/pkg/client/core/store/filesystem/externalsecrets.go
@@ -30,11 +30,14 @@ func (s *externalSecretsStore) RemoveExternalSecrets(_ api.ID) (*store.Report, e
 		Remove(s.chart.OutputFile).
 		Remove(s.chart.ReleaseFile).
 		Remove(s.chart.ChartFile).
-		Remove("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
+
+	_, _ = store.NewFileSystem(s.chart.BaseDir, s.fs).
+		Remove("").
+		Do()
 
 	return report, nil
 }

--- a/pkg/client/core/store/filesystem/identitymanager.go
+++ b/pkg/client/core/store/filesystem/identitymanager.go
@@ -66,21 +66,29 @@ func (s *identityManagerStore) RemoveIdentityPool(id api.ID) (*store.Report, err
 	report, err := store.NewFileSystem(s.aliasPaths.BaseDir, s.fs).
 		Remove(authDomain + s.aliasPaths.CloudFormationFile).
 		Remove(authDomain + s.aliasPaths.OutputFile).
-		Remove("").
 		AlterStore(store.SetBaseDir(s.certPaths.BaseDir)).
 		Remove(authDomain + s.certPaths.CloudFormationFile).
 		Remove(authDomain + s.certPaths.OutputFile).
-		Remove("").
 		AlterStore(store.SetBaseDir(s.poolPaths.BaseDir)).
 		Remove(s.poolPaths.CloudFormationFile).
 		Remove(s.poolPaths.OutputFile).
-		Remove("").
-		AlterStore(store.SetBaseDir(s.poolPaths.BaseDir)).
-		Remove("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
+
+	_, _ = store.NewFileSystem(s.aliasPaths.BaseDir, s.fs).
+		Remove("").
+		Do()
+	_, _ = store.NewFileSystem(s.certPaths.BaseDir, s.fs).
+		Remove("").
+		Do()
+	_, _ = store.NewFileSystem(s.certPaths.BaseDir, s.fs).
+		Remove("").
+		Do()
+	_, _ = store.NewFileSystem(s.poolPaths.BaseDir, s.fs).
+		Remove("").
+		Do()
 
 	return report, err
 }

--- a/pkg/client/core/store/filesystem/vpc.go
+++ b/pkg/client/core/store/filesystem/vpc.go
@@ -110,11 +110,14 @@ func (s *vpcStore) DeleteVpc(_ api.ID) (*store.Report, error) {
 	report, err := store.NewFileSystem(s.paths.BaseDir, s.fs).
 		Remove(s.paths.OutputFile).
 		Remove(s.paths.CloudFormationFile).
-		Remove("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
+
+	_, _ = store.NewFileSystem(s.paths.BaseDir, s.fs).
+		Remove("").
+		Do()
 
 	return report, nil
 }


### PR DESCRIPTION
## Description
If some directories were not empty the delete proscess would fail

## Motivation and Context
We want delete to go on, even if a folder we figured would be empty still has files.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
