### PR TITLE
👌 Minor improvements to declarative cluster

### DIFF
--- a/cmd/okctl/applycluster.go
+++ b/cmd/okctl/applycluster.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/logrusorgru/aurora"
+
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/oslokommune/okctl/pkg/api"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
@@ -147,6 +149,15 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("error synchronizing declaration with state: %w", err)
 			}
+
+			fmt.Fprintln(o.Out, "\nYour cluster is up to date.")
+			fmt.Fprintln(o.Out,
+				fmt.Sprintf(
+					"\nTo access your cluster, run %s to activate the environment for your cluster",
+					aurora.Green(fmt.Sprintf("okctl venv %s", id.Environment)),
+				),
+			)
+			fmt.Fprintln(o.Out, fmt.Sprintf("Your cluster should then be available with %s", aurora.Green("kubectl")))
 
 			return nil
 		},

--- a/cmd/okctl/applycluster.go
+++ b/cmd/okctl/applycluster.go
@@ -115,6 +115,7 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 			reconciliationManager := reconciler.NewReconcilerManager(&resourcetree.CommonMetadata{
 				Ctx:       o.Ctx,
 				ClusterID: id,
+				Out:       o.Out,
 				Spin:      spin,
 			})
 

--- a/docs/release_notes/0.0.37.md
+++ b/docs/release_notes/0.0.37.md
@@ -3,6 +3,10 @@
 ## Features
 
 ## Bugfixes
+7e7f15b Fix erroneous remote branch existence check
 
 ## Other
+575ea78 Improve feedback from apply cluster on successful sync
+a697f1f Add information about the nameserver delegation process
+
 Refactor deletion of ssm parameters

--- a/pkg/client/core/api/git/nameserverdelegator_api.go
+++ b/pkg/client/core/api/git/nameserverdelegator_api.go
@@ -147,10 +147,10 @@ func (n *NameserverDelegator) hasExistingRequest(request *NameserverDelegationRe
 			break
 		}
 
-		parts := strings.Split(current.Name().String(), "/")
-		currentName := parts[len(parts)-1]
+		currentRef := current.Name().String()
+		desiredRef := fmt.Sprintf("refs/remotes/origin/%s", desiredName)
 
-		if currentName == desiredName {
+		if currentRef == desiredRef {
 			return true
 		}
 	}

--- a/pkg/controller/reconciler/nameserverdelegator_reconciler.go
+++ b/pkg/controller/reconciler/nameserverdelegator_reconciler.go
@@ -60,6 +60,8 @@ func (z *nameserverDelegationReconciler) Reconcile(node *resourcetree.ResourceNo
 			return &ReconcilationResult{Requeue: true}, fmt.Errorf("error handling nameservers: %w", err)
 		}
 
+		fmt.Fprint(z.commonMetadata.Out, delegationRequestMessage)
+
 		waitForNameserverDelegation(nsRecordValidationIntervalSeconds, resourceState.PrimaryHostedZoneFQDN)
 
 		err = z.domainService.SetHostedZoneDelegation(z.commonMetadata.Ctx, domain.EnsureNotFQDN(record.FQDN), true)
@@ -94,3 +96,10 @@ func waitForNameserverDelegation(interval time.Duration, fqdn string) {
 		time.Sleep(interval * time.Second)
 	}
 }
+
+const delegationRequestMessage = `
+A nameserver delegation request has been submitted. We'll process this request as soon as possible.
+Let us know in #kjøremiljø-support if it takes too long
+
+
+`

--- a/pkg/controller/resourcetree/tree.go
+++ b/pkg/controller/resourcetree/tree.go
@@ -86,6 +86,7 @@ const (
 type CommonMetadata struct {
 	Ctx       context.Context
 	ClusterID api.ID
+	Out       io.Writer
 	Spin      spinner.Spinner
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fixes bug in nameserver delegation idempotency
* Adds feedback upon successful cluster synchronization (when cluster is created)
* Adds feedback when waiting for a nameserver delegation request to be approved 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The bug resultet in okctl thinking there already was a request active. I set it to ensure the branch it creates must be available remotely.

Regarding the feedback for successful cluster sync; previously the user had no information on wether the operation was successful or not. 

Regarding the feedback for nameserver delegation request; the process now hints about the step that is manual in case we forget. Also helps the user to understand why the process takes some time. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
