### PR TITLE
[NOTASK] Increase actionable output on errors originating from kube package

### DIFF
--- a/pkg/kube/manifests/echoserver/echoserver_test.go
+++ b/pkg/kube/manifests/echoserver/echoserver_test.go
@@ -59,7 +59,7 @@ func TestEchoServer(t *testing.T) {
 
 			k.WithLogger(logrus.StandardLogger())
 
-			resources, err := k.Apply(tc.ext.CreateDeployment)
+			resources, err := k.Apply(kube.Applier{Fn: tc.ext.CreateDeployment})
 			assert.NoError(t, err)
 
 			err = k.Watch(resources, 2*time.Minute)

--- a/pkg/kube/manifests/externaldns/externaldns_test.go
+++ b/pkg/kube/manifests/externaldns/externaldns_test.go
@@ -94,7 +94,7 @@ func TestExternalDNS(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Need to add k.Watch to the output her, but that means bringing up localstack, I think?
-			_, err = k.Apply(tc.ext.CreateDeployment, tc.ext.CreateClusterRole, tc.ext.CreateClusterRoleBinding)
+			_, err = k.Apply(kube.Applier{Fn: tc.ext.CreateDeployment}, kube.Applier{Fn: tc.ext.CreateClusterRole}, kube.Applier{Fn: tc.ext.CreateClusterRoleBinding})
 			assert.NoError(t, err)
 
 			outputs, err := cluster.Debug("kube-system")

--- a/pkg/kube/manifests/externalsecret/externalsecret.go
+++ b/pkg/kube/manifests/externalsecret/externalsecret.go
@@ -45,14 +45,14 @@ func (a *ExternalSecret) CreateSecret(_ kubernetes.Interface, config *rest.Confi
 
 	externalSecrets, err := clientSet.ExternalSecrets(a.Namespace).List(a.Ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing external secrets in %s: %w", a.Namespace, err)
 	}
 
 	for _, es := range externalSecrets.Items {
 		if es.Name == a.Name {
 			got, err := clientSet.ExternalSecrets(a.Namespace).Get(a.Ctx, es.Name, metav1.GetOptions{})
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("getting external secret %s in %s: %w", es.Name, es.Namespace, err)
 			}
 
 			return got, nil

--- a/pkg/kube/manifests/externalsecret/externalsecret_test.go
+++ b/pkg/kube/manifests/externalsecret/externalsecret_test.go
@@ -96,7 +96,7 @@ func TestExternalDNS(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Need to add k.Watch to the output her, but that means bringing up localstack, I think?
-			_, err = k.Apply(tc.ext.CreateSecret)
+			_, err = k.Apply(kube.Applier{Fn: tc.ext.CreateSecret})
 			assert.NoError(t, err)
 
 			outputs, err := cluster.Debug("kube-system")


### PR DESCRIPTION
This PR is branched from #290, merge first.

Increase actionable output on errors originating from kube package

## Description

Currently it is difficult to debug an authorisation error that occurs when ArgoCD/ExternalSecrets is being deployed. In this PR we add additional debugging information to an error when it occurs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
