### PR TITLE
OKCTL_DEBUG now also works for keyring integration

### DIFF
--- a/pkg/credentials/github/github_test.go
+++ b/pkg/credentials/github/github_test.go
@@ -145,7 +145,7 @@ func TestNewKeyringPersister(t *testing.T) {
 				Type:        github.CredentialsTypeDeviceFlow,
 			},
 			keyring: func() keyring.Keyringer {
-				k, err := keyring.New(keyring.NewInMemoryKeyring())
+				k, err := keyring.New(keyring.NewInMemoryKeyring(), false)
 				assert.NoError(t, err)
 
 				return k

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -32,7 +32,9 @@ type Keyring struct {
 var _ Keyringer = &Keyring{}
 
 // New creates a new keyring
-func New(keyring krPkg.Keyring) (*Keyring, error) {
+func New(keyring krPkg.Keyring, debug bool) (*Keyring, error) {
+	krPkg.Debug = debug
+
 	return &Keyring{
 		ring: keyring,
 	}, nil

--- a/pkg/keyring/keyring_test.go
+++ b/pkg/keyring/keyring_test.go
@@ -34,7 +34,7 @@ func TestStore(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			ring, err := keyring.New(keyring.NewInMemoryKeyring())
+			ring, err := keyring.New(keyring.NewInMemoryKeyring(), false)
 			assert.NoError(t, err)
 
 			err = ring.Store(tc.keytype, tc.secret)
@@ -60,7 +60,7 @@ func TestFetch(t *testing.T) {
 		{
 			name: "Fetched password should work",
 			ring: func() keyring.Keyringer {
-				r, err := keyring.New(keyring.NewInMemoryKeyring())
+				r, err := keyring.New(keyring.NewInMemoryKeyring(), false)
 				assert.NoError(t, err)
 
 				return r
@@ -72,7 +72,7 @@ func TestFetch(t *testing.T) {
 		{
 			name: "Fetching non exisiting secret should return error",
 			ring: func() keyring.Keyringer {
-				r, err := keyring.New(keyring.NewInMemoryKeyring())
+				r, err := keyring.New(keyring.NewInMemoryKeyring(), false)
 				assert.NoError(t, err)
 
 				return r

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -743,7 +743,7 @@ https://www.passwordstore.org/
 %w`, err)
 	}
 
-	k, err := keyring.New(defaultRing)
+	k, err := keyring.New(defaultRing, o.Debug)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If the keyring integration isn't working as expected adding `OKCTL_DEBUG=true` will now provide additional debugging information

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
