### PR TITLE
[KM27] Add cluster autoscaler to Kubernetes cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ We have a basic cluster up and running, and we are currently working on getting 
 - [x] [ExternalSecrets](https://external-secrets.github.io/kubernetes-external-secrets/) for storing secrets securely
 - [x] [AWS ALB Ingress Controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) creates load balancers for incoming traffic
 - [x] [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) ensures humane DNS hostnames 
-- [ ] [Autoscaler](https://github.com/kubernetes/autoscaler/) for adjusting the size of pods and nodes
+- [x] [Autoscaler](https://github.com/kubernetes/autoscaler/) for adjusting the size of pods and nodes
 - [x] [Argo CD](https://github.com/argoproj/argo-cd) gives us continuous delivery
 - [ ] [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) for monitoring
 - [ ] [Amazon Elastic Block Store (EBS) CSI driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/) for block storage

--- a/cmd/okctl/applycluster.go
+++ b/cmd/okctl/applycluster.go
@@ -133,6 +133,7 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 			reconciliationManager.AddReconciler(resourcetree.ResourceNodeTypeVPC, reconciler.NewVPCReconciler(services.Vpc))
 			reconciliationManager.AddReconciler(resourcetree.ResourceNodeTypeCluster, reconciler.NewClusterReconciler(services.Cluster))
 			reconciliationManager.AddReconciler(resourcetree.ResourceNodeTypeExternalSecrets, reconciler.NewExternalSecretsReconciler(services.ExternalSecrets))
+			reconciliationManager.AddReconciler(resourcetree.ResourceNodeTypeAutoscaler, reconciler.NewAutoscalerReconciler(services.Autoscaler))
 			reconciliationManager.AddReconciler(resourcetree.ResourceNodeTypeALBIngress, reconciler.NewALBIngressReconciler(services.ALBIngressController))
 			reconciliationManager.AddReconciler(resourcetree.ResourceNodeTypeAWSLoadBalancerController, reconciler.NewAWSLoadBalancerControllerReconciler(services.AWSLoadBalancerControllerService))
 			reconciliationManager.AddReconciler(resourcetree.ResourceNodeTypeExternalDNS, reconciler.NewExternalDNSReconciler(services.ExternalDNS))

--- a/cmd/okctl/create.go
+++ b/cmd/okctl/create.go
@@ -361,6 +361,13 @@ and database subnets.`,
 				return formatErr(err)
 			}
 
+			_, err = services.Autoscaler.CreateAutoscaler(o.Ctx, client.CreateAutoscalerOpts{
+				ID: id,
+			})
+			if err != nil {
+				return formatErr(err)
+			}
+
 			_, err = services.ExternalSecrets.CreateExternalSecrets(o.Ctx, client.CreateExternalSecretsOpts{
 				ID: id,
 			})

--- a/cmd/okctl/createtestcluster.go
+++ b/cmd/okctl/createtestcluster.go
@@ -289,6 +289,13 @@ with Github or other production services.
 				return formatErr(err)
 			}
 
+			_, err = services.Autoscaler.CreateAutoscaler(o.Ctx, client.CreateAutoscalerOpts{
+				ID: id,
+			})
+			if err != nil {
+				return formatErr(err)
+			}
+
 			_, err = services.ExternalSecrets.CreateExternalSecrets(o.Ctx, client.CreateExternalSecretsOpts{
 				ID: id,
 			})

--- a/cmd/okctl/delete.go
+++ b/cmd/okctl/delete.go
@@ -174,6 +174,11 @@ including VPC, this is a highly destructive operation.`,
 				return formatErr(err)
 			}
 
+			err = services.Autoscaler.DeleteAutoscaler(o.Ctx, id)
+			if err != nil {
+				return formatErr(err)
+			}
+
 			err = cleanup.DeleteDanglingALBs(o.CloudProvider, vpc.VpcID)
 			if err != nil {
 				return formatErr(err)

--- a/cmd/okctl/deletetestcluster.go
+++ b/cmd/okctl/deletetestcluster.go
@@ -166,6 +166,11 @@ $ kubectl get service --all-namespaces
 				return formatErr(err)
 			}
 
+			err = services.Autoscaler.DeleteAutoscaler(o.Ctx, id)
+			if err != nil {
+				return formatErr(err)
+			}
+
 			err = services.Cluster.DeleteCluster(o.Ctx, api.ClusterDeleteOpts{
 				ID:                 id,
 				FargateProfileName: "fp-default",

--- a/pkg/api/core/cloudprovider/aws/managedpolicy_aws.go
+++ b/pkg/api/core/cloudprovider/aws/managedpolicy_aws.go
@@ -14,6 +14,10 @@ type managedPolicy struct {
 	provider v1alpha1.CloudProvider
 }
 
+func (m *managedPolicy) DeleteAutoscalerPolicy(id api.ID) error {
+	return m.deletePolicy(cfn.NewStackNamer().AutoscalerPolicy(id.Repository, id.Environment))
+}
+
 func (m *managedPolicy) DeleteExternalSecretsPolicy(id api.ID) error {
 	return m.deletePolicy(cfn.NewStackNamer().ExternalSecretsPolicy(id.Repository, id.Environment))
 }
@@ -39,6 +43,17 @@ func (m *managedPolicy) deletePolicy(stackName string) error {
 	}
 
 	return nil
+}
+
+func (m *managedPolicy) CreateAutoscalerPolicy(opts api.CreateAutoscalerPolicy) (*api.ManagedPolicy, error) {
+	b := cfn.New(
+		components.NewAutoscalerPolicyComposer(opts.ID.Repository, opts.ID.Environment),
+	)
+
+	stackName := cfn.NewStackNamer().
+		AutoscalerPolicy(opts.ID.Repository, opts.ID.Environment)
+
+	return m.createPolicy(stackName, opts.ID, "AutoscalerPolicy", b)
 }
 
 func (m *managedPolicy) CreateExternalDNSPolicy(opts api.CreateExternalDNSPolicyOpts) (*api.ManagedPolicy, error) {

--- a/pkg/api/core/endpoint_helm.go
+++ b/pkg/api/core/endpoint_helm.go
@@ -30,3 +30,9 @@ func makeCreateArgoCD(s api.HelmService) endpoint.Endpoint {
 		return s.CreateArgoCD(ctx, request.(api.CreateArgoCDOpts))
 	}
 }
+
+func makeCreateAutoscalerHelmtChartEndpoint(s api.HelmService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return s.CreateAutoscalerHelmChart(ctx, request.(api.CreateAutoscalerHelmChartOpts))
+	}
+}

--- a/pkg/api/core/endpoint_managedpolicy.go
+++ b/pkg/api/core/endpoint_managedpolicy.go
@@ -1,4 +1,4 @@
-package core
+package core // nolint: dupl
 
 import (
 	"context"

--- a/pkg/api/core/endpoint_managedpolicy.go
+++ b/pkg/api/core/endpoint_managedpolicy.go
@@ -54,3 +54,15 @@ func makeDeleteExternalDNSPolicyEndpoint(s api.ManagedPolicyService) endpoint.En
 		return &Empty{}, s.DeleteExternalDNSPolicy(ctx, request.(api.ID))
 	}
 }
+
+func makeCreateAutoscalerPolicyEndpoint(s api.ManagedPolicyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return s.CreateAutoscalerPolicy(ctx, request.(api.CreateAutoscalerPolicy))
+	}
+}
+
+func makeDeleteAutoscalerPolicyEndpoint(s api.ManagedPolicyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return &Empty{}, s.DeleteAutoscalerPolicy(ctx, request.(api.ID))
+	}
+}

--- a/pkg/api/core/endpoint_serviceaccount.go
+++ b/pkg/api/core/endpoint_serviceaccount.go
@@ -54,3 +54,15 @@ func makeDeleteExternalDNSServiceAccountEndpoint(s api.ServiceAccountService) en
 		return &Empty{}, s.DeleteExternalDNSServiceAccount(ctx, request.(api.ID))
 	}
 }
+
+func makeCreateAutoscalerServiceAccountEndpoint(s api.ServiceAccountService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return s.CreateAutoscalerServiceAccount(ctx, request.(api.CreateAutoscalerServiceAccountOpts))
+	}
+}
+
+func makeDeleteAutoscalerServiceAccountEndpoint(s api.ServiceAccountService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return &Empty{}, s.DeleteAutoscalerServiceAccount(ctx, request.(api.ID))
+	}
+}

--- a/pkg/api/core/endpoint_serviceaccount.go
+++ b/pkg/api/core/endpoint_serviceaccount.go
@@ -1,4 +1,4 @@
-package core
+package core // nolint: dupl
 
 import (
 	"context"

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -56,6 +56,8 @@ type Endpoints struct {
 	DeleteNamespace                               endpoint.Endpoint
 	DeleteCognitoCertificate                      endpoint.Endpoint
 	CreateAutoscalerHelmChart                     endpoint.Endpoint
+	CreateAutoscalerServiceAccount                endpoint.Endpoint
+	DeleteAutoscalerServiceAccount                endpoint.Endpoint
 }
 
 // MakeEndpoints returns the endpoints initialised with their
@@ -102,6 +104,8 @@ func MakeEndpoints(s Services) Endpoints {
 		DeleteNamespace:                               makeDeleteNamespaceEndpoint(s.Kube),
 		DeleteCognitoCertificate:                      makeDeleteCognitoCertificateEndpoint(s.Certificate),
 		CreateAutoscalerHelmChart:                     makeCreateAutoscalerHelmtChartEndpoint(s.Helm),
+		CreateAutoscalerServiceAccount:                makeCreateAutoscalerServiceAccountEndpoint(s.ServiceAccount),
+		DeleteAutoscalerServiceAccount:                makeDeleteAutoscalerServiceAccountEndpoint(s.ServiceAccount),
 	}
 }
 
@@ -147,6 +151,8 @@ type Handlers struct {
 	DeleteNamespace                               http.Handler
 	DeleteCognitoCertificate                      http.Handler
 	CreateAutoscalerHelmChart                     http.Handler
+	CreateAutoscalerServiceAccount                http.Handler
+	DeleteAutoscalerServiceAccount                http.Handler
 }
 
 // EncodeResponseType defines a type for responses
@@ -219,6 +225,8 @@ func MakeHandlers(responseType EncodeResponseType, endpoints Endpoints) *Handler
 		DeleteNamespace:                               newServer(endpoints.DeleteNamespace, decodeDeleteNamespace),
 		DeleteCognitoCertificate:                      newServer(endpoints.DeleteCognitoCertificate, decodeDeleteCognitoCertificate),
 		CreateAutoscalerHelmChart:                     newServer(endpoints.CreateAutoscalerHelmChart, decodeCreateAutoscalerHelmChart),
+		CreateAutoscalerServiceAccount:                newServer(endpoints.CreateAutoscalerServiceAccount, decodeCreateAutoscalerServiceAccount),
+		DeleteAutoscalerServiceAccount:                newServer(endpoints.DeleteAutoscalerServiceAccount, decodeIDRequest),
 	}
 }
 
