### PR TITLE
Km116 unsafe store operations

### DIFF
--- a/docs/release_notes/0.0.32.md
+++ b/docs/release_notes/0.0.32.md
@@ -5,4 +5,5 @@
 ## Bugfixes
 
 ## Other
+Made some store operations safer to run, introduce RemoveDir instead of ignoring FS errors on Remove
 

--- a/pkg/client/core/store/filesystem/albingresscontroller.go
+++ b/pkg/client/core/store/filesystem/albingresscontroller.go
@@ -30,14 +30,11 @@ func (s *albIngressControllerStore) RemoveALBIngressController(_ api.ID) (*store
 		Remove(s.chart.OutputFile).
 		Remove(s.chart.ReleaseFile).
 		Remove(s.chart.ChartFile).
+		RemoveDir("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
-
-	_, _ = store.NewFileSystem(s.policy.BaseDir, s.fs).
-		Remove("").
-		Do()
 
 	return report, nil
 }

--- a/pkg/client/core/store/filesystem/cluster.go
+++ b/pkg/client/core/store/filesystem/cluster.go
@@ -32,17 +32,21 @@ func (s *clusterStore) SaveCluster(c *api.Cluster) (*store.Report, error) {
 func (s *clusterStore) DeleteCluster(_ api.ID) (*store.Report, error) {
 	report, err := store.NewFileSystem(s.paths.BaseDir, s.fs).
 		Remove(s.paths.ConfigFile).
+		RemoveDir("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
 
-	_, _ = store.NewFileSystem(s.paths.BaseDir, s.fs).
-		Remove("").
-		Do()
+	err = s.fs.RemoveAll(path.Join(s.paths.BaseDir, "../argocd"))
+	if err != nil {
+		return nil, err
+	}
 
-	_ = s.fs.RemoveAll(path.Join(s.paths.BaseDir, "../argocd"))
-	_ = s.fs.RemoveAll(path.Join(s.paths.BaseDir, "../helm"))
+	err = s.fs.RemoveAll(path.Join(s.paths.BaseDir, "../helm"))
+	if err != nil {
+		return nil, err
+	}
 
 	return report, nil
 }

--- a/pkg/client/core/store/filesystem/externalsecrets.go
+++ b/pkg/client/core/store/filesystem/externalsecrets.go
@@ -30,14 +30,11 @@ func (s *externalSecretsStore) RemoveExternalSecrets(_ api.ID) (*store.Report, e
 		Remove(s.chart.OutputFile).
 		Remove(s.chart.ReleaseFile).
 		Remove(s.chart.ChartFile).
+		RemoveDir("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
-
-	_, _ = store.NewFileSystem(s.chart.BaseDir, s.fs).
-		Remove("").
-		Do()
 
 	return report, nil
 }

--- a/pkg/client/core/store/filesystem/identitymanager.go
+++ b/pkg/client/core/store/filesystem/identitymanager.go
@@ -66,29 +66,21 @@ func (s *identityManagerStore) RemoveIdentityPool(id api.ID) (*store.Report, err
 	report, err := store.NewFileSystem(s.aliasPaths.BaseDir, s.fs).
 		Remove(authDomain + s.aliasPaths.CloudFormationFile).
 		Remove(authDomain + s.aliasPaths.OutputFile).
+		RemoveDir("").
 		AlterStore(store.SetBaseDir(s.certPaths.BaseDir)).
 		Remove(authDomain + s.certPaths.CloudFormationFile).
 		Remove(authDomain + s.certPaths.OutputFile).
+		RemoveDir("").
 		AlterStore(store.SetBaseDir(s.poolPaths.BaseDir)).
 		Remove(s.poolPaths.CloudFormationFile).
 		Remove(s.poolPaths.OutputFile).
+		RemoveDir("").
+		AlterStore(store.SetBaseDir(s.poolPaths.BaseDir)).
+		RemoveDir("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
-
-	_, _ = store.NewFileSystem(s.aliasPaths.BaseDir, s.fs).
-		Remove("").
-		Do()
-	_, _ = store.NewFileSystem(s.certPaths.BaseDir, s.fs).
-		Remove("").
-		Do()
-	_, _ = store.NewFileSystem(s.certPaths.BaseDir, s.fs).
-		Remove("").
-		Do()
-	_, _ = store.NewFileSystem(s.poolPaths.BaseDir, s.fs).
-		Remove("").
-		Do()
 
 	return report, err
 }

--- a/pkg/client/core/store/filesystem/vpc.go
+++ b/pkg/client/core/store/filesystem/vpc.go
@@ -110,14 +110,11 @@ func (s *vpcStore) DeleteVpc(_ api.ID) (*store.Report, error) {
 	report, err := store.NewFileSystem(s.paths.BaseDir, s.fs).
 		Remove(s.paths.OutputFile).
 		Remove(s.paths.CloudFormationFile).
+		RemoveDir("").
 		Do()
 	if err != nil {
 		return nil, err
 	}
-
-	_, _ = store.NewFileSystem(s.paths.BaseDir, s.fs).
-		Remove("").
-		Do()
 
 	return report, nil
 }

--- a/pkg/client/store/store.go
+++ b/pkg/client/store/store.go
@@ -119,6 +119,11 @@ type Operations interface {
 	// This method is chainable, so multiple actions may be performed.
 	Remove(name string, options ...OperationOption) Operations
 
+	// RemoveDir will delete a directory under the given name, how this data is
+	// removed is given by the underlying implementation
+	// This method is chainable, so multiple actions may be performed.
+	RemoveDir(name string, options ...OperationOption) Operations
+
 	// GetStruct will read the stored data and process it using the
 	// provided post processor, the result will be stored in the report
 	// and can be accessed afterwards.

--- a/pkg/client/store/store_test.go
+++ b/pkg/client/store/store_test.go
@@ -389,3 +389,43 @@ func TestWithFilePermissionsMode(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveDir(t *testing.T) {
+	const perm = 0o744
+
+	fs := &afero.Afero{Fs: afero.NewMemMapFs()}
+	_ = fs.Mkdir("testing/sub1", perm)
+
+	fileSystem := store.NewFileSystem("testing", fs)
+
+	isEmpty, _ := fs.IsEmpty("testing/sub1")
+	isDirectory, _ := fs.IsDir("testing/sub1")
+
+	assert.True(t, isEmpty)
+	assert.True(t, isDirectory)
+
+	_, _ = fileSystem.RemoveDir("sub1").Do()
+
+	isDirectory, _ = fs.IsDir("testing/sub1")
+
+	assert.False(t, isDirectory)
+}
+
+func TestRemoveDirWithContent(t *testing.T) {
+	const perm = 0o744
+
+	fs := &afero.Afero{Fs: afero.NewMemMapFs()}
+
+	_ = fs.Mkdir("testing/sub1", perm)
+	_ = fs.Mkdir("testing/sub1", perm)
+	_ = fs.WriteFile("testing/sub1/hellofile", []byte("hello"), perm)
+
+	fileSystem := store.NewFileSystem("testing", fs)
+	_, _ = fileSystem.RemoveDir("sub1").Do()
+
+	isDirectory, _ := fs.IsDir("testing/sub1")
+	isEmpty, _ := fs.IsEmpty("testing/sub1")
+
+	assert.True(t, isDirectory)
+	assert.False(t, isEmpty)
+}


### PR DESCRIPTION
## Description
Introduce safer RemoveDir function. Previously we would just remove directories in one step, and ignore errors (if for example not empty), this check is now done in RemoveDir, which will not run if target is a file or a non empty directory.

## Motivation and Context
Current implementation was too optimistic, not handling all FS errors. Thanks @yngvark  for pointing this out :) 

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
