### PR TITLE
👌 Move NS record delegation test to after cluster

### DIFF
--- a/cmd/okctl/applycluster.go
+++ b/cmd/okctl/applycluster.go
@@ -149,7 +149,8 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 				reconciler.NewIdentityManagerReconciler(services.IdentityManager),
 				reconciler.NewVPCReconciler(services.Vpc),
 				reconciler.NewZoneReconciler(services.Domain),
-				reconciler.NewNameserverDelegationReconciler(services.NameserverHandler, services.Domain),
+				reconciler.NewNameserverDelegationReconciler(services.NameserverHandler),
+				reconciler.NewNameserverDelegatedTestReconciler(services.Domain),
 			)
 
 			reconciliationManager.SetCommonMetadata(&resourcetree.CommonMetadata{

--- a/docs/release_notes/0.0.43.md
+++ b/docs/release_notes/0.0.43.md
@@ -7,3 +7,4 @@
 
 ## Other
 - 👌 Improve creation of apply cluster resource dependency trees
+- 👌 Move NS delegation test as far down the road as possible

--- a/pkg/controller/convert.go
+++ b/pkg/controller/convert.go
@@ -70,6 +70,7 @@ func CreateResourceDependencyTree() (root *resourcetree.ResourceNode) {
 	createNode(clusterNode, resourcetree.ResourceNodeTypeAWSLoadBalancerController)
 	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalDNS)
 
+	// All resources that requires SSL / a certificate needs the delegatedNameserversConfirmedNode as a dependency
 	delegatedNameserversConfirmedNode := createNode(clusterNode, resourcetree.ResourceNodeTypeNameserversDelegatedTest)
 
 	identityProviderNode := createNode(delegatedNameserversConfirmedNode, resourcetree.ResourceNodeTypeIdentityManager)

--- a/pkg/controller/convert.go
+++ b/pkg/controller/convert.go
@@ -11,19 +11,20 @@ import (
 
 // ExistingResources contains information about what services already exists in a cluster
 type ExistingResources struct {
-	hasALBIngressController           bool
-	hasAWSLoadBalancerController      bool
-	hasCluster                        bool
-	hasExternalDNS                    bool
-	hasExternalSecrets                bool
-	hasAutoscaler                     bool
-	hasBlockstorage                   bool
-	hasKubePromStack                  bool
-	hasIdentityManager                bool
-	hasArgoCD                         bool
-	hasPrimaryHostedZone              bool
-	hasVPC                            bool
-	hasDelegatedHostedZoneNameservers bool
+	hasALBIngressController               bool
+	hasAWSLoadBalancerController          bool
+	hasCluster                            bool
+	hasExternalDNS                        bool
+	hasExternalSecrets                    bool
+	hasAutoscaler                         bool
+	hasBlockstorage                       bool
+	hasKubePromStack                      bool
+	hasIdentityManager                    bool
+	hasArgoCD                             bool
+	hasPrimaryHostedZone                  bool
+	hasVPC                                bool
+	hasDelegatedHostedZoneNameservers     bool
+	hasDelegatedHostedZoneNameserversTest bool
 }
 
 // IdentifyResourcePresence creates an initialized ExistingResources struct
@@ -31,19 +32,20 @@ func IdentifyResourcePresence(fs *afero.Afero, outputDir string, hzFetcher Hoste
 	hz := hzFetcher()
 
 	return ExistingResources{
-		hasPrimaryHostedZone:              hz != nil,
-		hasVPC:                            directoryTester(fs, outputDir, config.DefaultVpcBaseDir),
-		hasCluster:                        directoryTester(fs, outputDir, config.DefaultClusterBaseDir),
-		hasExternalSecrets:                directoryTester(fs, outputDir, config.DefaultExternalSecretsBaseDir),
-		hasAutoscaler:                     directoryTester(fs, outputDir, config.DefaultAutoscalerBaseDir),
-		hasKubePromStack:                  directoryTester(fs, outputDir, config.DefaultKubePromStackBaseDir),
-		hasBlockstorage:                   directoryTester(fs, outputDir, config.DefaultBlockstorageBaseDir),
-		hasALBIngressController:           directoryTester(fs, outputDir, config.DefaultAlbIngressControllerBaseDir),
-		hasAWSLoadBalancerController:      directoryTester(fs, outputDir, config.DefaultAWSLoadBalancerControllerBaseDir),
-		hasExternalDNS:                    directoryTester(fs, outputDir, config.DefaultExternalDNSBaseDir),
-		hasIdentityManager:                directoryTester(fs, outputDir, config.DefaultIdentityPoolBaseDir),
-		hasArgoCD:                         directoryTester(fs, outputDir, config.DefaultArgoCDBaseDir),
-		hasDelegatedHostedZoneNameservers: hz != nil && hz.IsDelegated,
+		hasPrimaryHostedZone:                  hz != nil,
+		hasVPC:                                directoryTester(fs, outputDir, config.DefaultVpcBaseDir),
+		hasCluster:                            directoryTester(fs, outputDir, config.DefaultClusterBaseDir),
+		hasExternalSecrets:                    directoryTester(fs, outputDir, config.DefaultExternalSecretsBaseDir),
+		hasAutoscaler:                         directoryTester(fs, outputDir, config.DefaultAutoscalerBaseDir),
+		hasKubePromStack:                      directoryTester(fs, outputDir, config.DefaultKubePromStackBaseDir),
+		hasBlockstorage:                       directoryTester(fs, outputDir, config.DefaultBlockstorageBaseDir),
+		hasALBIngressController:               directoryTester(fs, outputDir, config.DefaultAlbIngressControllerBaseDir),
+		hasAWSLoadBalancerController:          directoryTester(fs, outputDir, config.DefaultAWSLoadBalancerControllerBaseDir),
+		hasExternalDNS:                        directoryTester(fs, outputDir, config.DefaultExternalDNSBaseDir),
+		hasIdentityManager:                    directoryTester(fs, outputDir, config.DefaultIdentityPoolBaseDir),
+		hasArgoCD:                             directoryTester(fs, outputDir, config.DefaultArgoCDBaseDir),
+		hasDelegatedHostedZoneNameservers:     hz != nil && hz.IsDelegated,
+		hasDelegatedHostedZoneNameserversTest: false,
 	}, nil
 }
 
@@ -68,7 +70,9 @@ func CreateResourceDependencyTree() (root *resourcetree.ResourceNode) {
 	createNode(clusterNode, resourcetree.ResourceNodeTypeAWSLoadBalancerController)
 	createNode(clusterNode, resourcetree.ResourceNodeTypeExternalDNS)
 
-	identityProviderNode := createNode(clusterNode, resourcetree.ResourceNodeTypeIdentityManager)
+	delegatedNameserversConfirmedNode := createNode(clusterNode, resourcetree.ResourceNodeTypeNameserversDelegatedTest)
+
+	identityProviderNode := createNode(delegatedNameserversConfirmedNode, resourcetree.ResourceNodeTypeIdentityManager)
 	createNode(identityProviderNode, resourcetree.ResourceNodeTypeKubePromStack)
 	createNode(identityProviderNode, resourcetree.ResourceNodeTypeArgoCD)
 

--- a/pkg/controller/reconciler/nameserverdelegator_reconciler.go
+++ b/pkg/controller/reconciler/nameserverdelegator_reconciler.go
@@ -2,19 +2,13 @@ package reconciler
 
 import (
 	"fmt"
-	"time"
-
-	"github.com/logrusorgru/aurora"
 
 	"github.com/miekg/dns"
 
 	"github.com/mishudark/errors"
 	"github.com/oslokommune/okctl/pkg/client"
 	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
-	"github.com/oslokommune/okctl/pkg/domain"
 )
-
-const nsRecordValidationIntervalSeconds = 15
 
 // NameserverHandlerReconcilerResourceState contains data extracted from the desired state
 type NameserverHandlerReconcilerResourceState struct {
@@ -28,8 +22,7 @@ type NameserverHandlerReconcilerResourceState struct {
 type nameserverDelegationReconciler struct {
 	commonMetadata *resourcetree.CommonMetadata
 
-	client        client.NameserverRecordDelegationService
-	domainService client.DomainService
+	client client.NameserverRecordDelegationService
 }
 
 // NodeType returns the relevant ResourceNodeType for this reconciler
@@ -51,31 +44,15 @@ func (z *nameserverDelegationReconciler) Reconcile(node *resourcetree.ResourceNo
 
 	switch node.State {
 	case resourcetree.ResourceNodeStatePresent:
-		var record *client.NameserverRecord
-
 		primaryHostedZoneFQDN := dns.Fqdn(z.commonMetadata.Declaration.PrimaryDNSZone.ParentDomain)
 
-		record, err = z.client.CreateNameserverRecordDelegationRequest(&client.CreateNameserverDelegationRequestOpts{
+		_, err = z.client.CreateNameserverRecordDelegationRequest(&client.CreateNameserverDelegationRequestOpts{
 			ClusterID:             z.commonMetadata.ClusterID,
 			PrimaryHostedZoneFQDN: primaryHostedZoneFQDN,
 			Nameservers:           resourceState.Nameservers,
 		})
 		if err != nil {
 			return result, fmt.Errorf("handling nameservers: %w", err)
-		}
-
-		fmt.Fprintf(
-			z.commonMetadata.Out,
-			delegationRequestMessage,
-			aurora.Green("nameserver delegation request"),
-			aurora.Bold("#kjøremiljø-support"),
-		)
-
-		waitForNameserverDelegation(nsRecordValidationIntervalSeconds, primaryHostedZoneFQDN)
-
-		err = z.domainService.SetHostedZoneDelegation(z.commonMetadata.Ctx, domain.EnsureNotFQDN(record.FQDN), true)
-		if err != nil {
-			return result, fmt.Errorf("setting hosted zone delegation status: %w", err)
 		}
 	case resourcetree.ResourceNodeStateAbsent:
 		return result, errors.New("deletion of the hosted zone delegation is not implemented")
@@ -85,32 +62,8 @@ func (z *nameserverDelegationReconciler) Reconcile(node *resourcetree.ResourceNo
 }
 
 // NewNameserverDelegationReconciler creates a new reconciler for the nameserver record delegation resource
-func NewNameserverDelegationReconciler(client client.NameserverRecordDelegationService, domainService client.DomainService) Reconciler {
+func NewNameserverDelegationReconciler(client client.NameserverRecordDelegationService) Reconciler {
 	return &nameserverDelegationReconciler{
-		client:        client,
-		domainService: domainService,
+		client: client,
 	}
 }
-
-func waitForNameserverDelegation(interval time.Duration, fqdn string) {
-	var err error
-
-	for {
-		err = domain.ShouldHaveNameServers(fqdn)
-
-		if err == nil {
-			break
-		}
-
-		time.Sleep(interval * time.Second)
-	}
-}
-
-const delegationRequestMessage = `
-
-
-A %s has been submitted. We'll process this request as soon as possible.
-Let us know in %s if it takes too long
-
-
-`

--- a/pkg/controller/reconciler/nameserversdelegatedtest_reconciler.go
+++ b/pkg/controller/reconciler/nameserversdelegatedtest_reconciler.go
@@ -1,0 +1,81 @@
+package reconciler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/miekg/dns"
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+	"github.com/oslokommune/okctl/pkg/domain"
+)
+
+const defaultTestingIntervalMinutes = 5 * time.Minute
+
+type nameserversDelegatedTestReconciler struct {
+	commonMetadata *resourcetree.CommonMetadata
+
+	domainService client.DomainService
+}
+
+// NodeType returns the relevant ResourceNodeType for this reconciler
+func (n *nameserversDelegatedTestReconciler) NodeType() resourcetree.ResourceNodeType {
+	return resourcetree.ResourceNodeTypeNameserversDelegatedTest
+}
+
+// SetCommonMetadata saves common metadata for use in Reconcile()
+func (n *nameserversDelegatedTestReconciler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	n.commonMetadata = metadata
+}
+
+// Reconcile knows how to do what is necessary to ensure the desired state is achieved
+func (n *nameserversDelegatedTestReconciler) Reconcile(node *resourcetree.ResourceNode) (result ReconcilationResult, err error) {
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		fmt.Fprintf(
+			n.commonMetadata.Out,
+			delegationRequestMessage,
+			aurora.Green("nameserver delegation request"),
+			aurora.Bold("#kjøremiljø-support"),
+		)
+
+		primaryHostedZoneFQDN := dns.Fqdn(n.commonMetadata.Declaration.PrimaryDNSZone.ParentDomain)
+
+		err = domain.ShouldHaveNameServers(primaryHostedZoneFQDN)
+		if err != nil {
+			result.Requeue = true
+			result.RequeueAfter = defaultTestingIntervalMinutes
+
+			return result, nil
+		}
+
+		err = n.domainService.SetHostedZoneDelegation(
+			n.commonMetadata.Ctx,
+			n.commonMetadata.Declaration.PrimaryDNSZone.ParentDomain,
+			true,
+		)
+		if err != nil {
+			return result, fmt.Errorf("setting hosted zone delegation status: %w", err)
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		return result, errors.New("removing nameservers delegated test is not implemented")
+	}
+
+	return result, nil
+}
+
+// NewNameserverDelegatedTestReconciler creates a new reconciler for the nameserver record delegation test resource
+func NewNameserverDelegatedTestReconciler(domainService client.DomainService) Reconciler {
+	return &nameserversDelegatedTestReconciler{domainService: domainService}
+}
+
+const delegationRequestMessage = `
+
+
+A %s has been submitted. We'll process this request as soon as possible.
+Let us know in %s if it takes too long
+
+
+`

--- a/pkg/controller/resourcetree/tree.go
+++ b/pkg/controller/resourcetree/tree.go
@@ -43,6 +43,8 @@ const (
 	ResourceNodeTypeArgoCD
 	// ResourceNodeTypeNameserverDelegator represents delegation of nameservers for a HostedZone
 	ResourceNodeTypeNameserverDelegator
+	// ResourceNodeTypeNameserversDelegatedTest represents testing if nameservers has been successfully delegated
+	ResourceNodeTypeNameserversDelegatedTest
 )
 
 // ResourceNodeTypeToString knows how to convert a Resource Node type to a human readable string
@@ -77,8 +79,10 @@ func ResourceNodeTypeToString(nodeType ResourceNodeType) string {
 		return "ArgoCD controller"
 	case ResourceNodeTypeNameserverDelegator:
 		return "Nameserver Delegation"
+	case ResourceNodeTypeNameserversDelegatedTest:
+		return "Nameservers Delegated Test"
 	default:
-		return ""
+		return "N/A"
 	}
 }
 

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -164,14 +164,3 @@ func ShouldHaveNameServers(domain string) error {
 
 	return fmt.Errorf("unable to get NS records for domain '%s', does not appear to be delegated yet", domain)
 }
-
-// EnsureNotFQDN returns a string without the trailing dot
-func EnsureNotFQDN(potentialFQDN string) string {
-	lastCharIndex := len(potentialFQDN) - 1
-
-	if potentialFQDN[lastCharIndex] == '.' {
-		return potentialFQDN[:lastCharIndex]
-	}
-
-	return potentialFQDN
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR creates a nameserver delegation tester reconciler, a reconciler that ensures that the nameservers has successfully been delegated. 

It also sets the identity provider as a dependency to the NS delegation test. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We can save some time by moving the actual test of a successful NS record delegation further down the process. That means that the `terraform apply` workflow and the actual dns propagation can do its thing while we set up more of the resources. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually and things

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
