### PR TITLE
Add autocompletion

### DIFF
--- a/cmd/okctl/completion.go
+++ b/cmd/okctl/completion.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/spf13/cobra"
+)
+
+// nolint: funlen
+func buildCompletionCommand(o *okctl.Okctl) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate completion script",
+		Long: `To load completions:
+
+Bash:
+
+	$ source <(okctl completion bash)
+
+	# To load completions for each session, execute once:
+	# Linux:
+	$ okctl completion bash > /etc/bash_completion.d/okctl
+	# macOS:
+	$ okctl completion bash > /usr/local/etc/bash_completion.d/okctl
+
+Zsh:
+
+	# If shell completion is not already enabled in your environment,
+	# you will need to enable it.  You can execute the following once:
+
+	$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+	# To load completions for each session, execute once:
+	$ okctl completion zsh > "${fpath[1]}/_okctl"
+
+	# You will need to start a new shell for this setup to take effect.
+
+fish:
+
+	$ okctl completion fish | source
+
+	# To load completions for each session, execute once:
+	$ okctl completion fish > ~/.config/fish/completions/okctl.fish
+
+PowerShell:
+
+	PS> okctl completion powershell | Out-String | Invoke-Expression
+
+	# To load completions for every new session, run:
+	PS> okctl completion powershell > okctl.ps1
+	# and source this file from your PowerShell profile.
+	`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactValidArgs(1),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+
+			switch args[0] {
+			case "bash":
+				err = cmd.Root().GenBashCompletion(o.Out)
+			case "zsh":
+				err = cmd.Root().GenZshCompletion(o.Out)
+			case "fish":
+				err = cmd.Root().GenFishCompletion(o.Out, true)
+			case "powershell":
+				err = cmd.Root().GenPowerShellCompletion(o.Out)
+			}
+
+			return err
+		},
+	}
+
+	return cmd
+}

--- a/cmd/okctl/main.go
+++ b/cmd/okctl/main.go
@@ -56,6 +56,10 @@ We also use the prometheus-operator for ensuring metrics and logs are
 being captured. Together with slack and slick.`,
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Name() == cobra.ShellCompRequestCmd {
+				return nil
+			}
+
 			var err error
 
 			err = loadUserData(o, cmd)
@@ -91,6 +95,7 @@ being captured. Together with slack and slick.`,
 
 	cmd.AddCommand(buildAddUserCommand(o))
 	cmd.AddCommand(buildApplyCommand(o))
+	cmd.AddCommand(buildCompletionCommand(o))
 	cmd.AddCommand(buildCreateCommand(o))
 	cmd.AddCommand(buildDeleteCommand(o))
 	cmd.AddCommand(buildScaffoldCommand(o))

--- a/userdocs/src/index.md
+++ b/userdocs/src/index.md
@@ -45,6 +45,10 @@ brew tap oslokommune/tap
 brew install oslokommune/tap/okctl
 ```
 
+### Shell autocompletion
+
+To get autocompletion in your shell working run `okctl completion -h` and follow the steps for your preferred shell.
+
 ## Getting started
 
 The following is a guide for how to create an environment that contains the elements described in


### PR DESCRIPTION
## Description

Cobra has built in support for autocompletion. The only needed thing is
a boilerplate to add the `completion` command which generates scripts
for popular shells.

The built in cobra autocompletion uses a hidden command called
`__completion` to do the actual look-ups. To make it work we need to
bypass `PersistentPreRunE` in the root-command when `__completion` is
called.

## Motivation and Context
Makes it easier to use okctl by mashing tab

## How Has This Been Tested?
 - Adding the `zsh` completion script to my shell and see that it runs
 - Testing the `__completion` command manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
