### PR TITLE
🐛 Fix external-secrets not being able to retrieve secrets from AWS secrets manager

### DIFF
--- a/docs/release_notes/0.0.39.md
+++ b/docs/release_notes/0.0.39.md
@@ -3,5 +3,6 @@
 ## Features
 
 ## Bugfixes
+34fe9be: Fix ASM permissions for external secrets GH#243
 
 ## Other

--- a/pkg/cfn/testdata/esp-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/esp-cloudformation.yaml.golden
@@ -6,14 +6,16 @@ Outputs:
 Resources:
   ExternalSecretsPolicy:
     Properties:
-      Description: Service account policy for reading SSM parameters
+      Description: Service account policy for reading SSM parameters and ASM secrets
       ManagedPolicyName: okctl-repo-test-ExternalSecretsServiceAccountPolicy
       PolicyDocument:
         Statement:
         - Action:
+          - secretsmanager:GetSecretValue
           - ssm:GetParameter
           Effect: Allow
           Resource:
+          - Fn::Sub: arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*
           - Fn::Sub: arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
         Version: 2012-10-17
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a new permission to the relevant policy letting the external secrets service user retrieve data from AWS secrets manager

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #243 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added the policy change manually in AWS IAM and confirmed that it solved the issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
