### PR TITLE
[KM142] Cloud formation stack outputs should also be exported, add DBSubnetGroupName output

### DIFF
--- a/docs/release_notes/0.0.39.md
+++ b/docs/release_notes/0.0.39.md
@@ -1,6 +1,8 @@
-# Release 0.0.38
+# Release 0.0.39
 
 ## Features
+- Export all outputs, so they can be referenced by other cloud formation stacks
+- Add an output to the VPC stack for the DBSubnetGroupName
 
 ## Bugfixes
 34fe9be: Fix ASM permissions for external secrets GH#243

--- a/docs/release_notes/0.0.39.md
+++ b/docs/release_notes/0.0.39.md
@@ -1,5 +1,9 @@
 # Release 0.0.39
 
+Primary new feature is that we export all cloud formation outputs. Please be aware that this requires you remove any references to these exports before running delete with okctl:
+
+> After another stack imports an output value, you can't delete the stack that is exporting the output value or modify the exported output value. All of the imports must be removed before you can delete the exporting stack or modify the output value.
+
 ## Features
 - Export all outputs, so they can be referenced by other cloud formation stacks
 - Add an output to the VPC stack for the DBSubnetGroupName

--- a/pkg/cfn/components/certificate/testdata/certificate.golden
+++ b/pkg/cfn/components/certificate/testdata/certificate.golden
@@ -1,6 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   PublicCertificate:
+    Export:
+      Fn::Sub: ${AWS::StackName}-PublicCertificate
     Value:
       Ref: PublicCertificate
 Resources:

--- a/pkg/cfn/components/certificate/testdata/certificate.golden
+++ b/pkg/cfn/components/certificate/testdata/certificate.golden
@@ -2,7 +2,8 @@ AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   PublicCertificate:
     Export:
-      Fn::Sub: ${AWS::StackName}-PublicCertificate
+      Name:
+        Fn::Sub: ${AWS::StackName}-PublicCertificate
     Value:
       Ref: PublicCertificate
 Resources:

--- a/pkg/cfn/components/composer.go
+++ b/pkg/cfn/components/composer.go
@@ -128,6 +128,7 @@ func (v *VPCComposer) Compose() (*cfn.Composition, error) {
 	dsg := dbsubnetgroup.New(dbSubnets)
 
 	composition.Resources = append(composition.Resources, dsg)
+	composition.Outputs = append(composition.Outputs, dsg)
 
 	return composition, nil
 }
@@ -225,6 +226,7 @@ func (v *MinimalVPCComposer) Compose() (*cfn.Composition, error) {
 	dsg := dbsubnetgroup.New(dbSubnets)
 
 	composition.Resources = append(composition.Resources, dsg)
+	composition.Outputs = append(composition.Outputs, dsg)
 
 	return composition, nil
 }

--- a/pkg/cfn/components/dbsubnetgroup/dbsubnetgroup.go
+++ b/pkg/cfn/components/dbsubnetgroup/dbsubnetgroup.go
@@ -14,6 +14,11 @@ type DBSubnetGroup struct {
 	Subnets    []cfn.Referencer
 }
 
