### PR TITLE
[KM89] Service quotas should ignore resources that are already provisioned 

### DIFF
--- a/cmd/okctl/create.go
+++ b/cmd/okctl/create.go
@@ -215,6 +215,9 @@ and database subnets.`,
 				return formatErr(err)
 			}
 
+			// The cloud formation stack is created atomically, and the EIP and IGW
+			// are created as part of this stack, therefore this check is sufficient
+			// for all of these checks.
 			vpcProvisioned := len(o.RepoStateWithEnv.GetVPC().VpcID) > 0
 
 			err = servicequota.CheckQuotas(

--- a/cmd/okctl/create.go
+++ b/cmd/okctl/create.go
@@ -215,11 +215,16 @@ and database subnets.`,
 				return formatErr(err)
 			}
 
-			_ = servicequota.CheckQuotas(
-				servicequota.NewVpcCheck(o.Err, o.CloudProvider, config.DefaultRequiredVpcs),
-				servicequota.NewEipCheck(o.Err, o.CloudProvider, config.DefaultRequiredEpis),
-				servicequota.NewIgwCheck(o.Err, o.CloudProvider, config.DefaultRequiredIgws),
+			vpcProvisioned := len(o.RepoStateWithEnv.GetVPC().VpcID) > 0
+
+			err = servicequota.CheckQuotas(
+				servicequota.NewVpcCheck(vpcProvisioned, config.DefaultRequiredVpcs, o.CloudProvider),
+				servicequota.NewEipCheck(vpcProvisioned, config.DefaultRequiredEpis, o.CloudProvider),
+				servicequota.NewIgwCheck(vpcProvisioned, config.DefaultRequiredIgws, o.CloudProvider),
 			)
+			if err != nil {
+				return formatErr(err)
+			}
 
 			ready := false
 			prompt := &survey.Confirm{

--- a/cmd/okctl/createtestcluster.go
+++ b/cmd/okctl/createtestcluster.go
@@ -152,11 +152,16 @@ with Github or other production services.
 				return formatErr(err)
 			}
 
-			_ = servicequota.CheckQuotas(
-				servicequota.NewVpcCheck(o.Err, o.CloudProvider, config.DefaultRequiredVpcsTestCluster),
-				servicequota.NewEipCheck(o.Err, o.CloudProvider, config.DefaultRequiredEpisTestCluster),
-				servicequota.NewIgwCheck(o.Err, o.CloudProvider, config.DefaultRequiredIgwsTestCluster),
+			vpcProvisioned := len(o.RepoStateWithEnv.GetVPC().VpcID) > 0
+
+			err = servicequota.CheckQuotas(
+				servicequota.NewVpcCheck(vpcProvisioned, config.DefaultRequiredVpcsTestCluster, o.CloudProvider),
+				servicequota.NewEipCheck(vpcProvisioned, config.DefaultRequiredEpisTestCluster, o.CloudProvider),
+				servicequota.NewIgwCheck(vpcProvisioned, config.DefaultRequiredIgwsTestCluster, o.CloudProvider),
 			)
+			if err != nil {
+				return formatErr(err)
+			}
 
 			ready := false
 			prompt := &survey.Confirm{

--- a/cmd/okctl/createtestcluster.go
+++ b/cmd/okctl/createtestcluster.go
@@ -152,6 +152,9 @@ with Github or other production services.
 				return formatErr(err)
 			}
 
+			// The cloud formation stack is created atomically, and the EIP and IGW
+			// are created as part of this stack, therefore this check is sufficient
+			// for all of these checks.
 			vpcProvisioned := len(o.RepoStateWithEnv.GetVPC().VpcID) > 0
 
 			err = servicequota.CheckQuotas(

--- a/pkg/mock/aws.go
+++ b/pkg/mock/aws.go
@@ -100,6 +100,7 @@ func DefaultValidStsCredentials() *sts.Credentials {
 	return creds
 }
 
+// SQAPI mocks the service quotas interface
 type SQAPI struct {
 	servicequotasiface.ServiceQuotasAPI
 
@@ -377,6 +378,7 @@ func NewCloudProvider() *CloudProvider {
 }
 
 // NewGoodCloudProvider returns a mocked cloud provider with success set on all
+// nolint: funlen
 func NewGoodCloudProvider() *CloudProvider {
 	return &CloudProvider{
 		EC2API: &EC2API{
@@ -461,7 +463,7 @@ func NewGoodCloudProvider() *CloudProvider {
 			GetServiceQuotaFn: func(*servicequotas.GetServiceQuotaInput) (*servicequotas.GetServiceQuotaOutput, error) {
 				return &servicequotas.GetServiceQuotaOutput{
 					Quota: &servicequotas.ServiceQuota{
-						Value: aws.Float64(3),
+						Value: aws.Float64(3), // nolint: gomnd
 					},
 				}, nil
 			},

--- a/pkg/servicequota/checker.go
+++ b/pkg/servicequota/checker.go
@@ -1,19 +1,33 @@
 // Package servicequota check if you have enough resources in aws before cluster creation starts
 package servicequota
 
+import (
+	"fmt"
+)
+
 // Checker defines what we need to know about a service quota
 type Checker interface {
-	CheckAvailability() error
+	CheckAvailability() (*Result, error)
+}
+
+// Result contains the data from an availability check
+type Result struct {
+	Required    int
+	Available   int
+	HasCapacity bool
+	Description string
 }
 
 // CheckQuotas will run through the checks and return an error if quotas are too small
-func CheckQuotas(checkers ...Checker) error {
-	for i := range checkers {
-		checker := checkers[i]
-
-		err := checker.CheckAvailability()
+func CheckQuotas(checks ...Checker) error {
+	for _, check := range checks {
+		r, err := check.CheckAvailability()
 		if err != nil {
 			return err
+		}
+
+		if !r.HasCapacity {
+			return fmt.Errorf("%s: required %d, but only have %d available", r.Description, r.Required, r.Available)
 		}
 	}
 

--- a/pkg/servicequota/checker.go
+++ b/pkg/servicequota/checker.go
@@ -12,10 +12,11 @@ type Checker interface {
 
 // Result contains the data from an availability check
 type Result struct {
-	Required    int
-	Available   int
-	HasCapacity bool
-	Description string
+	Required      int
+	Available     int
+	IsProvisioned bool
+	HasCapacity   bool
+	Description   string
 }
 
 // CheckQuotas will run through the checks and return an error if quotas are too small
@@ -24,6 +25,10 @@ func CheckQuotas(checks ...Checker) error {
 		r, err := check.CheckAvailability()
 		if err != nil {
 			return err
+		}
+
+		if r.IsProvisioned {
+			continue
 		}
 
 		if !r.HasCapacity {

--- a/pkg/servicequota/checker_test.go
+++ b/pkg/servicequota/checker_test.go
@@ -1,0 +1,96 @@
+package servicequota_test
+
+import (
+	"testing"
+
+	"github.com/oslokommune/okctl/pkg/mock"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oslokommune/okctl/pkg/servicequota"
+)
+
+func TestCheckQuotas(t *testing.T) {
+	testCases := []struct {
+		name      string
+		checks    []servicequota.Checker
+		expect    interface{}
+		expectErr bool
+	}{
+		{
+			name: "EIP check valid",
+			checks: []servicequota.Checker{
+				servicequota.NewEipCheck(false, 1, mock.NewGoodCloudProvider()),
+			},
+		},
+		{
+			name: "EIP check no more available",
+			checks: []servicequota.Checker{
+				servicequota.NewEipCheck(false, 5, mock.NewGoodCloudProvider()),
+			},
+			expect:    "AWS VPC Elastic IPs: required 5, but only have 2 available",
+			expectErr: true,
+		},
+		{
+			name: "EIP check is provisioned",
+			checks: []servicequota.Checker{
+				servicequota.NewEipCheck(true, 5, mock.NewGoodCloudProvider()),
+			},
+		},
+		{
+			name: "VPC check valid",
+			checks: []servicequota.Checker{
+				servicequota.NewVpcCheck(false, 1, mock.NewGoodCloudProvider()),
+			},
+		},
+		{
+			name: "VPC check no more available",
+			checks: []servicequota.Checker{
+				servicequota.NewVpcCheck(false, 5, mock.NewGoodCloudProvider()),
+			},
+			expect:    "AWS VPCs: required 5, but only have 2 available",
+			expectErr: true,
+		},
+		{
+			name: "VPC check is provisioned",
+			checks: []servicequota.Checker{
+				servicequota.NewVpcCheck(true, 5, mock.NewGoodCloudProvider()),
+			},
+		},
+		{
+			name: "IGW check valid",
+			checks: []servicequota.Checker{
+				servicequota.NewIgwCheck(false, 1, mock.NewGoodCloudProvider()),
+			},
+		},
+		{
+			name: "IGW check no more available",
+			checks: []servicequota.Checker{
+				servicequota.NewIgwCheck(false, 5, mock.NewGoodCloudProvider()),
+			},
+			expect:    "AWS VPC Internet Gateways: required 5, but only have 2 available",
+			expectErr: true,
+		},
+		{
+			name: "IGW check is provisioned",
+			checks: []servicequota.Checker{
+				servicequota.NewIgwCheck(true, 5, mock.NewGoodCloudProvider()),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			err := servicequota.CheckQuotas(tc.checks...)
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expect, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/servicequota/checker_test.go
+++ b/pkg/servicequota/checker_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/oslokommune/okctl/pkg/servicequota"
 )
 
+// nolint: funlen
 func TestCheckQuotas(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/pkg/servicequota/eipcheck.go
+++ b/pkg/servicequota/eipcheck.go
@@ -10,20 +10,28 @@ import (
 
 // EipCheck is used to check if you have enough Elastic Ips
 type EipCheck struct {
-	provider v1alpha1.CloudProvider
-	required int
+	provider      v1alpha1.CloudProvider
+	required      int
+	isProvisioned bool
 }
 
 // NewEipCheck makes a new instance of check for Elastic Ips
-func NewEipCheck(required int, provider v1alpha1.CloudProvider) *EipCheck {
+func NewEipCheck(isProvisioned bool, required int, provider v1alpha1.CloudProvider) *EipCheck {
 	return &EipCheck{
-		provider: provider,
-		required: required,
+		provider:      provider,
+		required:      required,
+		isProvisioned: isProvisioned,
 	}
 }
 
 // CheckAvailability determines if you will be able to make required Elastic Ip(s)
 func (e *EipCheck) CheckAvailability() (*Result, error) {
+	if e.isProvisioned {
+		return &Result{
+			IsProvisioned: true,
+		}, nil
+	}
+
 	q, err := e.provider.ServiceQuotas().GetServiceQuota(&servicequotas.GetServiceQuotaInput{
 		QuotaCode:   aws.String("L-0263D0A3"),
 		ServiceCode: aws.String("ec2"),

--- a/pkg/servicequota/igwcheck.go
+++ b/pkg/servicequota/igwcheck.go
@@ -10,20 +10,28 @@ import (
 
 // IgwCheck is used to check if you have enough Internet Gateways
 type IgwCheck struct {
-	provider v1alpha1.CloudProvider
-	required int
+	provider      v1alpha1.CloudProvider
+	required      int
+	isProvisioned bool
 }
 
 // NewIgwCheck makes a new instance of check for Internet Gateways
-func NewIgwCheck(required int, provider v1alpha1.CloudProvider) *IgwCheck {
+func NewIgwCheck(isProvisioned bool, required int, provider v1alpha1.CloudProvider) *IgwCheck {
 	return &IgwCheck{
-		provider: provider,
-		required: required,
+		provider:      provider,
+		required:      required,
+		isProvisioned: isProvisioned,
 	}
 }
 
 // CheckAvailability determines if you will be able to make required Internet Gateway(s)
 func (i *IgwCheck) CheckAvailability() (*Result, error) {
+	if i.isProvisioned {
+		return &Result{
+			IsProvisioned: true,
+		}, nil
+	}
+
 	quotas, err := i.provider.ServiceQuotas().GetServiceQuota(&servicequotas.GetServiceQuotaInput{
 		QuotaCode:   aws.String("L-A4707A72"),
 		ServiceCode: aws.String("vpc"),

--- a/pkg/servicequota/igwcheck.go
+++ b/pkg/servicequota/igwcheck.go
@@ -2,59 +2,49 @@ package servicequota
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
-	"github.com/logrusorgru/aurora"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 )
 
-// IgwCheck is used to check if you have enough Internet Gatweays
+// IgwCheck is used to check if you have enough Internet Gateways
 type IgwCheck struct {
-	Out           io.Writer
-	CloudProvider v1alpha1.CloudProvider
-	Required      int
+	provider v1alpha1.CloudProvider
+	required int
 }
 
 // NewIgwCheck makes a new instance of check for Internet Gateways
-func NewIgwCheck(out io.Writer, provider v1alpha1.CloudProvider, required int) *IgwCheck {
-	return &IgwCheck{Out: out, CloudProvider: provider, Required: required}
+func NewIgwCheck(required int, provider v1alpha1.CloudProvider) *IgwCheck {
+	return &IgwCheck{
+		provider: provider,
+		required: required,
+	}
 }
 
-// CheckAvailability determines if you will be able to make required Internet Gatweay(s)
-func (i *IgwCheck) CheckAvailability() error {
-	quotas, err := i.CloudProvider.ServiceQuotas().GetServiceQuota(&servicequotas.GetServiceQuotaInput{
+// CheckAvailability determines if you will be able to make required Internet Gateway(s)
+func (i *IgwCheck) CheckAvailability() (*Result, error) {
+	quotas, err := i.provider.ServiceQuotas().GetServiceQuota(&servicequotas.GetServiceQuotaInput{
 		QuotaCode:   aws.String("L-A4707A72"),
 		ServiceCode: aws.String("vpc"),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get igw quota: %w", err)
+		return nil, fmt.Errorf("getting igw quota: %w", err)
 	}
 
-	quotaValue := int(*quotas.Quota.Value)
-
-	igws, err := i.CloudProvider.EC2().DescribeInternetGateways(nil)
+	igws, err := i.provider.EC2().DescribeInternetGateways(nil)
 	if err != nil {
-		return fmt.Errorf("failed to get igw count: %w", err)
+		return nil, fmt.Errorf("getting current igw count: %w", err)
 	}
 
-	currentCount := len(igws.InternetGateways)
+	quota := int(*quotas.Quota.Value)
+	count := len(igws.InternetGateways)
+	available := quota - count
 
-	avail := quotaValue - currentCount
-
-	fmt.Fprintf(i.Out,
-		"You have %d IGWs, and the quota for %s is %d,\n%d are available and you need %d",
-		currentCount, i.CloudProvider.Region(), quotaValue, avail, i.Required)
-
-	if avail < i.Required {
-		fmt.Fprintln(i.Out, aurora.Red(" ❌"))
-		fmt.Fprintln(i.Out, "You need a internet gateway to enable traffic from outside AWS.")
-
-		return fmt.Errorf("not enough IGWs available")
-	}
-
-	fmt.Fprintln(i.Out, aurora.Green(" ✔"))
-
-	return nil
+	return &Result{
+		Required:    i.required,
+		Available:   available,
+		HasCapacity: i.required <= available,
+		Description: "AWS VPC Internet Gateways",
+	}, nil
 }

--- a/pkg/servicequota/vpccheck.go
+++ b/pkg/servicequota/vpccheck.go
@@ -2,59 +2,49 @@ package servicequota
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
-	"github.com/logrusorgru/aurora"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 )
 
 // VpcCheck is used to check if you have enough vpcs
 type VpcCheck struct {
-	Out           io.Writer
-	CloudProvider v1alpha1.CloudProvider
-	Required      int
+	provider v1alpha1.CloudProvider
+	required int
 }
 
 // NewVpcCheck make a new instance of check for VPCs
-func NewVpcCheck(out io.Writer, provider v1alpha1.CloudProvider, required int) *VpcCheck {
-	return &VpcCheck{Out: out, CloudProvider: provider, Required: required}
+func NewVpcCheck(required int, provider v1alpha1.CloudProvider) *VpcCheck {
+	return &VpcCheck{
+		provider: provider,
+		required: required,
+	}
 }
 
 // CheckAvailability determines if you will be able to make required Virtual Private Cloud(s)
-func (v *VpcCheck) CheckAvailability() error {
-	quota, err := v.CloudProvider.ServiceQuotas().GetServiceQuota(&servicequotas.GetServiceQuotaInput{
+func (v *VpcCheck) CheckAvailability() (*Result, error) {
+	q, err := v.provider.ServiceQuotas().GetServiceQuota(&servicequotas.GetServiceQuotaInput{
 		QuotaCode:   aws.String("L-F678F1CE"),
 		ServiceCode: aws.String("vpc"),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get vpc quota: %w", err)
+		return nil, fmt.Errorf("getting vpc quota: %w", err)
 	}
 
-	quotaValue := int(*quota.Quota.Value)
-
-	vpcs, err := v.CloudProvider.EC2().DescribeVpcs(nil)
+	vpcs, err := v.provider.EC2().DescribeVpcs(nil)
 	if err != nil {
-		return fmt.Errorf("failed to get vpc count: %w", err)
+		return nil, fmt.Errorf("getting current vpc count: %w", err)
 	}
 
-	currentCount := len(vpcs.Vpcs)
+	quota := int(*q.Quota.Value)
+	count := len(vpcs.Vpcs)
+	available := quota - count
 
-	avail := quotaValue - currentCount
-
-	fmt.Fprintf(v.Out,
-		"You have %d VPCs, and the quota for %s is %d,\n%d are available and you need %d",
-		currentCount, v.CloudProvider.Region(), quotaValue, avail, v.Required)
-
-	if avail < v.Required {
-		fmt.Println(aurora.Red(" ❌"))
-		fmt.Println("You need a VPC to put your cluster in")
-
-		return fmt.Errorf("not enough VPCs available")
-	}
-
-	fmt.Fprintln(v.Out, aurora.Green(" ✔"))
-
-	return nil
+	return &Result{
+		Required:    v.required,
+		Available:   available,
+		HasCapacity: v.required <= available,
+		Description: "AWS VPCs",
+	}, nil
 }

--- a/pkg/servicequota/vpccheck.go
+++ b/pkg/servicequota/vpccheck.go
@@ -10,20 +10,28 @@ import (
 
 // VpcCheck is used to check if you have enough vpcs
 type VpcCheck struct {
-	provider v1alpha1.CloudProvider
-	required int
+	provider      v1alpha1.CloudProvider
+	required      int
+	isProvisioned bool
 }
 
 // NewVpcCheck make a new instance of check for VPCs
-func NewVpcCheck(required int, provider v1alpha1.CloudProvider) *VpcCheck {
+func NewVpcCheck(isProvisioned bool, required int, provider v1alpha1.CloudProvider) *VpcCheck {
 	return &VpcCheck{
-		provider: provider,
-		required: required,
+		provider:      provider,
+		required:      required,
+		isProvisioned: isProvisioned,
 	}
 }
 
 // CheckAvailability determines if you will be able to make required Virtual Private Cloud(s)
 func (v *VpcCheck) CheckAvailability() (*Result, error) {
+	if v.isProvisioned {
+		return &Result{
+			IsProvisioned: true,
+		}, nil
+	}
+
 	q, err := v.provider.ServiceQuotas().GetServiceQuota(&servicequotas.GetServiceQuotaInput{
 		QuotaCode:   aws.String("L-F678F1CE"),
 		ServiceCode: aws.String("vpc"),


### PR DESCRIPTION
Service quotas should ignore resources that are already provisioned 

## Description
If a cluster has already provisioned a VPC for itself, we should not write an error message to the user. The logic has also been rewritten so that we only write the status to the user if there are insufficient quotas available.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
