### PR TITLE
[KM34] Tag all cloud formation resources created by okctl

### DIFF
--- a/.goreleaser-local.yml
+++ b/.goreleaser-local.yml
@@ -12,8 +12,9 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -X main.GitCommit={{.Commit}}
-      - -X main.OkctlVersion={{.Version}}
+      - -X github.com/oslokommune/okctl/pkg/version.ShortCommit={{.ShortCommit}}
+      - -X github.com/oslokommune/okctl/pkg/version.Version={{.Version}}
+      - -X github.com/oslokommune/okctl/pkg/version.BuildDate={{.Date}}
     goos:
       - darwin
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,9 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -X main.GitCommit={{.Commit}}
-      - -X main.OkctlVersion={{.Version}}
+      - -X github.com/oslokommune/okctl/pkg/version.ShortCommit={{.ShortCommit}}
+      - -X github.com/oslokommune/okctl/pkg/version.Version={{.Version}}
+      - -X github.com/oslokommune/okctl/pkg/version.BuildDate={{.Date}}
     goos:
       - darwin
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,8 +46,8 @@ brews:
       name: homebrew-tap
 
     commit_author:
-      name: veiviser
-      email: veiviser@oslo.kommune.no
+      name: okctl
+      email: okctl@oslo.kommune.no
 
     folder: Formula
 

