### PR TITLE
fix(goreleaser): Rename github to tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,7 @@ checksum:
 
 brews:
   -
-    github:
+    tap:
       owner: oslokommune
       name: homebrew-tap
 


### PR DESCRIPTION
Field `github` in `.gorelease.yml` is deprecated, renamed to `tap`.

Described here: https://goreleaser.com/deprecations/
https://github.com/goreleaser/goreleaser/commit/11e3afe1c8d1009e085b9af2455f51e75c7c76bc

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

In Makefile, I edited the target release-local to use `.gorelease.yml` instead of `gorelease-local.yml` and observed that the change worked.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