@@ -270,6 +278,10 @@ func AttachRoutes(handlers *Handlers) http.Handler {
 			r.Route("/externaldns", func(r chi.Router) {
 				r.Method(http.MethodPost, "/", handlers.CreateExternalDNSServiceAccount)
 				r.Method(http.MethodDelete, "/", handlers.DeleteExternalDNSServiceAccount)
+			})
+			r.Route("/autoscaler", func(r chi.Router) {
+				r.Method(http.MethodPost, "/", handlers.CreateAutoscalerServiceAccount)
+				r.Method(http.MethodDelete, "/", handlers.DeleteAutoscalerServiceAccount)
 			})
 		})
 		r.Route("/helm", func(r chi.Router) {
@@ -426,6 +438,8 @@ func InstrumentEndpoints(logger *logrus.Logger) EndpointOption {
 			DeleteNamespace:                               logmd.Logging(logger, strings.Join([]string{kubeTag, namespaceTag}, "/"), "delete")(endpoints.DeleteNamespace),
 			DeleteCognitoCertificate:                      logmd.Logging(logger, strings.Join([]string{certificateTag, cognitoTag}, "/"), "delete")(endpoints.DeleteCognitoCertificate),
 			CreateAutoscalerHelmChart:                     logmd.Logging(logger, strings.Join([]string{helmTag, autoscalerTag}, "/"), "create")(endpoints.CreateAutoscalerHelmChart),
+			CreateAutoscalerServiceAccount:                logmd.Logging(logger, strings.Join([]string{serviceAccountsTag, autoscalerTag}, "/"), "create")(endpoints.CreateAutoscalerServiceAccount),
+			DeleteAutoscalerServiceAccount:                logmd.Logging(logger, strings.Join([]string{serviceAccountsTag, autoscalerTag}, "/"), "delete")(endpoints.DeleteAutoscalerServiceAccount),
 		}
 	}
 }

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -174,6 +174,7 @@ const (
 )
 
 // MakeHandlers returns all handlers initialised with encoders, decoders, etc
+// nolint: funlen
 func MakeHandlers(responseType EncodeResponseType, endpoints Endpoints) *Handlers {
 	var encoderFn kit.EncodeResponseFunc
 

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -58,6 +58,8 @@ type Endpoints struct {
 	CreateAutoscalerHelmChart                     endpoint.Endpoint
 	CreateAutoscalerServiceAccount                endpoint.Endpoint
 	DeleteAutoscalerServiceAccount                endpoint.Endpoint
+	CreateAutoscalerPolicy                        endpoint.Endpoint
+	DeleteAutoscalerPolicy                        endpoint.Endpoint
 }
 
 // MakeEndpoints returns the endpoints initialised with their
@@ -106,6 +108,8 @@ func MakeEndpoints(s Services) Endpoints {
 		CreateAutoscalerHelmChart:                     makeCreateAutoscalerHelmtChartEndpoint(s.Helm),
 		CreateAutoscalerServiceAccount:                makeCreateAutoscalerServiceAccountEndpoint(s.ServiceAccount),
 		DeleteAutoscalerServiceAccount:                makeDeleteAutoscalerServiceAccountEndpoint(s.ServiceAccount),
+		CreateAutoscalerPolicy:                        makeCreateAutoscalerPolicyEndpoint(s.ManagedPolicy),
+		DeleteAutoscalerPolicy:                        makeDeleteAutoscalerPolicyEndpoint(s.ManagedPolicy),
 	}
 }
 
@@ -153,6 +157,8 @@ type Handlers struct {
 	CreateAutoscalerHelmChart                     http.Handler
 	CreateAutoscalerServiceAccount                http.Handler
 	DeleteAutoscalerServiceAccount                http.Handler
+	CreateAutoscalerPolicy                        http.Handler
+	DeleteAutoscalerPolicy                        http.Handler
 }
 
 // EncodeResponseType defines a type for responses
@@ -227,6 +233,8 @@ func MakeHandlers(responseType EncodeResponseType, endpoints Endpoints) *Handler
 		CreateAutoscalerHelmChart:                     newServer(endpoints.CreateAutoscalerHelmChart, decodeCreateAutoscalerHelmChart),
 		CreateAutoscalerServiceAccount:                newServer(endpoints.CreateAutoscalerServiceAccount, decodeCreateAutoscalerServiceAccount),
 		DeleteAutoscalerServiceAccount:                newServer(endpoints.DeleteAutoscalerServiceAccount, decodeIDRequest),
+		CreateAutoscalerPolicy:                        newServer(endpoints.CreateAutoscalerPolicy, decodeCreateAutoscalerPolicy),
+		DeleteAutoscalerPolicy:                        newServer(endpoints.DeleteAutoscalerPolicy, decodeIDRequest),
 	}
 }
 
@@ -260,6 +268,10 @@ func AttachRoutes(handlers *Handlers) http.Handler {
 			r.Route("/externaldns", func(r chi.Router) {
 				r.Method(http.MethodPost, "/", handlers.CreateExternalDNSPolicy)
 				r.Method(http.MethodDelete, "/", handlers.DeleteExternalDNSPolicy)
+			})
+			r.Route("/autoscaler", func(r chi.Router) {
+				r.Method(http.MethodPost, "/", handlers.CreateAutoscalerPolicy)
+				r.Method(http.MethodDelete, "/", handlers.DeleteAutoscalerPolicy)
 			})
 		})
 		r.Route("/serviceaccounts", func(r chi.Router) {
@@ -440,6 +452,8 @@ func InstrumentEndpoints(logger *logrus.Logger) EndpointOption {
 			CreateAutoscalerHelmChart:                     logmd.Logging(logger, strings.Join([]string{helmTag, autoscalerTag}, "/"), "create")(endpoints.CreateAutoscalerHelmChart),
 			CreateAutoscalerServiceAccount:                logmd.Logging(logger, strings.Join([]string{serviceAccountsTag, autoscalerTag}, "/"), "create")(endpoints.CreateAutoscalerServiceAccount),
 			DeleteAutoscalerServiceAccount:                logmd.Logging(logger, strings.Join([]string{serviceAccountsTag, autoscalerTag}, "/"), "delete")(endpoints.DeleteAutoscalerServiceAccount),
+			CreateAutoscalerPolicy:                        logmd.Logging(logger, strings.Join([]string{managedPoliciesTag, autoscalerTag}, "/"), "create")(endpoints.CreateAutoscalerPolicy),
+			DeleteAutoscalerPolicy:                        logmd.Logging(logger, strings.Join([]string{managedPoliciesTag, autoscalerTag}, "/"), "delete")(endpoints.DeleteAutoscalerPolicy),
 		}
 	}
 }

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -55,6 +55,7 @@ type Endpoints struct {
 	DeleteCertificate                             endpoint.Endpoint
 	DeleteNamespace                               endpoint.Endpoint
 	DeleteCognitoCertificate                      endpoint.Endpoint
+	CreateAutoscalerHelmChart                     endpoint.Endpoint
 }
 
 // MakeEndpoints returns the endpoints initialised with their
@@ -100,6 +101,7 @@ func MakeEndpoints(s Services) Endpoints {
 		DeleteCertificate:                             makeDeleteCertificateEndpoint(s.Certificate),
 		DeleteNamespace:                               makeDeleteNamespaceEndpoint(s.Kube),
 		DeleteCognitoCertificate:                      makeDeleteCognitoCertificateEndpoint(s.Certificate),
+		CreateAutoscalerHelmChart:                     makeCreateAutoscalerHelmtChartEndpoint(s.Helm),
 	}
 }
 
@@ -144,6 +146,7 @@ type Handlers struct {
 	DeleteCertificate                             http.Handler
 	DeleteNamespace                               http.Handler
 	DeleteCognitoCertificate                      http.Handler
+	CreateAutoscalerHelmChart                     http.Handler
 }
 
 // EncodeResponseType defines a type for responses
@@ -215,6 +218,7 @@ func MakeHandlers(responseType EncodeResponseType, endpoints Endpoints) *Handler
 		DeleteCertificate:                             newServer(endpoints.DeleteCertificate, decodeDeleteCertificate),
 		DeleteNamespace:                               newServer(endpoints.DeleteNamespace, decodeDeleteNamespace),
 		DeleteCognitoCertificate:                      newServer(endpoints.DeleteCognitoCertificate, decodeDeleteCognitoCertificate),
+		CreateAutoscalerHelmChart:                     newServer(endpoints.CreateAutoscalerHelmChart, decodeCreateAutoscalerHelmChart),
 	}
 }
 
@@ -280,6 +284,9 @@ func AttachRoutes(handlers *Handlers) http.Handler {
 			})
 			r.Route("/argocd", func(r chi.Router) {
 				r.Method(http.MethodPost, "/", handlers.CreateArgoCD)
+			})
+			r.Route("/autoscaler", func(r chi.Router) {
+				r.Method(http.MethodPost, "/", handlers.CreateAutoscalerHelmChart)
 			})
 		})
 		r.Route("/kube", func(r chi.Router) {
@@ -371,6 +378,7 @@ const (
 	identityPoolUserTag          = "identitypooluser"
 	namespaceTag                 = "namespace"
 	cognitoTag                   = "cognito"
+	autoscalerTag                = "autoscaler"
 )
 
 // InstrumentEndpoints adds instrumentation to the endpoints
@@ -417,6 +425,7 @@ func InstrumentEndpoints(logger *logrus.Logger) EndpointOption {
 			DeleteCertificate:                             logmd.Logging(logger, certificateTag, "delete")(endpoints.DeleteCertificate),
 			DeleteNamespace:                               logmd.Logging(logger, strings.Join([]string{kubeTag, namespaceTag}, "/"), "delete")(endpoints.DeleteNamespace),
 			DeleteCognitoCertificate:                      logmd.Logging(logger, strings.Join([]string{certificateTag, cognitoTag}, "/"), "delete")(endpoints.DeleteCognitoCertificate),
+			CreateAutoscalerHelmChart:                     logmd.Logging(logger, strings.Join([]string{helmTag, autoscalerTag}, "/"), "create")(endpoints.CreateAutoscalerHelmChart),
 		}
 	}
 }