--- a/cmd/okctl/create.go
+++ b/cmd/okctl/create.go
@@ -462,7 +462,7 @@ and database subnets.`,
 				AwsIamAuthenticatorCmd:  aurora.Green("aws-iam-authenticator").String(),
 				KubectlPath:             k.BinaryPath,
 				AwsIamAuthenticatorPath: a.BinaryPath,
-				K8sClusterVersion:       aurora.Green("1.17").String(),
+				K8sClusterVersion:       aurora.Green(config.DefaultEKSKubernetesVersion).String(),
 				ArgoCD:                  aurora.Green("ArgoCD").String(),
 				ArgoCDURL:               aurora.Green(argoCD.ArgoURL).String(),
 			}

--- a/cmd/okctl/version.go
+++ b/cmd/okctl/version.go
@@ -3,17 +3,11 @@ package main
 import (
 	"fmt"
 
+	"github.com/oslokommune/okctl/pkg/version"
+
 	"github.com/oslokommune/okctl/pkg/okctl"
 	"github.com/spf13/cobra"
 )
-
-// nolint: globalvar
-// The current git commit at build-time with goreleaser
-var GitCommit string
-
-// nolint: globalvar
-// The current version of okctl
-var OkctlVersion string
 
 func buildVersionCommand(o *okctl.Okctl) *cobra.Command {
 	cmd := &cobra.Command{
@@ -24,9 +18,8 @@ func buildVersionCommand(o *okctl.Okctl) *cobra.Command {
 			return nil
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			fmt.Fprintf(o.Out, "Version: %s\n", OkctlVersion)
-			fmt.Fprintf(o.Out, "Commit : %s\n", GitCommit)
-			return nil
+			_, err := fmt.Fprintf(o.Out, version.String())
+			return err
 		},
 	}
 

--- a/cmd/okctl/version.go
+++ b/cmd/okctl/version.go
@@ -18,7 +18,7 @@ func buildVersionCommand(o *okctl.Okctl) *cobra.Command {
 			return nil
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			_, err := fmt.Fprintf(o.Out, version.String())
+			_, err := fmt.Fprint(o.Out, version.String())
 			return err
 		},
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/clusterconfig_v1alpha5.go
+++ b/pkg/apis/eksctl.io/v1alpha5/clusterconfig_v1alpha5.go
@@ -39,9 +39,10 @@ type ClusterStatus struct {
 
 // ClusterMeta comes from eksctl and maps up what we need
 type ClusterMeta struct {
-	Name    string `json:"name"`
-	Region  string `json:"region"`
-	Version string `json:"version,omitempty"`
+	Name    string            `json:"name"`
+	Region  string            `json:"region"`
+	Version string            `json:"version,omitempty"`
+	Tags    map[string]string `json:"tags,omitempty"`
 }
 
 func (c *ClusterMeta) String() string {

--- a/pkg/apis/okctl.io/v1alpha1/types.go
+++ b/pkg/apis/okctl.io/v1alpha1/types.go
@@ -17,6 +17,11 @@ const (
 	OkRoleARNPattern = "arn:aws:iam::%s:role/oslokommune/iamadmin-SAML"
 	// OkSamlURL is the starting point for authenticating via KeyCloak towards AWS
 	OkSamlURL = "https://login.oslo.kommune.no/auth/realms/AD/protocol/saml/clients/amazon-aws"
+
+	// OkctlVersionTag defines the version of okctl used to provision the given resources
+	OkctlVersionTag = "alpha.okctl.io/okctl-version"
+	// OkctlCommitTag defines the git commit hash used to provision the given resources
+	OkctlCommitTag = "alpha.okctl.io/okctl-commit"
 )
 
 // SupportedRegions returns the supported regions on AWS

--- a/pkg/cfn/runner.go
+++ b/pkg/cfn/runner.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oslokommune/okctl/pkg/version"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	cfPkg "github.com/aws/aws-sdk-go/service/cloudformation"
@@ -152,11 +154,23 @@ func (r *Runner) CreateIfNotExists(stackName string, template []byte, capabiliti
 		return nil
 	}
 
+	v := version.GetVersionInfo()
+
 	stackInput := &cfPkg.CreateStackInput{
 		OnFailure:        aws.String(cfPkg.OnFailureDelete),
 		StackName:        aws.String(stackName),
 		TemplateBody:     aws.String(string(template)),
 		TimeoutInMinutes: aws.Int64(timeout),
+		Tags: []*cfPkg.Tag{
+			{
+				Key:   aws.String(v1alpha1.OkctlVersionTag),
+				Value: aws.String(v.Version),
+			},
+			{
+				Key:   aws.String(v1alpha1.OkctlCommitTag),
+				Value: aws.String(v.ShortCommit),
+			},
+		},
 	}
 
 	for _, c := range capabilities {

--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -4,6 +4,9 @@ package clusterconfig
 import (
 	"fmt"
 
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/version"
+
 	"github.com/oslokommune/okctl/pkg/apis/eksctl.io/v1alpha5"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -50,12 +53,18 @@ func (a *Args) validate() error {
 // New creates a cluster config
 // nolint: funlen
 func (a *Args) build() *v1alpha5.ClusterConfig {
+	v := version.GetVersionInfo()
+
 	cfg := &v1alpha5.ClusterConfig{
 		TypeMeta: TypeMeta(),
 		Metadata: v1alpha5.ClusterMeta{
 			Name:    a.ClusterName,
 			Region:  a.Region,
 			Version: a.Version,
+			Tags: map[string]string{
+				v1alpha1.OkctlVersionTag: v.Version,
+				v1alpha1.OkctlCommitTag:  v.ShortCommit,
+			},
 		},
 		IAM: v1alpha5.ClusterIAM{
 			ServiceRolePermissionsBoundary:             a.PermissionsBoundaryARN,
@@ -168,11 +177,17 @@ func (a *ServiceAccountArgs) validate() error {
 }
 
 func (a *ServiceAccountArgs) build() *v1alpha5.ClusterConfig {
+	v := version.GetVersionInfo()
+
 	return &v1alpha5.ClusterConfig{
 		TypeMeta: TypeMeta(),
 		Metadata: v1alpha5.ClusterMeta{
 			Name:   a.ClusterName,
 			Region: a.Region,
+			Tags: map[string]string{
+				v1alpha1.OkctlVersionTag: v.Version,
+				v1alpha1.OkctlCommitTag:  v.ShortCommit,
+			},
 		},
 		IAM: v1alpha5.ClusterIAM{
 			WithOIDC: true,
@@ -280,12 +295,18 @@ func (a *MinimalArgs) validate() error {
 // New creates a cluster config
 // nolint: funlen
 func (a *MinimalArgs) build() *v1alpha5.ClusterConfig {
+	v := version.GetVersionInfo()
+
 	cfg := &v1alpha5.ClusterConfig{
 		TypeMeta: TypeMeta(),
 		Metadata: v1alpha5.ClusterMeta{
 			Name:    a.ClusterName,
 			Region:  a.Region,
 			Version: a.Version,
+			Tags: map[string]string{
+				v1alpha1.OkctlVersionTag: v.Version,
+				v1alpha1.OkctlCommitTag:  v.ShortCommit,
+			},
 		},
 		IAM: v1alpha5.ClusterIAM{
 			ServiceRolePermissionsBoundary:             a.PermissionsBoundaryARN,

--- a/pkg/clusterconfig/testdata/aws-alb-ingres-controller.golden
+++ b/pkg/clusterconfig/testdata/aws-alb-ingres-controller.golden
@@ -14,3 +14,6 @@ kind: ClusterConfig
 metadata:
   name: test
   region: eu-west-1
+  tags:
+    alpha.okctl.io/okctl-commit: unknown
+    alpha.okctl.io/okctl-version: dev

--- a/pkg/clusterconfig/testdata/clusterConfig.golden
+++ b/pkg/clusterconfig/testdata/clusterConfig.golden
@@ -12,6 +12,9 @@ kind: ClusterConfig
 metadata:
   name: test
   region: eu-west-1
+  tags:
+    alpha.okctl.io/okctl-commit: unknown
+    alpha.okctl.io/okctl-version: dev
   version: "1.18"
 nodeGroups:
 - desiredCapacity: 2

--- a/pkg/clusterconfig/testdata/external-dns.golden
+++ b/pkg/clusterconfig/testdata/external-dns.golden
@@ -14,3 +14,6 @@ kind: ClusterConfig
 metadata:
   name: test
   region: eu-west-1
+  tags:
+    alpha.okctl.io/okctl-commit: unknown
+    alpha.okctl.io/okctl-version: dev

--- a/pkg/clusterconfig/testdata/externalSecretsServiceAccount.golden
+++ b/pkg/clusterconfig/testdata/externalSecretsServiceAccount.golden
@@ -14,3 +14,6 @@ kind: ClusterConfig
 metadata:
   name: test
   region: eu-west-1
+  tags:
+    alpha.okctl.io/okctl-commit: unknown
+    alpha.okctl.io/okctl-version: dev

--- a/pkg/clusterconfig/testdata/minimal-cluster-config.golden
+++ b/pkg/clusterconfig/testdata/minimal-cluster-config.golden
@@ -12,6 +12,9 @@ kind: ClusterConfig
 metadata:
   name: test
   region: eu-west-1
+  tags:
+    alpha.okctl.io/okctl-commit: unknown
+    alpha.okctl.io/okctl-version: dev
   version: "1.18"
 nodeGroups:
 - desiredCapacity: 2

--- a/pkg/clusterconfig/testdata/serviceAccount.golden
+++ b/pkg/clusterconfig/testdata/serviceAccount.golden
@@ -14,3 +14,6 @@ kind: ClusterConfig
 metadata:
   name: test
   region: eu-west-1
+  tags:
+    alpha.okctl.io/okctl-commit: unknown
+    alpha.okctl.io/okctl-version: dev

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,7 +45,7 @@ const (
 
 	DefaultRepositoryStateFile = ".okctl.yml"
 
-	DefaultEKSKubernetesVersion = "1.18"
+	DefaultEKSKubernetesVersion = "1.17"
 
 	DefaultClusterConfig         = "cluster.yml"
 	DefaultClusterKubeConfig     = "kubeconfig"

--- a/pkg/version/doc.go
+++ b/pkg/version/doc.go
@@ -1,0 +1,2 @@
+// Package version knows how to serialise a release
+package version

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -1,0 +1,13 @@
+package version
+
+// Version of okctl
+// nolint: gochecknoglobals
+var Version = "dev"
+
+// ShortCommit hash
+// nolint: gochecknoglobals
+var ShortCommit = "unknown"
+
+// BuildDate of the release
+// nolint: gochecknoglobals
+var BuildDate = "unknown"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,28 @@
+package version
+
+import "encoding/json"
+
+// Info contains the version information
+type Info struct {
+	Version     string
+	ShortCommit string
+	BuildDate   string
+}
+
+// GetVersionInfo populates the version information
+func GetVersionInfo() Info {
+	return Info{
+		Version:     Version,
+		ShortCommit: ShortCommit,
+		BuildDate:   BuildDate,
+	}
+}
+
+// String returns version info as JSON
+func String() string {
+	if data, err := json.Marshal(GetVersionInfo()); err == nil {
+		return string(data)
+	}
+
+	return ""
+}


### PR DESCRIPTION
Tag all cloud formation resources created by okctl

This also closes #171 

## Description
This makes it easier to find all resources created by okctl, as they can simply be listed by tags with the aws-cli. The following tags are added to all resources created by okctl:

- `alpha.okctl.io/okctl-commit: fgh3784`
- `alpha.okctl.io/okctl-version: v0.0.39`

![image](https://user-images.githubusercontent.com/154348/107284083-87561300-6a5d-11eb-9173-373543f3b2ac.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
