### PR TITLE
🐛 Fix kubeconfig being stored and retrieved to and from different places

### DIFF
--- a/docs/release_notes/0.0.38.md
+++ b/docs/release_notes/0.0.38.md
@@ -3,5 +3,6 @@
 ## Features
 
 ## Bugfixes
+c400ae9 : Fix kubeconfig being stored and retrieved to and from different places
 
 ## Other

--- a/pkg/commands/venv.go
+++ b/pkg/commands/venv.go
@@ -65,7 +65,7 @@ func GetOkctlEnvironment(o *okctl.Okctl) (OkctlEnvironment, error) {
 		AWSAccountID:           cluster.AWSAccountID,
 		Environment:            cluster.Environment,
 		Repository:             meta.Name,
-		ClusterName:            cluster.Name,
+		ClusterName:            o.RepoStateWithEnv.GetClusterName(),
 		UserDataDir:            userDataDir,
 		Debug:                  o.Debug,
 		KubectlBinaryDir:       path.Dir(k.BinaryPath),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Due to "cluster name" being two different concepts, I had ensure `venv` and `show credentials` use the concept where "cluster name" means "name-environment" instead of just "name".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Due to `kubeconfig.yaml` and `aws-authenticator" being stored at one place and retrieved from a different place, one would get an error that they were missing. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