--- a/pkg/api/core/run/helm_run.go
+++ b/pkg/api/core/run/helm_run.go
@@ -3,6 +3,8 @@ package run
 import (
 	"fmt"
 
+	"github.com/oslokommune/okctl/pkg/helm/charts/autoscaler"
+
 	"github.com/oslokommune/okctl/pkg/helm/charts/awslbc"
 
 	"github.com/oslokommune/okctl/pkg/helm/charts/argocd"
@@ -16,6 +18,12 @@ import (
 type helmRun struct {
 	helm            helm.Helmer
 	kubeConfigStore api.KubeConfigStore
+}
+
+func (r *helmRun) CreateAutoscalerHelmChart(opts api.CreateAutoscalerHelmChartOpts) (*api.Helm, error) {
+	chart := autoscaler.New(autoscaler.NewDefaultValues(opts.ID.Region, opts.ID.ClusterName, "autoscaler"))
+
+	return r.createHelmChart(opts.ID, chart)
 }
 
 func (r *helmRun) CreateArgoCD(opts api.CreateArgoCDOpts) (*api.Helm, error) {

--- a/pkg/api/core/service_helm.go
+++ b/pkg/api/core/service_helm.go
@@ -13,20 +13,34 @@ type helmService struct {
 	store api.HelmStore
 }
 
+func (s *helmService) CreateAutoscalerHelmChart(_ context.Context, opts api.CreateAutoscalerHelmChartOpts) (*api.Helm, error) {
+	err := opts.Validate()
+	if err != nil {
+		return nil, errors.E(err, "validating input options")
+	}
+
+	h, err := s.run.CreateAutoscalerHelmChart(opts)
+	if err != nil {
+		return nil, errors.E(err, "creating autoscaler helm chart", errors.Internal)
+	}
+
+	return h, nil
+}
+
 func (s *helmService) CreateArgoCD(_ context.Context, opts api.CreateArgoCDOpts) (*api.Helm, error) {
 	err := opts.Validate()
 	if err != nil {
-		return nil, errors.E(err, "failed to validate input options")
+		return nil, errors.E(err, "validating input options")
 	}
 
 	h, err := s.run.CreateArgoCD(opts)
 	if err != nil {
-		return nil, errors.E(err, "failed to create argocd helm chart")
+		return nil, errors.E(err, "creating argocd helm chart")
 	}
 
 	err = s.store.SaveArgoCD(h)
 	if err != nil {
-		return nil, errors.E(err, "failed to store argocd helm chart")
+		return nil, errors.E(err, "storing argocd helm chart")
 	}
 
 	return h, nil

--- a/pkg/api/core/service_managedpolicy.go
+++ b/pkg/api/core/service_managedpolicy.go
@@ -11,6 +11,34 @@ type managedPolicyService struct {
 	provider api.ManagedPolicyCloudProvider
 }
 
+func (m *managedPolicyService) CreateAutoscalerPolicy(_ context.Context, opts api.CreateAutoscalerPolicy) (*api.ManagedPolicy, error) {
+	err := opts.Validate()
+	if err != nil {
+		return nil, errors.E(err, "validating inputs", errors.Invalid)
+	}
+
+	got, err := m.provider.CreateAutoscalerPolicy(opts)
+	if err != nil {
+		return nil, errors.E(err, "creating autoscaler policy", errors.Internal)
+	}
+
+	return got, nil
+}
+
+func (m *managedPolicyService) DeleteAutoscalerPolicy(_ context.Context, id api.ID) error {
+	err := id.Validate()
+	if err != nil {
+		return errors.E(err, "validating inputs", errors.Invalid)
+	}
+
+	err = m.provider.DeleteAutoscalerPolicy(id)
+	if err != nil {
+		return errors.E(err, "deleting autoscaler policy", errors.Internal)
+	}
+
+	return nil
+}
+
 func (m *managedPolicyService) DeleteExternalSecretsPolicy(_ context.Context, id api.ID) error {
 	err := id.Validate()
 	if err != nil {

--- a/pkg/api/core/service_serviceaccount.go
+++ b/pkg/api/core/service_serviceaccount.go
@@ -32,6 +32,54 @@ var errBuildServiceAccount = func(err error) error {
 	return errors.E(err, "failed to build service account config", errors.Internal)
 }
 
+func (c *serviceAccount) CreateAutoscalerServiceAccount(_ context.Context, opts api.CreateAutoscalerServiceAccountOpts) (*api.ServiceAccount, error) {
+	err := opts.Validate()
+	if err != nil {
+		return nil, errInvalidInputs(err)
+	}
+
+	config, err := clusterconfig.NewAutoscalerServiceAccount(
+		opts.ID.ClusterName,
+		opts.ID.Region,
+		opts.PolicyArn,
+		v1alpha1.PermissionsBoundaryARN(opts.ID.AWSAccountID),
+	)
+	if err != nil {
+		return nil, errBuildServiceAccount(err)
+	}
+
+	account, err := c.createServiceAccount(opts.CreateServiceAccountOpts, config)
+	if err != nil {
+		return nil, errCreateServiceAccount(err)
+	}
+
+	return account, nil
+}
+
+func (c *serviceAccount) DeleteAutoscalerServiceAccount(_ context.Context, id api.ID) error {
+	err := id.Validate()
+	if err != nil {
+		return errInvalidInputs(err)
+	}
+
+	config, err := clusterconfig.NewAutoscalerServiceAccount(
+		id.ClusterName,
+		id.Region,
+		"n/a",
+		v1alpha1.PermissionsBoundaryARN(id.AWSAccountID),
+	)
+	if err != nil {
+		return errBuildServiceAccount(err)
+	}
+
+	err = c.run.DeleteServiceAccount(config)
+	if err != nil {
+		return errDeleteServiceAccount(err)
+	}
+
+	return nil
+}
+
 func (c *serviceAccount) DeleteExternalSecretsServiceAccount(_ context.Context, id api.ID) error {
 	err := id.Validate()
 	if err != nil {

--- a/pkg/api/core/transport_helm.go
+++ b/pkg/api/core/transport_helm.go
@@ -51,3 +51,14 @@ func decodeCreateArgoCD(_ context.Context, r *http.Request) (interface{}, error)
 
 	return opts, nil
 }
+
+func decodeCreateAutoscalerHelmChart(_ context.Context, r *http.Request) (interface{}, error) {
+	var opts api.CreateAutoscalerHelmChartOpts
+
+	err := json.NewDecoder(r.Body).Decode(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}

--- a/pkg/api/core/transport_managedpolicy.go
+++ b/pkg/api/core/transport_managedpolicy.go
@@ -51,3 +51,14 @@ func decodeCreateExternalDNSPolicyRequest(_ context.Context, r *http.Request) (i
 
 	return opts, nil
 }
+
+func decodeCreateAutoscalerPolicy(_ context.Context, r *http.Request) (interface{}, error) {
+	var opts api.CreateAutoscalerPolicy
+
+	err := json.NewDecoder(r.Body).Decode(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}

--- a/pkg/api/core/transport_serviceaccount.go
+++ b/pkg/api/core/transport_serviceaccount.go
@@ -51,3 +51,14 @@ func decodeCreateExternalDNSServiceAccount(_ context.Context, r *http.Request) (
 
 	return opts, nil
 }
+
+func decodeCreateAutoscalerServiceAccount(_ context.Context, r *http.Request) (interface{}, error) {
+	var opts api.CreateAutoscalerServiceAccountOpts
+
+	err := json.NewDecoder(r.Body).Decode(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}

--- a/pkg/api/helm_api.go
+++ b/pkg/api/helm_api.go
@@ -15,6 +15,18 @@ type Helm struct {
 	Chart   *helm.Chart
 }
 
+// CreateAutoscalerHelmChartOpts contains the required inputs
+type CreateAutoscalerHelmChartOpts struct {
+	ID ID
+}
+
+// Validate the inputs
+func (o CreateAutoscalerHelmChartOpts) Validate() error {
+	return validation.ValidateStruct(&o,
+		validation.Field(&o.ID, validation.Required),
+	)
+}
+
 // CreateExternalSecretsHelmChartOpts contains the data
 // required for creating a helm chart
 type CreateExternalSecretsHelmChartOpts struct {
@@ -98,6 +110,7 @@ type HelmService interface {
 	CreateAlbIngressControllerHelmChart(ctx context.Context, opts CreateAlbIngressControllerHelmChartOpts) (*Helm, error)
 	CreateAWSLoadBalancerControllerHelmChart(ctx context.Context, opts CreateAWSLoadBalancerControllerHelmChartOpts) (*Helm, error)
 	CreateArgoCD(ctx context.Context, opts CreateArgoCDOpts) (*Helm, error)
+	CreateAutoscalerHelmChart(ctx context.Context, opts CreateAutoscalerHelmChartOpts) (*Helm, error)
 }
 
 // HelmRun defines the runner layer
@@ -106,6 +119,7 @@ type HelmRun interface {
 	CreateAlbIngressControllerHelmChart(opts CreateAlbIngressControllerHelmChartOpts) (*Helm, error)
 	CreateAWSLoadBalancerControllerHelmChart(opts CreateAWSLoadBalancerControllerHelmChartOpts) (*Helm, error)
 	CreateArgoCD(opts CreateArgoCDOpts) (*Helm, error)
+	CreateAutoscalerHelmChart(opts CreateAutoscalerHelmChartOpts) (*Helm, error)
 }
 
 // HelmStore defines the storage layer

--- a/pkg/api/managedpolicy_api.go
+++ b/pkg/api/managedpolicy_api.go
@@ -68,6 +68,7 @@ type CreateAutoscalerPolicy struct {
 	ID ID
 }
 
+// Validate the inputs
 func (o CreateAutoscalerPolicy) Validate() error {
 	return validation.ValidateStruct(&o,
 		validation.Field(&o.ID, validation.Required),

--- a/pkg/api/managedpolicy_api.go
+++ b/pkg/api/managedpolicy_api.go
@@ -63,6 +63,17 @@ func (o CreateExternalDNSPolicyOpts) Validate() error {
 	)
 }
 
+// CreateAutoscalerPolicy contains all required inputs
+type CreateAutoscalerPolicy struct {
+	ID ID
+}
+
+func (o CreateAutoscalerPolicy) Validate() error {
+	return validation.ValidateStruct(&o,
+		validation.Field(&o.ID, validation.Required),
+	)
+}
+
 // ManagedPolicyService defines the service layer for managed policies
 type ManagedPolicyService interface {
 	CreateExternalSecretsPolicy(ctx context.Context, opts CreateExternalSecretsPolicyOpts) (*ManagedPolicy, error)
@@ -73,6 +84,8 @@ type ManagedPolicyService interface {
 	DeleteAWSLoadBalancerControllerPolicy(ctx context.Context, id ID) error
 	CreateExternalDNSPolicy(ctx context.Context, opts CreateExternalDNSPolicyOpts) (*ManagedPolicy, error)
 	DeleteExternalDNSPolicy(ctx context.Context, id ID) error
+	CreateAutoscalerPolicy(ctx context.Context, opts CreateAutoscalerPolicy) (*ManagedPolicy, error)
+	DeleteAutoscalerPolicy(ctx context.Context, id ID) error
 }
 
 // ManagedPolicyCloudProvider defines the cloud provider layer for managed policies
@@ -85,6 +98,8 @@ type ManagedPolicyCloudProvider interface {
 	DeleteAWSLoadBalancerControllerPolicy(id ID) error
 	CreateExternalDNSPolicy(opts CreateExternalDNSPolicyOpts) (*ManagedPolicy, error)
 	DeleteExternalDNSPolicy(id ID) error
+	CreateAutoscalerPolicy(opts CreateAutoscalerPolicy) (*ManagedPolicy, error)
+	DeleteAutoscalerPolicy(id ID) error
 }
 
 // ManagedPolicyStore defines the storage layer for managed policies

--- a/pkg/api/serviceaccount_api.go
+++ b/pkg/api/serviceaccount_api.go
@@ -73,6 +73,16 @@ func (o CreateExternalDNSServiceAccountOpts) Validate() error {
 	return o.ValidateStruct()
 }
 
+// CreateAutoscalerServiceAccountOpts contains the required inputs
+type CreateAutoscalerServiceAccountOpts struct {
+	CreateServiceAccountOpts
+}
+
+// Validate the inputs
+func (o CreateAutoscalerServiceAccountOpts) Validate() error {
+	return o.ValidateStruct()
+}
+
 // ServiceAccountService provides the interface for all service account operations
 type ServiceAccountService interface {
 	CreateExternalSecretsServiceAccount(context.Context, CreateExternalSecretsServiceAccountOpts) (*ServiceAccount, error)
@@ -83,6 +93,8 @@ type ServiceAccountService interface {
 	DeleteAWSLoadBalancerControllerServiceAccount(context.Context, ID) error
 	CreateExternalDNSServiceAccount(context.Context, CreateExternalDNSServiceAccountOpts) (*ServiceAccount, error)
 	DeleteExternalDNSServiceAccount(context.Context, ID) error
+	CreateAutoscalerServiceAccount(context.Context, CreateAutoscalerServiceAccountOpts) (*ServiceAccount, error)
+	DeleteAutoscalerServiceAccount(context.Context, ID) error
 }
 
 // ServiceAccountRun provides the interface for running operations

--- a/pkg/apis/okctl.io/v1alpha1/cluster_v1alpha1.go
+++ b/pkg/apis/okctl.io/v1alpha1/cluster_v1alpha1.go
@@ -192,6 +192,10 @@ type ClusterIntegrations struct {
 	// +optional
 	ExternalSecrets bool `json:"externalSecrets,omitempty"`
 
+	// Autoscaler if set to true will install the cluster autoscaler into the cluster
+	// +optional
+	Autoscaler bool `json:"autoscaler,omitempty"`
+
 	// Cognito if set to true will install the Cognito user pool into the cluster.
 	// Might want to make this one more fine-grained, so that the teams can more easily
 	// give access to their admin APIs or whatever. Might not be required for now.
@@ -249,6 +253,7 @@ func NewDefaultCluster(name, env, org, repo, team, accountID string) Cluster {
 		Integrations: &ClusterIntegrations{
 			ALBIngressController:      false,
 			AWSLoadBalancerController: true,
+			Autoscaler:                true,
 			ExternalDNS:               true,
 			ExternalSecrets:           true,
 			Cognito:                   true,

--- a/pkg/apis/okctl.io/v1alpha1/testdata/default-cluster.yml.golden
+++ b/pkg/apis/okctl.io/v1alpha1/testdata/default-cluster.yml.golden
@@ -6,6 +6,7 @@ github:
   team: kjøremiljø
 integrations:
   argoCD: true
+  autoscaler: true
   awsLoadBalancerController: true
   cognito: true
   externalDNS: true

--- a/pkg/cfn/builder_test.go
+++ b/pkg/cfn/builder_test.go
@@ -47,6 +47,11 @@ func TestBuilderAndComposers(t *testing.T) {
 			composer: components.NewExternalDNSPolicyComposer("repo", "env"),
 		},
 		{
+			name:     "Builder with AutoscalerPolicy composer",
+			golden:   "autoscaler-cloudformation.yaml",
+			composer: components.NewAutoscalerPolicyComposer("repo", "env"),
+		},
+		{
 			name:     "Builder with PublicCertificate composer",
 			golden:   "public-certificate-cf.yaml",
 			composer: components.NewPublicCertificateComposer("test.oslo.systems.", "AZ12345"),

--- a/pkg/cfn/namer.go
+++ b/pkg/cfn/namer.go
@@ -11,6 +11,7 @@ const (
 	DefaultStackNamePrefix                            = "okctl"
 	DefaultStackNameVpcID                             = "vpc"
 	DefaultStackNameExternalSecretsPolicyID           = "externalsecretspolicy"
+	DefaultStackNameAutoscalerPolicyID                = "autoscalerpolicy"
 	DefaultStackNameAlbIngressControllerPolicyID      = "albingresscontrollerpolicy"
 	DefaultStackNameAWSLoadBalancerControllerPolicyID = "awsloadbalancercontrollerpolicy"
 	DefaultStackNameExternalDNSPolicyID               = "externaldns"
@@ -45,6 +46,16 @@ func (n *StackNamer) ExternalSecretsPolicy(repository, env string) string {
 	return fmt.Sprintf("%s-%s-%s-%s",
 		DefaultStackNamePrefix,
 		DefaultStackNameExternalSecretsPolicyID,
+		repository,
+		env,
+	)
+}
+
+// AutoscalerPolicy returns the stack name of an autoscaler policy
+func (n *StackNamer) AutoscalerPolicy(repository, env string) string {
+	return fmt.Sprintf("%s-%s-%s-%s",
+		DefaultStackNamePrefix,
+		DefaultStackNameAutoscalerPolicyID,
 		repository,
 		env,
 	)

--- a/pkg/cfn/testdata/autoscaler-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/autoscaler-cloudformation.yaml.golden
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: 2010-09-09
+Outputs:
+  AutoscalerPolicy:
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-AutoscalerPolicy
+    Value:
+      Ref: AutoscalerPolicy
+Resources:
+  AutoscalerPolicy:
+    Properties:
+      Description: Service account policy for automatically scaling the cluster nodegroup
+      ManagedPolicyName: okctl-repo-env-AutoscalerServiceAccountPolicy
+      PolicyDocument:
+        Statement:
+        - Action:
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeAutoScalingInstances
+          - autoscaling:DescribeLaunchConfigurations
+          - autoscaling:SetDesiredCapacity
+          - autoscaling:TerminateInstanceInAutoScalingGroup
+          - autoscaling:DescribeTags
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - ec2:DescribeLaunchTemplateVersions
+          Effect: Allow
+          Resource:
+          - '*'
+        Version: 2012-10-17
+    Type: AWS::IAM::ManagedPolicy

--- a/pkg/client/autoscaler_client.go
+++ b/pkg/client/autoscaler_client.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"context"
+
+	"github.com/oslokommune/okctl/pkg/client/store"
+
+	"github.com/oslokommune/okctl/pkg/api"
+)
+
+// Autoscaler is the content of an autoscaler deployment
+type Autoscaler struct {
+	Policy         *api.ManagedPolicy
+	ServiceAccount *api.ServiceAccount
+	Chart          *api.Helm
+}
+
+// CreateAutoscalerOpts contains the required inputs
+type CreateAutoscalerOpts struct {
+	ID api.ID
+}
+
+// AutoscalerService is an implementation of the business logic
+type AutoscalerService interface {
+	CreateAutoscaler(ctx context.Context, opts CreateAutoscalerOpts) (*Autoscaler, error)
+	DeleteAutoscaler(ctx context.Context, id api.ID) error
+}
+
+// AutoscalerAPI invokes REST API endpoints
+type AutoscalerAPI interface {
+	CreateAutoscalerPolicy(opts api.CreateAutoscalerPolicy) (*api.ManagedPolicy, error)
+	DeleteAutoscalerPolicy(id api.ID) error
+	CreateAutoscalerServiceAccount(opts api.CreateAutoscalerServiceAccountOpts) (*api.ServiceAccount, error)
+	DeleteAutoscalerServiceAccount(id api.ID) error
+	CreateAutoscalerHelmChart(opts api.CreateAutoscalerHelmChartOpts) (*api.Helm, error)
+}
+
+// AutoscalerStore is a storage layer implementation
+type AutoscalerStore interface {
+	SaveAutoscaler(scaler *Autoscaler) (*store.Report, error)
+	RemoveAutoscaler(id api.ID) (*store.Report, error)
+}
+
+// AutoscalerReport is a report layer
+type AutoscalerReport interface {
+	ReportCreateAutoscaler(scaler *Autoscaler, report *store.Report) error
+	ReportDeleteAutoscaler(report *store.Report) error
+}

--- a/pkg/client/core/api/rest/autoscaler_rest.go
+++ b/pkg/client/core/api/rest/autoscaler_rest.go
@@ -1,0 +1,49 @@
+package rest
+
+import (
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+)
+
+const (
+	// TargetAutoscalerPolicy is the API route for the policy
+	TargetAutoscalerPolicy = "managedpolicies/autoscaler/"
+	// TargetAutoscalerServiceAccount is the API route for the service account
+	TargetAutoscalerServiceAccount = "serviceaccounts/autoscaler/"
+	// TargetAutoscalerHelm is the API route for helm
+	TargetAutoscalerHelm = "helm/autoscaler/"
+)
+
+type autoscalerAPI struct {
+	client *HTTPClient
+}
+
+func (a *autoscalerAPI) DeleteAutoscalerPolicy(id api.ID) error {
+	return a.client.DoDelete(TargetAutoscalerPolicy, &id)
+}
+
+func (a *autoscalerAPI) DeleteAutoscalerServiceAccount(id api.ID) error {
+	return a.client.DoDelete(TargetAutoscalerServiceAccount, &id)
+}
+
+func (a *autoscalerAPI) CreateAutoscalerPolicy(opts api.CreateAutoscalerPolicy) (*api.ManagedPolicy, error) {
+	into := &api.ManagedPolicy{}
+	return into, a.client.DoPost(TargetAutoscalerPolicy, &opts, into)
+}
+
+func (a *autoscalerAPI) CreateAutoscalerServiceAccount(opts api.CreateAutoscalerServiceAccountOpts) (*api.ServiceAccount, error) {
+	into := &api.ServiceAccount{}
+	return into, a.client.DoPost(TargetAutoscalerServiceAccount, &opts, into)
+}
+
+func (a *autoscalerAPI) CreateAutoscalerHelmChart(opts api.CreateAutoscalerHelmChartOpts) (*api.Helm, error) {
+	into := &api.Helm{}
+	return into, a.client.DoPost(TargetAutoscalerHelm, &opts, into)
+}
+
+// NewAutoscalerAPI returns an initialised API client
+func NewAutoscalerAPI(client *HTTPClient) client.AutoscalerAPI {
+	return &autoscalerAPI{
+		client: client,
+	}
+}

--- a/pkg/client/core/handler_client.go
+++ b/pkg/client/core/handler_client.go
@@ -19,4 +19,5 @@ type Services struct {
 	Parameter                        client.ParameterService
 	Vpc                              client.VPCService
 	IdentityManager                  client.IdentityManagerService
+	Autoscaler                       client.Autoscaler
 }

--- a/pkg/client/core/handler_client.go
+++ b/pkg/client/core/handler_client.go
@@ -19,5 +19,5 @@ type Services struct {
 	Parameter                        client.ParameterService
 	Vpc                              client.VPCService
 	IdentityManager                  client.IdentityManagerService
-	Autoscaler                       client.Autoscaler
+	Autoscaler                       client.AutoscalerService
 }

--- a/pkg/client/core/report/console/autoscaler_console.go
+++ b/pkg/client/core/report/console/autoscaler_console.go
@@ -1,0 +1,37 @@
+package console
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/oslokommune/okctl/pkg/spinner"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/client/store"
+)
+
+type autoscalerReport struct {
+	console *Console
+}
+
+func (r *autoscalerReport) ReportDeleteAutoscaler(report *store.Report) error {
+	return r.console.Report(report.Actions, "autoscaler", aurora.Green("deleting").String())
+}
+
+func (r *autoscalerReport) ReportCreateAutoscaler(secret *client.Autoscaler, report *store.Report) error {
+	description := fmt.Sprintf("%s (policy), %s (service account), %s (kubernetes)",
+		aurora.Green(secret.Policy.StackName),
+		aurora.Green(secret.ServiceAccount.Config.Metadata.Name),
+		aurora.Green("autoscaler"),
+	)
+
+	return r.console.Report(report.Actions, "autoscaler", description)
+}
+
+// NewAutoscalerReport returns an initialised reporter
+func NewAutoscalerReport(out io.Writer, spinner spinner.Spinner) client.AutoscalerReport {
+	return &autoscalerReport{
+		console: New(out, spinner),
+	}
+}

--- a/pkg/client/core/service_autoscaler.go
+++ b/pkg/client/core/service_autoscaler.go
@@ -1,0 +1,119 @@
+package core
+
+import (
+	"context"
+
+	"github.com/oslokommune/okctl/pkg/spinner"
+
+	"github.com/oslokommune/okctl/pkg/api"
+
+	"github.com/oslokommune/okctl/pkg/client"
+)
+
+type autoscalerService struct {
+	spinner spinner.Spinner
+	api     client.AutoscalerAPI
+	store   client.AutoscalerStore
+	report  client.AutoscalerReport
+}
+
+func (s *autoscalerService) DeleteAutoscaler(_ context.Context, id api.ID) error {
+	err := s.spinner.Start("autoscaler")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = s.spinner.Stop()
+	}()
+
+	err = s.api.DeleteAutoscalerServiceAccount(id)
+	if err != nil {
+		return err
+	}
+
+	err = s.api.DeleteAutoscalerPolicy(id)
+	if err != nil {
+		return err
+	}
+
+	report, err := s.store.RemoveAutoscaler(id)
+	if err != nil {
+		return err
+	}
+
+	err = s.report.ReportDeleteAutoscaler(report)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *autoscalerService) CreateAutoscaler(_ context.Context, opts client.CreateAutoscalerOpts) (*client.Autoscaler, error) {
+	err := s.spinner.Start("autoscaler")
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err = s.spinner.Stop()
+	}()
+
+	policy, err := s.api.CreateAutoscalerPolicy(api.CreateAutoscalerPolicy{
+		ID: opts.ID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sa, err := s.api.CreateAutoscalerServiceAccount(api.CreateAutoscalerServiceAccountOpts{
+		CreateServiceAccountOpts: api.CreateServiceAccountOpts{
+			ID:        opts.ID,
+			PolicyArn: policy.PolicyARN,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	chart, err := s.api.CreateAutoscalerHelmChart(api.CreateAutoscalerHelmChartOpts{
+		ID: opts.ID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	a := &client.Autoscaler{
+		Policy:         policy,
+		ServiceAccount: sa,
+		Chart:          chart,
+	}
+
+	report, err := s.store.SaveAutoscaler(a)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.report.ReportCreateAutoscaler(a, report)
+	if err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
+// NewAutoscalerService returns an initialised service
+func NewAutoscalerService(
+	spinner spinner.Spinner,
+	api client.AutoscalerAPI,
+	store client.AutoscalerStore,
+	report client.AutoscalerReport,
+) client.AutoscalerService {
+	return &autoscalerService{
+		spinner: spinner,
+		api:     api,
+		store:   store,
+		report:  report,
+	}
+}

--- a/pkg/client/core/store/filesystem/autoscaler_filesystem.go
+++ b/pkg/client/core/store/filesystem/autoscaler_filesystem.go
@@ -10,14 +10,14 @@ import (
 	"github.com/spf13/afero"
 )
 
-type externalSecretsStore struct {
+type autoscalerStore struct {
 	policy         Paths
 	serviceAccount Paths
 	chart          Paths
 	fs             *afero.Afero
 }
 
-func (s *externalSecretsStore) RemoveExternalSecrets(_ api.ID) (*store.Report, error) {
+func (s *autoscalerStore) RemoveAutoscaler(_ api.ID) (*store.Report, error) {
 	report, err := store.NewFileSystem(s.policy.BaseDir, s.fs).
 		Remove(s.policy.OutputFile).
 		Remove(s.policy.CloudFormationFile).
@@ -37,7 +37,7 @@ func (s *externalSecretsStore) RemoveExternalSecrets(_ api.ID) (*store.Report, e
 	return report, nil
 }
 
-func (s *externalSecretsStore) SaveExternalSecrets(e *client.ExternalSecrets) (*store.Report, error) {
+func (s *autoscalerStore) SaveAutoscaler(e *client.Autoscaler) (*store.Report, error) {
 	policy := &ManagedPolicy{
 		ID:        e.Policy.ID,
 		StackName: e.Policy.StackName,
@@ -68,15 +68,15 @@ func (s *externalSecretsStore) SaveExternalSecrets(e *client.ExternalSecrets) (*
 		StoreStruct(s.chart.ChartFile, e.Chart.Chart, store.ToJSON()).
 		Do()
 	if err != nil {
-		return nil, fmt.Errorf("storing external secrets: %w", err)
+		return nil, fmt.Errorf("storing autoscaler: %w", err)
 	}
 
 	return report, nil
 }
 
-// NewExternalSecretsStore returns an initialised store
-func NewExternalSecretsStore(policy, serviceAccount, chart Paths, fs *afero.Afero) client.ExternalSecretsStore {
-	return &externalSecretsStore{
+// NewAutoscalerStore returns an initialised store
+func NewAutoscalerStore(policy, serviceAccount, chart Paths, fs *afero.Afero) client.AutoscalerStore {
+	return &autoscalerStore{
 		policy:         policy,
 		serviceAccount: serviceAccount,
 		chart:          chart,

--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -285,6 +285,22 @@ func NewExternalDNSServiceAccount(clusterName, region, policyArn, permissionsBou
 	})
 }
 
+// NewAutoscalerServiceAccount returns an initialised configuration
+// for creating a cluster autoscaler service account
+func NewAutoscalerServiceAccount(clusterName, region, policyArn, permissionsBoundaryArn string) (*v1alpha5.ClusterConfig, error) {
+	return NewServiceAccount(&ServiceAccountArgs{
+		ClusterName: clusterName,
+		Labels: map[string]string{
+			"aws-usage": "cluster-ops",
+		},
+		Name:                   "autoscaler",
+		Namespace:              "kube-system",
+		PermissionsBoundaryArn: permissionsBoundaryArn,
+		PolicyArn:              policyArn,
+		Region:                 region,
+	})
+}
+
 // MinimalArgs contains the input arguments for creating a valid
 // cluster configuration
 type MinimalArgs struct {

--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -98,7 +98,7 @@ func (a *Args) build() *v1alpha5.ClusterConfig {
 				Name:         "ng-generic",
 				InstanceType: "m5.large",
 				ScalingConfig: v1alpha5.ScalingConfig{
-					DesiredCapacity: 2, //nolint: gomnd
+					DesiredCapacity: 1, //nolint: gomnd
 					MinSize:         1,
 					MaxSize:         10, //nolint: gomnd
 				},

--- a/pkg/clusterconfig/clusterconfig_test.go
+++ b/pkg/clusterconfig/clusterconfig_test.go
@@ -281,6 +281,48 @@ func TestNewExternalDNSServiceAccount(t *testing.T) {
 	}
 }
 
+func TestNewAutoscalerServiceAccount(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		clusterName            string
+		region                 string
+		policyArn              string
+		permissionsBoundaryArn string
+		golden                 string
+		expectErr              bool
+		err                    string
+	}{
+		{
+			name:                   "Validate service account",
+			clusterName:            "test",
+			region:                 mock.DefaultRegion,
+			policyArn:              mock.DefaultPolicyARN,
+			permissionsBoundaryArn: v1alpha1.PermissionsBoundaryARN(mock.DefaultAWSAccountID),
+			golden:                 "autoscaler",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := clusterconfig.NewAutoscalerServiceAccount(tc.clusterName, tc.region, tc.policyArn, tc.permissionsBoundaryArn)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, tc.err, err.Error())
+			} else {
+				assert.NoError(t, err)
+
+				d, err := got.YAML()
+				assert.NoError(t, err)
+
+				g := goldie.New(t)
+				g.Assert(t, tc.golden, d)
+			}
+		})
+	}
+}
+
 func TestNewMinimal(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/pkg/clusterconfig/testdata/autoscaler.golden
+++ b/pkg/clusterconfig/testdata/autoscaler.golden
@@ -1,0 +1,19 @@
+apiVersion: eksctl.io/v1alpha5
+iam:
+  serviceAccounts:
+  - attachPolicyARNs:
+    - arn:aws:iam::123456789012:policy/somePolicy
+    metadata:
+      labels:
+        aws-usage: cluster-ops
+      name: autoscaler
+      namespace: kube-system
+    permissionsBoundary: arn:aws:iam::123456789012:policy/oslokommune/oslokommune-boundary
+  withOIDC: true
+kind: ClusterConfig
+metadata:
+  name: test
+  region: eu-west-1
+  tags:
+    alpha.okctl.io/okctl-commit: unknown
+    alpha.okctl.io/okctl-version: dev

--- a/pkg/clusterconfig/testdata/clusterConfig.golden
+++ b/pkg/clusterconfig/testdata/clusterConfig.golden
@@ -25,7 +25,7 @@ metadata:
     alpha.okctl.io/okctl-version: dev
   version: "1.18"
 nodeGroups:
-- desiredCapacity: 2
+- desiredCapacity: 1
   iam:
     instanceRolePermissionsBoundary: arn:aws:iam::123456789012:policy/oslokommune/oslokommune-boundary
   instanceType: m5.large

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,6 +79,7 @@ const (
 	DefaultDomainOutputsFile                        = "domains-outputs.json"
 	DefaultExternalDNSBaseDir                       = "external-dns"
 	DefaultExternalSecretsBaseDir                   = "external-secrets"
+	DefaultAutoscalerBaseDir                        = "autoscaler"
 	DefaultHelmChartFile                            = "helm-chart.json"
 	DefaultHelmOutputsFile                          = "helm-outputs.json"
 	DefaultHelmReleaseFile                          = "helm-release.json"

--- a/pkg/controller/convert.go
+++ b/pkg/controller/convert.go
@@ -21,6 +21,7 @@ type ExistingServices struct {
 	hasCluster                        bool
 	hasExternalDNS                    bool
 	hasExternalSecrets                bool
+	hasAutoscaler                     bool
 	hasGithubSetup                    bool
 	hasIdentityManager                bool
 	hasPrimaryHostedZone              bool
@@ -38,6 +39,7 @@ func NewCreateCurrentStateTreeOpts(fs *afero.Afero, outputDir string, githubGett
 		hasVPC:                            directoryTester(fs, outputDir, config.DefaultVpcBaseDir),
 		hasCluster:                        directoryTester(fs, outputDir, config.DefaultClusterBaseDir),
 		hasExternalSecrets:                directoryTester(fs, outputDir, config.DefaultExternalSecretsBaseDir),
+		hasAutoscaler:                     directoryTester(fs, outputDir, config.DefaultAutoscalerBaseDir),
 		hasALBIngressController:           directoryTester(fs, outputDir, config.DefaultAlbIngressControllerBaseDir),
 		hasAWSLoadBalancerController:      directoryTester(fs, outputDir, config.DefaultAWSLoadBalancerControllerBaseDir),
 		hasExternalDNS:                    directoryTester(fs, outputDir, config.DefaultExternalDNSBaseDir),
@@ -90,6 +92,7 @@ func CreateDesiredStateTree(cluster *v1alpha1.Cluster) (root *resourcetree.Resou
 	clusterNode = createNode(vpcNode, resourcetree.ResourceNodeTypeCluster, true)
 
 	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalSecrets, cluster.Integrations.ExternalSecrets)
+	createNode(clusterNode, resourcetree.ResourceNodeTypeAutoscaler, cluster.Integrations.Autoscaler)
 	createNode(clusterNode, resourcetree.ResourceNodeTypeALBIngress, cluster.Integrations.ALBIngressController)
 	createNode(clusterNode, resourcetree.ResourceNodeTypeAWSLoadBalancerController, cluster.Integrations.AWSLoadBalancerController)
 	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalDNS, cluster.Integrations.ExternalDNS)

--- a/pkg/controller/convert.go
+++ b/pkg/controller/convert.go
@@ -68,6 +68,7 @@ func CreateCurrentStateTree(opts *ExistingServices) (root *resourcetree.Resource
 	clusterNode = createNode(vpcNode, resourcetree.ResourceNodeTypeCluster, opts.hasCluster)
 
 	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalSecrets, opts.hasExternalSecrets)
+	createNode(clusterNode, resourcetree.ResourceNodeTypeAutoscaler, opts.hasAutoscaler)
 	createNode(clusterNode, resourcetree.ResourceNodeTypeALBIngress, opts.hasALBIngressController)
 	createNode(clusterNode, resourcetree.ResourceNodeTypeAWSLoadBalancerController, opts.hasAWSLoadBalancerController)
 	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalDNS, opts.hasExternalDNS)

--- a/pkg/controller/convert_test.go
+++ b/pkg/controller/convert_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 )
 
+// nolint: funlen
 func TestTreeCreators(t *testing.T) {
 	testCases := []struct {
 		name string
@@ -27,6 +28,7 @@ func TestTreeCreators(t *testing.T) {
 				hasCluster:                        true,
 				hasExternalDNS:                    true,
 				hasExternalSecrets:                true,
+				hasAutoscaler:                     true,
 				hasGithubSetup:                    true,
 				hasIdentityManager:                true,
 				hasPrimaryHostedZone:              true,
@@ -48,6 +50,7 @@ func TestTreeCreators(t *testing.T) {
 				hasCluster:                        true,
 				hasExternalDNS:                    false,
 				hasExternalSecrets:                true,
+				hasAutoscaler:                     true,
 				hasGithubSetup:                    true,
 				hasIdentityManager:                true,
 				hasPrimaryHostedZone:              true,

--- a/pkg/controller/reconciler/autoscaler_reconciler.go
+++ b/pkg/controller/reconciler/autoscaler_reconciler.go
@@ -1,0 +1,45 @@
+package reconciler
+
+import (
+	"fmt"
+
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// autoscalerReconciler contains service and metadata for the relevant resource
+type autoscalerReconciler struct {
+	commonMetadata *resourcetree.CommonMetadata
+
+	client client.AutoscalerService
+}
+
+// SetCommonMetadata saves common metadata for use in Reconcile()
+func (z *autoscalerReconciler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	z.commonMetadata = metadata
+}
+
+// Reconcile knows how to do what is necessary to ensure the desired state is achieved
+func (z *autoscalerReconciler) Reconcile(node *resourcetree.ResourceNode) (*ReconcilationResult, error) {
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		_, err := z.client.CreateAutoscaler(z.commonMetadata.Ctx, client.CreateAutoscalerOpts{ID: z.commonMetadata.ClusterID})
+		if err != nil {
+			return &ReconcilationResult{Requeue: true}, fmt.Errorf("creating autoscaler: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		err := z.client.DeleteAutoscaler(z.commonMetadata.Ctx, z.commonMetadata.ClusterID)
+		if err != nil {
+			return &ReconcilationResult{Requeue: true}, fmt.Errorf("deleting autoscaler: %w", err)
+		}
+	}
+
+	return &ReconcilationResult{Requeue: false}, nil
+}
+
+// NewAutoscalerReconciler creates a new reconciler for the autoscaler resource
+func NewAutoscalerReconciler(client client.AutoscalerService) Reconciler {
+	return &autoscalerReconciler{
+		client: client,
+	}
+}

--- a/pkg/controller/resourcetree/tree.go
+++ b/pkg/controller/resourcetree/tree.go
@@ -25,6 +25,8 @@ const (
 	ResourceNodeTypeCluster
 	// ResourceNodeTypeExternalSecrets represents an External Secrets resource
 	ResourceNodeTypeExternalSecrets
+	// ResourceNodeTypeAutoscaler represents an autoscaler resource
+	ResourceNodeTypeAutoscaler
 	// ResourceNodeTypeALBIngress represents an ALB Ingress resource
 	ResourceNodeTypeALBIngress
 	// ResourceNodeTypeAWSLoadBalancerController represents an AWS load balancer controller resource
@@ -54,6 +56,8 @@ func ResourceNodeTypeToString(nodeType ResourceNodeType) string {
 		return "K8s Cluster"
 	case ResourceNodeTypeExternalSecrets:
 		return "External Secrets"
+	case ResourceNodeTypeAutoscaler:
+		return "Autoscaler"
 	case ResourceNodeTypeALBIngress:
 		return "ALB Ingress Controller"
 	case ResourceNodeTypeAWSLoadBalancerController:

--- a/pkg/helm/charts/autoscaler/autoscaler.go
+++ b/pkg/helm/charts/autoscaler/autoscaler.go
@@ -16,7 +16,7 @@ func New(values *Values) *helm.Chart {
 		RepositoryName: "autoscaler",
 		RepositoryURL:  "https://kubernetes.github.io/autoscaler",
 		ReleaseName:    "cluster-autoscaler",
-		Version:        "9.4.9",
+		Version:        "9.4.0",
 		Chart:          "cluster-autoscaler",
 		Namespace:      "kube-system",
 		Timeout:        5 * time.Minute, // nolint: gomnd

--- a/pkg/helm/charts/autoscaler/autoscaler.go
+++ b/pkg/helm/charts/autoscaler/autoscaler.go
@@ -1,0 +1,370 @@
+// Package autoscaler provides a Helm chart for installing:
+// - https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler
+package autoscaler
+
+import (
+	"bytes"
+	"text/template"
+	"time"
+
+	"github.com/oslokommune/okctl/pkg/helm"
+)
+
+// New returns an initialised Helm chart for installing cluster-autoscaler
+func New(values *Values) *helm.Chart {
+	return &helm.Chart{
+		RepositoryName: "autoscaler",
+		RepositoryURL:  "https://kubernetes.github.io/autoscaler",
+		ReleaseName:    "cluster-autoscaler",
+		Version:        "9.4.9",
+		Chart:          "cluster-autoscaler",
+		Namespace:      "kube-system",
+		Timeout:        5 * time.Minute, // nolint: gomnd
+		Values:         values,
+	}
+}
+
+// NewDefaultValues returns the mapped values.yml containing
+// the default values
+func NewDefaultValues(region, clusterName, serviceAccount string) *Values {
+	return &Values{
+		Region:         region,
+		ClusterName:    clusterName,
+		ServiceAccount: serviceAccount,
+	}
+}
+
+// Values contains the required inputs for generating the values.yml
+type Values struct {
+	Region         string
+	ClusterName    string
+	ServiceAccount string
+}
+
+// RawYAML implements the raw marshaller interface in the Helm package
+func (v *Values) RawYAML() ([]byte, error) {
+	tmpl, err := template.New("values").Parse(valuesTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	var buff bytes.Buffer
+
+	err = tmpl.Execute(&buff, *v)
+	if err != nil {
+		return nil, err
+	}
+
+	return buff.Bytes(), nil
+}
+
+// nolint: lll
+const valuesTemplate = `## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity -- Affinity for pod assignment
+affinity: {}
+
+autoDiscovery:
+  # cloudProviders "aws", "gce" and "magnum" are supported by auto-discovery at this time
+  # AWS: Set tags as described in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
+
+  # autoDiscovery.clusterName -- Enable autodiscovery for "cloudProvider=aws", for groups matching "autoDiscovery.tags".
+  # Enable autodiscovery for "cloudProvider=gce", but no MIG tagging required.
+  # Enable autodiscovery for "cloudProvider=magnum", for groups matching "autoDiscovery.roles".
+  clusterName:  {{.ClusterName}}
+
+  # autoDiscovery.tags -- ASG tags to match, run through "tpl".
+  tags:
+  - k8s.io/cluster-autoscaler/enabled
+  - k8s.io/cluster-autoscaler/{{.ClusterName}}
+
+  # autoDiscovery.roles -- Magnum node group roles to match.
+  roles:
+  - worker
+
+# autoscalingGroups -- For AWS, Azure AKS or Magnum. At least one element is required if not using "autoDiscovery". For example:
+# <pre>
+# - name: asg1<br />
+#   maxSize: 2<br />
+#   minSize: 1
+# </pre>
+autoscalingGroups: []
+# - name: asg1
+#   maxSize: 2
+#   minSize: 1
+# - name: asg2
+#   maxSize: 2
+#   minSize: 1
+
+# autoscalingGroupsnamePrefix -- For GCE. At least one element is required if not using "autoDiscovery". For example:
+# <pre>
+# - name: ig01<br />
+#   maxSize: 10<br />
+#   minSize: 0
+# </pre>
+autoscalingGroupsnamePrefix: []
+# - name: ig01
+#   maxSize: 10
+#   minSize: 0
+# - name: ig02
+#   maxSize: 10
+#   minSize: 0
+
+# awsAccessKeyID -- AWS access key ID ([if AWS user keys used](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-aws-credentials))
+awsAccessKeyID: ""
+
+# awsRegion -- AWS region (required if "cloudProvider=aws")
+awsRegion: {{.Region}}
+
+# awsSecretAccessKey -- AWS access secret key ([if AWS user keys used](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-aws-credentials))
+awsSecretAccessKey: ""
+
+# azureClientID -- Service Principal ClientID with contributor permission to Cluster and Node ResourceGroup.
+# Required if "cloudProvider=azure"
+azureClientID: ""
+
+# azureClientSecret -- Service Principal ClientSecret with contributor permission to Cluster and Node ResourceGroup.
+# Required if "cloudProvider=azure"
+azureClientSecret: ""
+
+# azureResourceGroup -- Azure resource group that the cluster is located.
+# Required if "cloudProvider=azure"
+azureResourceGroup: ""
+
+# azureSubscriptionID -- Azure subscription where the resources are located.
+# Required if "cloudProvider=azure"
+azureSubscriptionID: ""
+
+# azureTenantID -- Azure tenant where the resources are located.
+# Required if "cloudProvider=azure"
+azureTenantID: ""
+
+# azureVMType -- Azure VM type.
+azureVMType: "AKS"
+
+# azureClusterName -- Azure AKS cluster name.
+# Required if "cloudProvider=azure"
+azureClusterName: ""
+
+# azureNodeResourceGroup -- Azure resource group where the cluster's nodes are located, typically set as "MC_<cluster-resource-group-name>_<cluster-name>_<location>".
+# Required if "cloudProvider=azure"
+azureNodeResourceGroup: ""
+
+# azureUseManagedIdentityExtension -- Whether to use Azure's managed identity extension for credentials. If using MSI, ensure subscription ID and resource group are set.
+azureUseManagedIdentityExtension: false
+
+# magnumClusterName -- Cluster name or ID in Magnum.
+# Required if "cloudProvider=magnum" and not setting "autoDiscovery.clusterName".
+magnumClusterName: ""
+
+# magnumCABundlePath -- Path to the host's CA bundle, from "ca-file" in the cloud-config file.
+magnumCABundlePath: "/etc/kubernetes/ca-bundle.crt"
+
+# cloudConfigPath -- Configuration file for cloud provider.
+cloudConfigPath: /etc/gce.conf
+
+# cloudProvider -- The cloud provider where the autoscaler runs.
+# Currently only "gce", "aws", "azure" and "magnum" are supported.
+# "aws" supported for AWS. "gce" for GCE. "azure" for Azure AKS.
+# "magnum" for OpenStack Magnum.
+cloudProvider: aws
+
+# containerSecurityContext -- [Security context for container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+
+# dnsPolicy -- Defaults to "ClusterFirst". Valid values are:
+# "ClusterFirstWithHostNet", "ClusterFirst", "Default" or "None".
+# If autoscaler does not depend on cluster DNS, recommended to set this to "Default".
+dnsPolicy: ClusterFirst
+
+## Priorities Expander
+# expanderPriorities -- The expanderPriorities is used if "extraArgs.expander" is set to "priority" and expanderPriorities is also set with the priorities.
+# If "extraArgs.expander" is set to "priority", then expanderPriorities is used to define cluster-autoscaler-priority-expander priorities.
+# See: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md
+expanderPriorities: {}
+
+# extraArgs -- Additional container arguments.
+# Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler
+# parameters and their default values.
+extraArgs:
+  logtostderr: true
+  stderrthreshold: info
+  v: 4
+  # write-status-configmap: true
+  # leader-elect: true
+  # skip-nodes-with-local-storage: true
+  # expander: random
+  # scale-down-enabled: true
+  # balance-similar-node-groups: true
+  # min-replica-count: 0
+  # scale-down-utilization-threshold: 0.5
+  # scale-down-non-empty-candidates-count: 30
+  # max-node-provision-time: 15m0s
+  # scan-interval: 10s
+  # scale-down-delay-after-add: 10m
+  # scale-down-delay-after-delete: 0s
+  # scale-down-delay-after-failure: 3m
+  # scale-down-unneeded-time: 10m
+  # skip-nodes-with-system-pods: true
+
+# extraEnv -- Additional container environment variables.
+extraEnv: {}
+
+# extraEnvConfigMaps -- Additional container environment variables from ConfigMaps.
+extraEnvConfigMaps: {}
+
+# extraEnvSecrets -- Additional container environment variables from Secrets.
+extraEnvSecrets: {}
+
+# envFromConfigMap -- ConfigMap name to use as envFrom.
+envFromConfigMap: ""
+
+# envFromSecret -- Secret name to use as envFrom.
+envFromSecret: ""
+
+# extraVolumeSecrets -- Additional volumes to mount from Secrets.
+extraVolumeSecrets: {}
+  # autoscaler-vol:
+  #   mountPath: /data/autoscaler/
+  # custom-vol:
+  #   name: custom-secret
+  #   mountPath: /data/custom/
+  #   items:
+  #     - key: subkey
+  #       path: mypath
+
+# extraVolumes -- Additional volumes.
+extraVolumes: []
+  # - name: ssl-certs
+  #   hostPath:
+  #     path: /etc/ssl/certs/ca-bundle.crt
+
+# extraVolumeMounts -- Additional volumes to mount.
+extraVolumeMounts: []
+  # - name: ssl-certs
+  #   mountPath: /etc/ssl/certs/ca-certificates.crt
+  #   readonly: true
+
+# fullnameOverride -- String to fully override "cluster-autoscaler.fullname" template.
+fullnameOverride: ""
+
+image:
+  # image.repository -- Image repository
+  repository: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
+  # image.tag -- Image tag
+  tag: v1.18.1
+  # image.pullPolicy -- Image pull policy
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # image.pullSecrets -- Image pull secrets
+  pullSecrets: []
+  # - myRegistrKeySecretName
+
+# kubeTargetVersionOverride -- Allow overriding the ".Capabilities.KubeVersion.GitVersion" check. Useful for "helm template" commands.
+kubeTargetVersionOverride: ""
+
+# nameOverride -- String to partially override "cluster-autoscaler.fullname" template (will maintain the release name)
+nameOverride: ""
+
+# nodeSelector -- Node labels for pod assignment. Ref: https://kubernetes.io/docs/user-guide/node-selection/.
+nodeSelector: {}
+
+# podAnnotations -- Annotations to add to each pod.
+podAnnotations: {}
+
+# podDisruptionBudget -- Pod disruption budget.
+podDisruptionBudget:
+  maxUnavailable: 1
+  # minAvailable: 2
+
+# podLabels -- Labels to add to each pod.
+podLabels: {}
+
+# additionalLabels -- Labels to add to each object of the chart.
+additionalLabels: {}
+
+# priorityClassName -- priorityClassName
+priorityClassName: ""
+
+rbac:
+  # rbac.create -- If "true", create and use RBAC resources.
+  create: true
+  # rbac.pspEnabled -- If "true", creates and uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled.
+  # Must be used with "rbac.create" set to "true".
+  pspEnabled: false
+  serviceAccount:
+    # rbac.serviceAccount.annotations -- Additional Service Account annotations.
+    annotations: {}
+    # rbac.serviceAccount.create -- If "true" and "rbac.create" is also true, a Service Account will be created.
+    create: false
+    # rbac.serviceAccount.name -- The name of the ServiceAccount to use. If not set and create is "true", a name is generated using the fullname template.
+    name: {{.ServiceAccount}}
+
+# replicaCount -- Desired number of pods
+replicaCount: 1
+
+# resources -- Pod resource requests and limits.
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi
+
+# securityContext -- [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+securityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1001
+  # runAsGroup: 1001
+
+service:
+  # service.annotations -- Annotations to add to service
+  annotations: {}
+  # service.labels -- Labels to add to service
+  labels: {}
+  # service.externalIPs -- List of IP addresses at which the service is available. Ref: https://kubernetes.io/docs/user-guide/services/#external-ips.
+  externalIPs: []
+
+  # service.loadBalancerIP -- IP address to assign to load balancer (if supported).
+  loadBalancerIP: ""
+  # service.loadBalancerSourceRanges -- List of IP CIDRs allowed access to load balancer (if supported).
+  loadBalancerSourceRanges: []
+  # service.servicePort -- Service port to expose.
+  servicePort: 8085
+  # service.portName -- Name for service port.
+  portName: http
+  # service.type -- Type of service to create.
+  type: ClusterIP
+
+## Are you using Prometheus Operator?
+serviceMonitor:
+  # serviceMonitor.enabled -- If true, creates a Prometheus Operator ServiceMonitor.
+  enabled: false
+  # serviceMonitor.interval -- Interval that Prometheus scrapes Cluster Autoscaler metrics.
+  interval: 10s
+  # serviceMonitor.namespace -- Namespace which Prometheus is running in.
+  namespace: monitoring
+  ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
+  ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
+  # serviceMonitor.selector -- Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install.
+  selector:
+    release: prometheus-operator
+  # serviceMonitor.path -- The path to scrape for metrics; autoscaler exposes "/metrics" (this is standard)
+  path: /metrics
+
+# tolerations -- List of node taints to tolerate (requires Kubernetes >= 1.6).
+tolerations: []
+
+# updateStrategy -- [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
+updateStrategy: {}
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+  # type: RollingUpdate
+`

--- a/pkg/helm/charts/autoscaler/autoscaler_test.go
+++ b/pkg/helm/charts/autoscaler/autoscaler_test.go
@@ -1,0 +1,36 @@
+package autoscaler_test
+
+import (
+	"testing"
+
+	"github.com/oslokommune/okctl/pkg/api/mock"
+	"github.com/oslokommune/okctl/pkg/helm/charts/autoscaler"
+	"github.com/sebdah/goldie/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDefaultValues(t *testing.T) {
+	testCases := []struct {
+		name   string
+		values *autoscaler.Values
+		golden string
+	}{
+		{
+			name:   "Default values should generate valid yaml",
+			values: autoscaler.NewDefaultValues(mock.DefaultRegion, mock.DefaultClusterName, "autoscaler"),
+			golden: "autoscaler.yml",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.values.RawYAML()
+			assert.NoError(t, err)
+
+			g := goldie.New(t)
+			g.Assert(t, tc.golden, got)
+		})
+	}
+}

--- a/pkg/helm/charts/autoscaler/testdata/autoscaler.yml.golden
+++ b/pkg/helm/charts/autoscaler/testdata/autoscaler.yml.golden
@@ -1,0 +1,308 @@
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity -- Affinity for pod assignment
+affinity: {}
+
+autoDiscovery:
+  # cloudProviders "aws", "gce" and "magnum" are supported by auto-discovery at this time
+  # AWS: Set tags as described in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
+
+  # autoDiscovery.clusterName -- Enable autodiscovery for "cloudProvider=aws", for groups matching "autoDiscovery.tags".
+  # Enable autodiscovery for "cloudProvider=gce", but no MIG tagging required.
+  # Enable autodiscovery for "cloudProvider=magnum", for groups matching "autoDiscovery.roles".
+  clusterName:  test-cluster-pro
+
+  # autoDiscovery.tags -- ASG tags to match, run through "tpl".
+  tags:
+  - k8s.io/cluster-autoscaler/enabled
+  - k8s.io/cluster-autoscaler/test-cluster-pro
+
+  # autoDiscovery.roles -- Magnum node group roles to match.
+  roles:
+  - worker
+
+# autoscalingGroups -- For AWS, Azure AKS or Magnum. At least one element is required if not using "autoDiscovery". For example:
+# <pre>
+# - name: asg1<br />
+#   maxSize: 2<br />
+#   minSize: 1
+# </pre>
+autoscalingGroups: []
+# - name: asg1
+#   maxSize: 2
+#   minSize: 1
+# - name: asg2
+#   maxSize: 2
+#   minSize: 1
+
+# autoscalingGroupsnamePrefix -- For GCE. At least one element is required if not using "autoDiscovery". For example:
+# <pre>
+# - name: ig01<br />
+#   maxSize: 10<br />
+#   minSize: 0
+# </pre>
+autoscalingGroupsnamePrefix: []
+# - name: ig01
+#   maxSize: 10
+#   minSize: 0
+# - name: ig02
+#   maxSize: 10
+#   minSize: 0
+
+# awsAccessKeyID -- AWS access key ID ([if AWS user keys used](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-aws-credentials))
+awsAccessKeyID: ""
+
+# awsRegion -- AWS region (required if "cloudProvider=aws")
+awsRegion: eu-west-1
+
+# awsSecretAccessKey -- AWS access secret key ([if AWS user keys used](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-aws-credentials))
+awsSecretAccessKey: ""
+
+# azureClientID -- Service Principal ClientID with contributor permission to Cluster and Node ResourceGroup.
+# Required if "cloudProvider=azure"
+azureClientID: ""
+
+# azureClientSecret -- Service Principal ClientSecret with contributor permission to Cluster and Node ResourceGroup.
+# Required if "cloudProvider=azure"
+azureClientSecret: ""
+
+# azureResourceGroup -- Azure resource group that the cluster is located.
+# Required if "cloudProvider=azure"
+azureResourceGroup: ""
+
+# azureSubscriptionID -- Azure subscription where the resources are located.
+# Required if "cloudProvider=azure"
+azureSubscriptionID: ""
+
+# azureTenantID -- Azure tenant where the resources are located.
+# Required if "cloudProvider=azure"
+azureTenantID: ""
+
+# azureVMType -- Azure VM type.
+azureVMType: "AKS"
+
+# azureClusterName -- Azure AKS cluster name.
+# Required if "cloudProvider=azure"
+azureClusterName: ""
+
+# azureNodeResourceGroup -- Azure resource group where the cluster's nodes are located, typically set as "MC_<cluster-resource-group-name>_<cluster-name>_<location>".
+# Required if "cloudProvider=azure"
+azureNodeResourceGroup: ""
+
+# azureUseManagedIdentityExtension -- Whether to use Azure's managed identity extension for credentials. If using MSI, ensure subscription ID and resource group are set.
+azureUseManagedIdentityExtension: false
+
+# magnumClusterName -- Cluster name or ID in Magnum.
+# Required if "cloudProvider=magnum" and not setting "autoDiscovery.clusterName".
+magnumClusterName: ""
+
+# magnumCABundlePath -- Path to the host's CA bundle, from "ca-file" in the cloud-config file.
+magnumCABundlePath: "/etc/kubernetes/ca-bundle.crt"
+
+# cloudConfigPath -- Configuration file for cloud provider.
+cloudConfigPath: /etc/gce.conf
+
+# cloudProvider -- The cloud provider where the autoscaler runs.
+# Currently only "gce", "aws", "azure" and "magnum" are supported.
+# "aws" supported for AWS. "gce" for GCE. "azure" for Azure AKS.
+# "magnum" for OpenStack Magnum.
+cloudProvider: aws
+
+# containerSecurityContext -- [Security context for container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+
+# dnsPolicy -- Defaults to "ClusterFirst". Valid values are:
+# "ClusterFirstWithHostNet", "ClusterFirst", "Default" or "None".
+# If autoscaler does not depend on cluster DNS, recommended to set this to "Default".
+dnsPolicy: ClusterFirst
+
+## Priorities Expander
+# expanderPriorities -- The expanderPriorities is used if "extraArgs.expander" is set to "priority" and expanderPriorities is also set with the priorities.
+# If "extraArgs.expander" is set to "priority", then expanderPriorities is used to define cluster-autoscaler-priority-expander priorities.
+# See: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md
+expanderPriorities: {}
+
+# extraArgs -- Additional container arguments.
+# Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler
+# parameters and their default values.
+extraArgs:
+  logtostderr: true
+  stderrthreshold: info
+  v: 4
+  # write-status-configmap: true
+  # leader-elect: true
+  # skip-nodes-with-local-storage: true
+  # expander: random
+  # scale-down-enabled: true
+  # balance-similar-node-groups: true
+  # min-replica-count: 0
+  # scale-down-utilization-threshold: 0.5
+  # scale-down-non-empty-candidates-count: 30
+  # max-node-provision-time: 15m0s
+  # scan-interval: 10s
+  # scale-down-delay-after-add: 10m
+  # scale-down-delay-after-delete: 0s
+  # scale-down-delay-after-failure: 3m
+  # scale-down-unneeded-time: 10m
+  # skip-nodes-with-system-pods: true
+
+# extraEnv -- Additional container environment variables.
+extraEnv: {}
+
+# extraEnvConfigMaps -- Additional container environment variables from ConfigMaps.
+extraEnvConfigMaps: {}
+
+# extraEnvSecrets -- Additional container environment variables from Secrets.
+extraEnvSecrets: {}
+
+# envFromConfigMap -- ConfigMap name to use as envFrom.
+envFromConfigMap: ""
+
+# envFromSecret -- Secret name to use as envFrom.
+envFromSecret: ""
+
+# extraVolumeSecrets -- Additional volumes to mount from Secrets.
+extraVolumeSecrets: {}
+  # autoscaler-vol:
+  #   mountPath: /data/autoscaler/
+  # custom-vol:
+  #   name: custom-secret
+  #   mountPath: /data/custom/
+  #   items:
+  #     - key: subkey
+  #       path: mypath
+
+# extraVolumes -- Additional volumes.
+extraVolumes: []
+  # - name: ssl-certs
+  #   hostPath:
+  #     path: /etc/ssl/certs/ca-bundle.crt
+
+# extraVolumeMounts -- Additional volumes to mount.
+extraVolumeMounts: []
+  # - name: ssl-certs
+  #   mountPath: /etc/ssl/certs/ca-certificates.crt
+  #   readonly: true
+
+# fullnameOverride -- String to fully override "cluster-autoscaler.fullname" template.
+fullnameOverride: ""
+
+image:
+  # image.repository -- Image repository
+  repository: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
+  # image.tag -- Image tag
+  tag: v1.18.1
+  # image.pullPolicy -- Image pull policy
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # image.pullSecrets -- Image pull secrets
+  pullSecrets: []
+  # - myRegistrKeySecretName
+
+# kubeTargetVersionOverride -- Allow overriding the ".Capabilities.KubeVersion.GitVersion" check. Useful for "helm template" commands.
+kubeTargetVersionOverride: ""
+
+# nameOverride -- String to partially override "cluster-autoscaler.fullname" template (will maintain the release name)
+nameOverride: ""
+
+# nodeSelector -- Node labels for pod assignment. Ref: https://kubernetes.io/docs/user-guide/node-selection/.
+nodeSelector: {}
+
+# podAnnotations -- Annotations to add to each pod.
+podAnnotations: {}
+
+# podDisruptionBudget -- Pod disruption budget.
+podDisruptionBudget:
+  maxUnavailable: 1
+  # minAvailable: 2
+
+# podLabels -- Labels to add to each pod.
+podLabels: {}
+
+# additionalLabels -- Labels to add to each object of the chart.
+additionalLabels: {}
+
+# priorityClassName -- priorityClassName
+priorityClassName: ""
+
+rbac:
+  # rbac.create -- If "true", create and use RBAC resources.
+  create: true
+  # rbac.pspEnabled -- If "true", creates and uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled.
+  # Must be used with "rbac.create" set to "true".
+  pspEnabled: false
+  serviceAccount:
+    # rbac.serviceAccount.annotations -- Additional Service Account annotations.
+    annotations: {}
+    # rbac.serviceAccount.create -- If "true" and "rbac.create" is also true, a Service Account will be created.
+    create: false
+    # rbac.serviceAccount.name -- The name of the ServiceAccount to use. If not set and create is "true", a name is generated using the fullname template.
+    name: autoscaler
+
+# replicaCount -- Desired number of pods
+replicaCount: 1
+
+# resources -- Pod resource requests and limits.
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi
+
+# securityContext -- [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+securityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1001
+  # runAsGroup: 1001
+
+service:
+  # service.annotations -- Annotations to add to service
+  annotations: {}
+  # service.labels -- Labels to add to service
+  labels: {}
+  # service.externalIPs -- List of IP addresses at which the service is available. Ref: https://kubernetes.io/docs/user-guide/services/#external-ips.
+  externalIPs: []
+
+  # service.loadBalancerIP -- IP address to assign to load balancer (if supported).
+  loadBalancerIP: ""
+  # service.loadBalancerSourceRanges -- List of IP CIDRs allowed access to load balancer (if supported).
+  loadBalancerSourceRanges: []
+  # service.servicePort -- Service port to expose.
+  servicePort: 8085
+  # service.portName -- Name for service port.
+  portName: http
+  # service.type -- Type of service to create.
+  type: ClusterIP
+
+## Are you using Prometheus Operator?
+serviceMonitor:
+  # serviceMonitor.enabled -- If true, creates a Prometheus Operator ServiceMonitor.
+  enabled: false
+  # serviceMonitor.interval -- Interval that Prometheus scrapes Cluster Autoscaler metrics.
+  interval: 10s
+  # serviceMonitor.namespace -- Namespace which Prometheus is running in.
+  namespace: monitoring
+  ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
+  ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
+  # serviceMonitor.selector -- Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install.
+  selector:
+    release: prometheus-operator
+  # serviceMonitor.path -- The path to scrape for metrics; autoscaler exposes "/metrics" (this is standard)
+  path: /metrics
+
+# tolerations -- List of node taints to tolerate (requires Kubernetes >= 1.6).
+tolerations: []
+
+# updateStrategy -- [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
+updateStrategy: {}
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+  # type: RollingUpdate

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -559,11 +559,30 @@ type Chart struct {
 	Values interface{}
 }
 
+// RawMarshaller provides an interface for
+// returning raw YAML
+type RawMarshaller interface {
+	RawYAML() ([]byte, error)
+}
+
 // InstallConfig returns a valid install config
 func (c *Chart) InstallConfig() (*InstallConfig, error) {
-	values, err := yaml.Marshal(c.Values)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialise values: %w", err)
+	var values []byte
+
+	var err error
+
+	if raw, ok := c.Values.(RawMarshaller); ok {
+		values, err = raw.RawYAML()
+
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		values, err = yaml.Marshal(c.Values)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialise values: %w", err)
+		}
 	}
 
 	return &InstallConfig{

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -193,6 +193,7 @@ func (o *Okctl) ClientServices(spin spinner.Spinner) (*clientCore.Services, erro
 		Parameter:                        o.paramService(outputDir, spin),
 		Vpc:                              o.vpcService(outputDir, spin),
 		IdentityManager:                  o.identityManagerService(outputDir, spin),
+		Autoscaler:                       o.autoscalerService(outputDir, spin),
 	}, nil
 }
 
@@ -364,6 +365,33 @@ func (o *Okctl) clusterService(outputDir string, spin spinner.Spinner) client.Cl
 		),
 		console.NewClusterReport(o.Err, spin),
 		stateSaver.NewClusterState(o.RepoStateWithEnv),
+	)
+}
+
+func (o *Okctl) autoscalerService(outputDir string, spin spinner.Spinner) client.AutoscalerService {
+	return clientCore.NewAutoscalerService(
+		spin,
+		rest.NewAutoscalerAPI(o.restClient),
+		clientFilesystem.NewAutoscalerStore(
+			clientFilesystem.Paths{
+				OutputFile:         config.DefaultPolicyOutputFile,
+				CloudFormationFile: config.DefaultPolicyCloudFormationTemplateFile,
+				BaseDir:            path.Join(outputDir, config.DefaultAutoscalerBaseDir),
+			},
+			clientFilesystem.Paths{
+				OutputFile: config.DefaultServiceAccountOutputsFile,
+				ConfigFile: config.DefaultServiceAccountConfigFile,
+				BaseDir:    path.Join(outputDir, config.DefaultAutoscalerBaseDir),
+			},
+			clientFilesystem.Paths{
+				OutputFile:  config.DefaultHelmOutputsFile,
+				ReleaseFile: config.DefaultHelmReleaseFile,
+				ChartFile:   config.DefaultHelmChartFile,
+				BaseDir:     path.Join(outputDir, config.DefaultAutoscalerBaseDir),
+			},
+			o.FileSystem,
+		),
+		console.NewAutoscalerReport(o.Err, spin),
 	)
 }
 

--- a/userdocs/src/components/kubernetes.md
+++ b/userdocs/src/components/kubernetes.md
@@ -7,6 +7,7 @@ Kubernetes is [highly configurable and extensible](https://kubernetes.io/docs/co
 - [Kubernetes External Secrets](#kubernetes-external-secrets)
 - [AWS ALB Ingress Controller](#aws-alb-ingress-controller)
 - [ExternalDNS](#externaldns)
+- [Cluster Autoscaler](#cluster-autoscaler)
 
 ### Kubernetes External Secrets
 
@@ -163,4 +164,7 @@ spec:
               serviceName: test-backend-service
               servicePort: 80
 ```
- 
+
+### Cluster Autoscaler 
+
+[Cluster Autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md) is a tool that automatically adjusts the size of the Kubernetes cluster. On AWS it does this by adjusting the size of the [Autoscaling Group](https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html) of the cluster's nodegroup. We have configured the cluster autoscaler to automatically adjust the default nodegroup that we add to a cluster. Starting at 1 node it can scale up and down to a maximum of 10 nodes.


### PR DESCRIPTION
Add [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) to Kubernetes cluster

## Description
Cluster Autoscaler is a tool that automatically adjusts the size of the Kubernetes cluster when one of the following conditions is true:

- Some pods failed to run in the cluster due to insufficient resources.
- There are nodes in the cluster that have been underutilized for an extended period of time, and their pods can be placed on other existing nodes.

By introducing the cluster autoscaler, we can reduce costs during slow periods by scaling down the resource usage.

Each commit represents an isolated unit of code; thus, you can follow the way this is implemented by stepping through the commits in turn.

## Motivation and Context

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