+// NamedOutputs returns the named outputs
+func (g *DBSubnetGroup) NamedOutputs() map[string]map[string]interface{} {
+	return cfn.NewValue("DatabaseSubnetGroupName", g.Ref()).NamedOutputs()
+}
+
 // Resource returns the cloud formation resource for a dbsubnetgroup
 func (g *DBSubnetGroup) Resource() cloudformation.Resource {
 	subnets := make([]string, len(g.Subnets))

--- a/pkg/cfn/components/dbsubnetgroup/dbsubnetgroup_test.go
+++ b/pkg/cfn/components/dbsubnetgroup/dbsubnetgroup_test.go
@@ -1,0 +1,48 @@
+package dbsubnetgroup_test
+
+import (
+	"testing"
+
+	"github.com/awslabs/goformation/v4/cloudformation/rds"
+
+	"github.com/oslokommune/okctl/pkg/cfn"
+	"github.com/oslokommune/okctl/pkg/cfn/components/dbsubnetgroup"
+
+	"github.com/awslabs/goformation/v4/cloudformation"
+	"github.com/sebdah/goldie/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+type testSubnet struct{}
+
+func (t testSubnet) Ref() string {
+	return cloudformation.Ref("DbSubnetSomething")
+}
+
+func TestNew(t *testing.T) {
+	testCases := []struct {
+		name     string
+		golden   string
+		resource cloudformation.Resource
+	}{
+		{
+			name:   "Validate output",
+			golden: "dbsubnetgroup.json",
+			resource: dbsubnetgroup.New(
+				[]cfn.Referencer{testSubnet{}},
+			).Resource(),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.resource.(*rds.DBSubnetGroup).MarshalJSON()
+			assert.NoError(t, err)
+
+			g := goldie.New(t)
+			g.Assert(t, tc.golden, got)
+		})
+	}
+}

--- a/pkg/cfn/components/dbsubnetgroup/testdata/dbsubnetgroup.json.golden
+++ b/pkg/cfn/components/dbsubnetgroup/testdata/dbsubnetgroup.json.golden
@@ -1,0 +1,1 @@
+{"Type":"AWS::RDS::DBSubnetGroup","Properties":{"DBSubnetGroupDescription":"DatabaseSubnetGroup","SubnetIds":["eyAiUmVmIjogIkRiU3VibmV0U29tZXRoaW5nIiB9"]}}

--- a/pkg/cfn/output.go
+++ b/pkg/cfn/output.go
@@ -27,7 +27,8 @@ func (j *Joined) NamedOutputs() map[string]map[string]interface{} {
 // Outputs returns the outputs only
 func (j *Joined) Outputs() map[string]interface{} {
 	return map[string]interface{}{
-		"Value": cloudformation.Join(",", j.Values),
+		"Value":  cloudformation.Join(",", j.Values),
+		"Export": cloudformation.Sub(fmt.Sprintf("${AWS::StackName}-%s", j.Name())),
 	}
 }
 
@@ -72,7 +73,8 @@ func (v *Value) NamedOutputs() map[string]map[string]interface{} {
 // Outputs returns only the cloud formation outputs
 func (v *Value) Outputs() map[string]interface{} {
 	return map[string]interface{}{
-		"Value": v.Value,
+		"Value":  v.Value,
+		"Export": cloudformation.Sub(fmt.Sprintf("${AWS::StackName}-%s", v.Name())),
 	}
 }
 

--- a/pkg/cfn/output.go
+++ b/pkg/cfn/output.go
@@ -27,8 +27,10 @@ func (j *Joined) NamedOutputs() map[string]map[string]interface{} {
 // Outputs returns the outputs only
 func (j *Joined) Outputs() map[string]interface{} {
 	return map[string]interface{}{
-		"Value":  cloudformation.Join(",", j.Values),
-		"Export": cloudformation.Sub(fmt.Sprintf("${AWS::StackName}-%s", j.Name())),
+		"Value": cloudformation.Join(",", j.Values),
+		"Export": map[string]string{
+			"Name": cloudformation.Sub(fmt.Sprintf("${AWS::StackName}-%s", j.Name())),
+		},
 	}
 }
 
@@ -73,8 +75,10 @@ func (v *Value) NamedOutputs() map[string]map[string]interface{} {
 // Outputs returns only the cloud formation outputs
 func (v *Value) Outputs() map[string]interface{} {
 	return map[string]interface{}{
-		"Value":  v.Value,
-		"Export": cloudformation.Sub(fmt.Sprintf("${AWS::StackName}-%s", v.Name())),
+		"Value": v.Value,
+		"Export": map[string]string{
+			"Name": cloudformation.Sub(fmt.Sprintf("${AWS::StackName}-%s", v.Name())),
+		},
 	}
 }
 

--- a/pkg/cfn/output_test.go
+++ b/pkg/cfn/output_test.go
@@ -124,7 +124,8 @@ func TestOutput(t *testing.T) {
 			outputer: cfn.NewJoined("JoinedTest").Add("value"),
 			expect: map[string]map[string]interface{}{
 				"JoinedTest": {
-					"Value": base64.StdEncoding.EncodeToString([]byte("{ \"Fn::Join\": [ \",\", [ \"value\" ] ] }")),
+					"Value":  base64.StdEncoding.EncodeToString([]byte("{ \"Fn::Join\": [ \",\", [ \"value\" ] ] }")),
+					"Export": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tSm9pbmVkVGVzdCIgfQ==",
 				},
 			},
 		},
@@ -133,7 +134,8 @@ func TestOutput(t *testing.T) {
 			outputer: cfn.NewValue("ValueTest", "value"),
 			expect: map[string]map[string]interface{}{
 				"ValueTest": {
-					"Value": "value",
+					"Value":  "value",
+					"Export": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tVmFsdWVUZXN0IiB9",
 				},
 			},
 		},
@@ -142,10 +144,12 @@ func TestOutput(t *testing.T) {
 			outputer: cfn.NewValueMap().Add(cfn.NewValue("Something", "v1")).Add(cfn.NewValue("Else", "v2")),
 			expect: map[string]map[string]interface{}{
 				"Something": {
-					"Value": "v1",
+					"Value":  "v1",
+					"Export": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tU29tZXRoaW5nIiB9",
 				},
 				"Else": {
-					"Value": "v2",
+					"Value":  "v2",
+					"Export": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tRWxzZSIgfQ==",
 				},
 			},
 		},

--- a/pkg/cfn/output_test.go
+++ b/pkg/cfn/output_test.go
@@ -124,8 +124,10 @@ func TestOutput(t *testing.T) {
 			outputer: cfn.NewJoined("JoinedTest").Add("value"),
 			expect: map[string]map[string]interface{}{
 				"JoinedTest": {
-					"Value":  base64.StdEncoding.EncodeToString([]byte("{ \"Fn::Join\": [ \",\", [ \"value\" ] ] }")),
-					"Export": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tSm9pbmVkVGVzdCIgfQ==",
+					"Value": base64.StdEncoding.EncodeToString([]byte("{ \"Fn::Join\": [ \",\", [ \"value\" ] ] }")),
+					"Export": map[string]string{
+						"Name": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tSm9pbmVkVGVzdCIgfQ==",
+					},
 				},
 			},
 		},
@@ -134,8 +136,10 @@ func TestOutput(t *testing.T) {
 			outputer: cfn.NewValue("ValueTest", "value"),
 			expect: map[string]map[string]interface{}{
 				"ValueTest": {
-					"Value":  "value",
-					"Export": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tVmFsdWVUZXN0IiB9",
+					"Value": "value",
+					"Export": map[string]string{
+						"Name": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tVmFsdWVUZXN0IiB9",
+					},
 				},
 			},
 		},
@@ -144,12 +148,16 @@ func TestOutput(t *testing.T) {
 			outputer: cfn.NewValueMap().Add(cfn.NewValue("Something", "v1")).Add(cfn.NewValue("Else", "v2")),
 			expect: map[string]map[string]interface{}{
 				"Something": {
-					"Value":  "v1",
-					"Export": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tU29tZXRoaW5nIiB9",
+					"Value": "v1",
+					"Export": map[string]string{
+						"Name": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tU29tZXRoaW5nIiB9",
+					},
 				},
 				"Else": {
-					"Value":  "v2",
-					"Export": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tRWxzZSIgfQ==",
+					"Value": "v2",
+					"Export": map[string]string{
+						"Name": "eyAiRm46OlN1YiIgOiAiJHtBV1M6OlN0YWNrTmFtZX0tRWxzZSIgfQ==",
+					},
 				},
 			},
 		},

--- a/pkg/cfn/testdata/alb-ingress-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/alb-ingress-cloudformation.yaml.golden
@@ -1,6 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   AlbIngressControllerPolicy:
+    Export:
+      Fn::Sub: ${AWS::StackName}-AlbIngressControllerPolicy
     Value:
       Ref: AlbIngressControllerPolicy
 Resources:

--- a/pkg/cfn/testdata/alb-ingress-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/alb-ingress-cloudformation.yaml.golden
@@ -2,7 +2,8 @@ AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   AlbIngressControllerPolicy:
     Export:
-      Fn::Sub: ${AWS::StackName}-AlbIngressControllerPolicy
+      Name:
+        Fn::Sub: ${AWS::StackName}-AlbIngressControllerPolicy
     Value:
       Ref: AlbIngressControllerPolicy
 Resources:

--- a/pkg/cfn/testdata/esp-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/esp-cloudformation.yaml.golden
@@ -2,7 +2,8 @@ AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   ExternalSecretsPolicy:
     Export:
-      Fn::Sub: ${AWS::StackName}-ExternalSecretsPolicy
+      Name:
+        Fn::Sub: ${AWS::StackName}-ExternalSecretsPolicy
     Value:
       Ref: ExternalSecretsPolicy
 Resources:

--- a/pkg/cfn/testdata/esp-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/esp-cloudformation.yaml.golden
@@ -1,6 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   ExternalSecretsPolicy:
+    Export:
+      Fn::Sub: ${AWS::StackName}-ExternalSecretsPolicy
     Value:
       Ref: ExternalSecretsPolicy
 Resources:

--- a/pkg/cfn/testdata/external-dns-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/external-dns-cloudformation.yaml.golden
@@ -2,7 +2,8 @@ AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   ExternalDNSPolicy:
     Export:
-      Fn::Sub: ${AWS::StackName}-ExternalDNSPolicy
+      Name:
+        Fn::Sub: ${AWS::StackName}-ExternalDNSPolicy
     Value:
       Ref: ExternalDNSPolicy
 Resources:

--- a/pkg/cfn/testdata/external-dns-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/external-dns-cloudformation.yaml.golden
@@ -1,6 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   ExternalDNSPolicy:
+    Export:
+      Fn::Sub: ${AWS::StackName}-ExternalDNSPolicy
     Value:
       Ref: ExternalDNSPolicy
 Resources:

--- a/pkg/cfn/testdata/public-certificate-cf.yaml.golden
+++ b/pkg/cfn/testdata/public-certificate-cf.yaml.golden
@@ -1,6 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   PublicCertificate:
+    Export:
+      Fn::Sub: ${AWS::StackName}-PublicCertificate
     Value:
       Ref: PublicCertificate
 Resources:

--- a/pkg/cfn/testdata/public-certificate-cf.yaml.golden
+++ b/pkg/cfn/testdata/public-certificate-cf.yaml.golden
@@ -2,7 +2,8 @@ AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   PublicCertificate:
     Export:
-      Fn::Sub: ${AWS::StackName}-PublicCertificate
+      Name:
+        Fn::Sub: ${AWS::StackName}-PublicCertificate
     Value:
       Ref: PublicCertificate
 Resources:

--- a/pkg/cfn/testdata/userpool-client.yaml.golden
+++ b/pkg/cfn/testdata/userpool-client.yaml.golden
@@ -2,7 +2,8 @@ AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   argocdClientID:
     Export:
-      Fn::Sub: ${AWS::StackName}-argocdClientID
+      Name:
+        Fn::Sub: ${AWS::StackName}-argocdClientID
     Value:
       Ref: UserPoolClientargocd
 Resources:

--- a/pkg/cfn/testdata/userpool-client.yaml.golden
+++ b/pkg/cfn/testdata/userpool-client.yaml.golden
@@ -1,6 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   argocdClientID:
+    Export:
+      Fn::Sub: ${AWS::StackName}-argocdClientID
     Value:
       Ref: UserPoolClientargocd
 Resources:

--- a/pkg/cfn/testdata/vpc-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/vpc-cloudformation.yaml.golden
@@ -2,12 +2,14 @@ AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   DatabaseSubnetGroupName:
     Export:
-      Fn::Sub: ${AWS::StackName}-DatabaseSubnetGroupName
+      Name:
+        Fn::Sub: ${AWS::StackName}-DatabaseSubnetGroupName
     Value:
       Ref: DatabaseSubnetGroup
   PrivateSubnetIds:
     Export:
-      Fn::Sub: ${AWS::StackName}-PrivateSubnetIds
+      Name:
+        Fn::Sub: ${AWS::StackName}-PrivateSubnetIds
     Value:
       Fn::Join:
       - ','
@@ -16,7 +18,8 @@ Outputs:
         - Ref: PrivateSubnet02
   PublicSubnetIds:
     Export:
-      Fn::Sub: ${AWS::StackName}-PublicSubnetIds
+      Name:
+        Fn::Sub: ${AWS::StackName}-PublicSubnetIds
     Value:
       Fn::Join:
       - ','
@@ -25,7 +28,8 @@ Outputs:
         - Ref: PublicSubnet02
   Vpc:
     Export:
-      Fn::Sub: ${AWS::StackName}-Vpc
+      Name:
+        Fn::Sub: ${AWS::StackName}-Vpc
     Value:
       Ref: Vpc
 Resources:

--- a/pkg/cfn/testdata/vpc-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/vpc-cloudformation.yaml.golden
@@ -1,6 +1,13 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
+  DatabaseSubnetGroupName:
+    Export:
+      Fn::Sub: ${AWS::StackName}-DatabaseSubnetGroupName
+    Value:
+      Ref: DatabaseSubnetGroup
   PrivateSubnetIds:
+    Export:
+      Fn::Sub: ${AWS::StackName}-PrivateSubnetIds
     Value:
       Fn::Join:
       - ','
@@ -8,6 +15,8 @@ Outputs:
         - Ref: PrivateSubnet01
         - Ref: PrivateSubnet02
   PublicSubnetIds:
+    Export:
+      Fn::Sub: ${AWS::StackName}-PublicSubnetIds
     Value:
       Fn::Join:
       - ','
@@ -15,6 +24,8 @@ Outputs:
         - Ref: PublicSubnet01
         - Ref: PublicSubnet02
   Vpc:
+    Export:
+      Fn::Sub: ${AWS::StackName}-Vpc
     Value:
       Ref: Vpc
 Resources:

--- a/pkg/cfn/testdata/vpc-minimal-cf.yaml.golden
+++ b/pkg/cfn/testdata/vpc-minimal-cf.yaml.golden
@@ -2,12 +2,14 @@ AWSTemplateFormatVersion: 2010-09-09
 Outputs:
   DatabaseSubnetGroupName:
     Export:
-      Fn::Sub: ${AWS::StackName}-DatabaseSubnetGroupName
+      Name:
+        Fn::Sub: ${AWS::StackName}-DatabaseSubnetGroupName
     Value:
       Ref: DatabaseSubnetGroup
   PrivateSubnetIds:
     Export:
-      Fn::Sub: ${AWS::StackName}-PrivateSubnetIds
+      Name:
+        Fn::Sub: ${AWS::StackName}-PrivateSubnetIds
     Value:
       Fn::Join:
       - ','
@@ -16,7 +18,8 @@ Outputs:
         - Ref: PrivateSubnet02
   PublicSubnetIds:
     Export:
-      Fn::Sub: ${AWS::StackName}-PublicSubnetIds
+      Name:
+        Fn::Sub: ${AWS::StackName}-PublicSubnetIds
     Value:
       Fn::Join:
       - ','
@@ -25,7 +28,8 @@ Outputs:
         - Ref: PublicSubnet02
   Vpc:
     Export:
-      Fn::Sub: ${AWS::StackName}-Vpc
+      Name:
+        Fn::Sub: ${AWS::StackName}-Vpc
     Value:
       Ref: Vpc
 Resources:

--- a/pkg/cfn/testdata/vpc-minimal-cf.yaml.golden
+++ b/pkg/cfn/testdata/vpc-minimal-cf.yaml.golden
@@ -1,6 +1,13 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
+  DatabaseSubnetGroupName:
+    Export:
+      Fn::Sub: ${AWS::StackName}-DatabaseSubnetGroupName
+    Value:
+      Ref: DatabaseSubnetGroup
   PrivateSubnetIds:
+    Export:
+      Fn::Sub: ${AWS::StackName}-PrivateSubnetIds
     Value:
       Fn::Join:
       - ','
@@ -8,6 +15,8 @@ Outputs:
         - Ref: PrivateSubnet01
         - Ref: PrivateSubnet02
   PublicSubnetIds:
+    Export:
+      Fn::Sub: ${AWS::StackName}-PublicSubnetIds
     Value:
       Fn::Join:
       - ','
@@ -15,6 +24,8 @@ Outputs:
         - Ref: PublicSubnet01
         - Ref: PublicSubnet02
   Vpc:
+    Export:
+      Fn::Sub: ${AWS::StackName}-Vpc
     Value:
       Ref: Vpc
 Resources:


### PR DESCRIPTION
Example output:
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/154348/106880348-88451880-66dc-11eb-91a7-a3977b3f761e.png">


A cloud formation stack output cannot be referenced by another cloud formation stack unless it is exported. The DBSubnetGroupName is required when creating an RDS database.

**NOTE:** Please be aware that this comes with some side-effects (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html)

`After another stack imports an output value, you can't delete the stack that is exporting the output value or modify the exported output value. All of the imports must be removed before you can delete the exporting stack or modify the output value.`

and

`For each AWS account, Export names must be unique within a region.`

Closes: https://trello.com/c/I9rMXErA/142-legge-til-output-på-stacken-som-oppretter-databasesubnetgroup-om-å-eksportere-id-navn

## Description
- We now always export an output, so it can be referenced from another stack
- Added outputs to DBSubnetGroup

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
