### PR TITLE
KM177: 🐛 Linux doesn't need pass

### DIFF
--- a/docs/release_notes/0.0.44.md
+++ b/docs/release_notes/0.0.44.md
@@ -1,0 +1,9 @@
+# Release 0.0.44
+
+## Features
+
+## Bugfixes
+- #355: Remove okctl requiring pass on Linux, it should use the default keychain
+
+## Other
+

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -3,13 +3,7 @@ package keyring
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path"
-	"path/filepath"
 	"runtime"
-
-	"github.com/mitchellh/go-homedir"
 
 	krPkg "github.com/99designs/keyring"
 	"github.com/oslokommune/okctl/pkg/config"
@@ -57,47 +51,11 @@ func DefaultKeyringForOS() (krPkg.Keyring, error) {
 	case "darwin":
 		cfg.AllowedBackends = []krPkg.BackendType{krPkg.KeychainBackend}
 	case "linux":
-		cfg.AllowedBackends = []krPkg.BackendType{krPkg.PassBackend}
-
-		if err := VerifyPass(); err != nil {
-			return nil, err
-		}
 	default:
 		return nil, fmt.Errorf("no supported keyring backends for your operating system: %s", runtime.GOOS)
 	}
 
 	return krPkg.Open(cfg)
-}
-
-// VerifyPass checks for the existence of pass on the commandline
-func VerifyPass() error {
-	passDir := ".password-store"
-
-	envPassDir := os.Getenv("PASSWORD_STORE_DIR")
-	if len(envPassDir) > 0 {
-		passDir = envPassDir
-	}
-
-	dir, err := homedir.Dir()
-	if err != nil {
-		return err
-	}
-
-	fullPassDir, err := filepath.Abs(path.Join(dir, passDir))
-	if err != nil {
-		return err
-	}
-
-	passBinary, err := exec.LookPath("pass")
-	if err != nil {
-		return err
-	}
-
-	if len(fullPassDir) > 0 || len(passBinary) > 0 {
-		return nil
-	}
-
-	return fmt.Errorf("you need to install pass (https://www.passwordstore.org), read the init section carefully")
 }
 
 // Store a value with given keytype and value in keyring


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Don't require `pass` on Linux.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#314 fixed so that macOS use it's native keychain instead of requiring pass. Unfortunately, now `okctl apply cluster` fails on Linux instead, as it now requires pass.

okctl should use the native keychain on Linux as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [x] Tested on fresh install of ubuntu in virtualbox. Confirmed that I got the non-pass-keyring-popup asking for password.
- [x] Tested on our macOS instance in the cloud: Removed pass from it, and got same result as for linux, i.e. the macOS native keychain-thing.

For future reference, the way I tested it on macOS was to

* edit the okctl.go:getGithubAuthenticator method to contain

```
_ = k.Store("mytest", "hallo")
pw, err := k.Fetch("mytest")
```

and call `o.getGithubAuthenticator` from main.go:buildRootCommand as on one of the first lines.
* push it to a branch
* on the virtual mac, clone the branch, build it, and run it.
* run okctl apply cluster (or some other command)

All this so I could avoid logging in to my aws account (which the okctl apply cluster command need), which was very hard, as Nomachine running the virtual mac doesn't support inserting a clipboard value from the host (i.e. transferring account password and 2fa), and I don't really want to login to my account from that remote machine.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).

As the user documentation is currently being edited in another branch, I will update the docs related to this in that PR or a new PR.
