### PR TITLE
[KM159] Enable EKS control plane logging by default

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/clusterconfig_v1alpha5.go
+++ b/pkg/apis/eksctl.io/v1alpha5/clusterconfig_v1alpha5.go
@@ -21,12 +21,43 @@ const (
 type ClusterConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Metadata        ClusterMeta      `json:"metadata"`
-	IAM             ClusterIAM       `json:"iam"`
-	VPC             *ClusterVPC      `json:"vpc,omitempty"`
-	FargateProfiles []FargateProfile `json:"fargateProfiles,omitempty"`
-	NodeGroups      []NodeGroup      `json:"nodeGroups,omitempty"`
-	Status          *ClusterStatus   `json:"status,omitempty"`
+	Metadata        ClusterMeta        `json:"metadata"`
+	IAM             ClusterIAM         `json:"iam"`
+	VPC             *ClusterVPC        `json:"vpc,omitempty"`
+	FargateProfiles []FargateProfile   `json:"fargateProfiles,omitempty"`
+	NodeGroups      []NodeGroup        `json:"nodeGroups,omitempty"`
+	Status          *ClusterStatus     `json:"status,omitempty"`
+	CloudWatch      *ClusterCloudWatch `json:"cloudWatch,omitempty"`
+}
+
+// ClusterCloudWatch maps up parts of the eksctl config that we require
+type ClusterCloudWatch struct {
+	ClusterLogging *ClusterCloudWatchLogging `json:"clusterLogging,omitempty"`
+}
+
+// ClusterCloudWatchLogging maps up parts of the eksctl config that we require
+type ClusterCloudWatchLogging struct {
+	EnableTypes []string `json:"enableTypes,omitempty"`
+}
+
+// nolint: golint
+const (
+	CloudWatchAPILogging               = "api"
+	CloudWatchAuditLogging             = "audit"
+	CloudWatchAuthenticatorLogging     = "authenticator"
+	CloudWatchControllerManagerLogging = "controllerManager"
+	CloudWatchSchedulerLogging         = "scheduler"
+)
+
+// AllCloudWatchLogging returns all the available cloud watch loggers
+func AllCloudWatchLogging() []string {
+	return []string{
+		CloudWatchAPILogging,
+		CloudWatchAuditLogging,
+		CloudWatchAuthenticatorLogging,
+		CloudWatchControllerManagerLogging,
+		CloudWatchSchedulerLogging,
+	}
 }
 
 // ClusterStatus hold read-only attributes of a cluster

--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -83,6 +83,18 @@ func (a *Args) build() *v1alpha5.ClusterConfig {
 				},
 			},
 		},
+		VPC: &v1alpha5.ClusterVPC{
+			ID:   a.VpcID,
+			CIDR: a.VpcCidr,
+			ClusterEndpoints: v1alpha5.ClusterEndpoints{
+				PrivateAccess: true,
+				PublicAccess:  true,
+			},
+			Subnets: v1alpha5.ClusterSubnets{
+				Private: map[string]v1alpha5.ClusterNetwork{},
+				Public:  map[string]v1alpha5.ClusterNetwork{},
+			},
+		},
 		FargateProfiles: []v1alpha5.FargateProfile{
 			{
 				Name: "fp-default",
@@ -115,16 +127,9 @@ func (a *Args) build() *v1alpha5.ClusterConfig {
 				},
 			},
 		},
-		VPC: &v1alpha5.ClusterVPC{
-			ID:   a.VpcID,
-			CIDR: a.VpcCidr,
-			ClusterEndpoints: v1alpha5.ClusterEndpoints{
-				PrivateAccess: true,
-				PublicAccess:  true,
-			},
-			Subnets: v1alpha5.ClusterSubnets{
-				Private: map[string]v1alpha5.ClusterNetwork{},
-				Public:  map[string]v1alpha5.ClusterNetwork{},
+		CloudWatch: &v1alpha5.ClusterCloudWatch{
+			ClusterLogging: &v1alpha5.ClusterCloudWatchLogging{
+				EnableTypes: v1alpha5.AllCloudWatchLogging(),
 			},
 		},
 	}

--- a/pkg/clusterconfig/testdata/clusterConfig.golden
+++ b/pkg/clusterconfig/testdata/clusterConfig.golden
@@ -1,4 +1,12 @@
 apiVersion: eksctl.io/v1alpha5
+cloudWatch:
+  clusterLogging:
+    enableTypes:
+    - api
+    - audit
+    - authenticator
+    - controllerManager
+    - scheduler
 fargateProfiles:
 - name: fp-default
   selectors:


### PR DESCRIPTION
**NB:** This PR needs to be merged into #323 first

Enable EKS [control plane logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) by default

## Description
By enabling control plane logging to cloud watch we can more easily debug certain failure scenarios from outside the cluster. We also get the added benefit of storing the audit and authentication logs outside of the cluster.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
