### PR TITLE
[KM121] Add names to the VPC and subnets so that they are easier to distinguish 

### DIFF
--- a/pkg/cfn/components/subnet/subnet.go
+++ b/pkg/cfn/components/subnet/subnet.go
@@ -76,6 +76,10 @@ func (s *Subnet) Resource() cloudformation.Resource {
 			Key:   fmt.Sprintf("kubernetes.io/cluster/%s", s.cluster.Name()),
 			Value: "shared",
 		},
+		{
+			Key:   "Name",
+			Value: fmt.Sprintf("%s-%s", s.cluster.Name(), s.Name()),
+		},
 	}
 
 	switch s.typ {

--- a/pkg/cfn/components/vpc/vpc.go
+++ b/pkg/cfn/components/vpc/vpc.go
@@ -30,6 +30,10 @@ func (v *VPC) Resource() cloudformation.Resource {
 			Key:   fmt.Sprintf("kubernetes.io/cluster/%s", v.cluster.Name()),
 			Value: "shared",
 		},
+		{
+			Key:   "Name",
+			Value: v.cluster.Name(),
+		},
 	}
 
 	return &ec2.VPC{

--- a/pkg/cfn/testdata/vpc-cloudformation.yaml.golden
+++ b/pkg/cfn/testdata/vpc-cloudformation.yaml.golden
@@ -177,6 +177,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PrivateSubnet00
       - Key: kubernetes.io/role/internal-elb
         Value: "1"
       VpcId:
@@ -196,6 +198,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PrivateSubnet01
       - Key: kubernetes.io/role/internal-elb
         Value: "1"
       VpcId:
@@ -215,6 +219,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PrivateSubnet02
       - Key: kubernetes.io/role/internal-elb
         Value: "1"
       VpcId:
@@ -250,6 +256,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PublicSubnet00
       - Key: kubernetes.io/role/elb
         Value: "1"
       VpcId:
@@ -270,6 +278,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PublicSubnet01
       - Key: kubernetes.io/role/elb
         Value: "1"
       VpcId:
@@ -290,6 +300,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PublicSubnet02
       - Key: kubernetes.io/role/elb
         Value: "1"
       VpcId:
@@ -317,4 +329,6 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test
     Type: AWS::EC2::VPC

--- a/pkg/cfn/testdata/vpc-minimal-cf.yaml.golden
+++ b/pkg/cfn/testdata/vpc-minimal-cf.yaml.golden
@@ -139,6 +139,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PrivateSubnet00
       - Key: kubernetes.io/role/internal-elb
         Value: "1"
       VpcId:
@@ -158,6 +160,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PrivateSubnet01
       - Key: kubernetes.io/role/internal-elb
         Value: "1"
       VpcId:
@@ -177,6 +181,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PrivateSubnet02
       - Key: kubernetes.io/role/internal-elb
         Value: "1"
       VpcId:
@@ -212,6 +218,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PublicSubnet00
       - Key: kubernetes.io/role/elb
         Value: "1"
       VpcId:
@@ -232,6 +240,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PublicSubnet01
       - Key: kubernetes.io/role/elb
         Value: "1"
       VpcId:
@@ -252,6 +262,8 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test-PublicSubnet02
       - Key: kubernetes.io/role/elb
         Value: "1"
       VpcId:
@@ -279,4 +291,6 @@ Resources:
       Tags:
       - Key: kubernetes.io/cluster/test-test
         Value: shared
+      - Key: Name
+        Value: test-test
     Type: AWS::EC2::VPC


### PR DESCRIPTION
Add names to the VPC and subnets so that they are easier to distinguish 

## Description
We now add the cluster name to the vpc and subnets and the type of subnet to the subnets also:

<img width="270" alt="image" src="https://user-images.githubusercontent.com/154348/108120653-e50fde00-70a1-11eb-80f3-a5d2e05fe7f7.png">


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
