### PR TITLE
[KM179] Add CloudWatch as a data source to Grafana

### DIFF
--- a/pkg/api/core/endpoint_kube.go
+++ b/pkg/api/core/endpoint_kube.go
@@ -54,3 +54,9 @@ func makeScaleDeployment(s api.KubeService) endpoint.Endpoint {
 		return Empty{}, s.ScaleDeployment(ctx, request.(api.ScaleDeploymentOpts))
 	}
 }
+
+func makeCreateNamespace(s api.KubeService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return s.CreateNamespace(ctx, request.(api.CreateNamespaceOpts))
+	}
+}

--- a/pkg/api/core/endpoint_managedpolicy.go
+++ b/pkg/api/core/endpoint_managedpolicy.go
@@ -78,3 +78,15 @@ func makeDeleteBlockstoragePolicyEndpoint(s api.ManagedPolicyService) endpoint.E
 		return &Empty{}, s.DeleteBlockstoragePolicy(ctx, request.(api.ID))
 	}
 }
+
+func makeCreatePolicyEndpoint(s api.ManagedPolicyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return s.CreatePolicy(ctx, request.(api.CreatePolicyOpts))
+	}
+}
+
+func makeDeletePolicyEndpoint(s api.ManagedPolicyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return &Empty{}, s.DeletePolicy(ctx, request.(api.DeletePolicyOpts))
+	}
+}

--- a/pkg/api/core/endpoint_serviceaccount.go
+++ b/pkg/api/core/endpoint_serviceaccount.go
@@ -78,3 +78,15 @@ func makeDeleteBlockstorageServiceAccountEndpoint(s api.ServiceAccountService) e
 		return &Empty{}, s.DeleteBlockstorageServiceAccount(ctx, request.(api.ID))
 	}
 }
+
+func makeCreateServiceAccountEndpoint(s api.ServiceAccountService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return s.CreateServiceAccount(ctx, request.(api.CreateServiceAccountOpts))
+	}
+}
+
+func makeDeleteServiceAccountEndpoint(s api.ServiceAccountService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return &Empty{}, s.DeleteServiceAccount(ctx, request.(api.DeleteServiceAccountOpts))
+	}
+}

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -79,6 +79,7 @@ type Endpoints struct {
 	DeletePolicy                                  endpoint.Endpoint
 	CreateServiceAccount                          endpoint.Endpoint
 	DeleteServiceAccount                          endpoint.Endpoint
+	CreateNamespace                               endpoint.Endpoint
 }
 
 // MakeEndpoints returns the endpoints initialised with their
@@ -149,6 +150,7 @@ func MakeEndpoints(s Services) Endpoints {
 		DeletePolicy:                                  makeDeletePolicyEndpoint(s.ManagedPolicy),
 		CreateServiceAccount:                          makeCreateServiceAccountEndpoint(s.ServiceAccount),
 		DeleteServiceAccount:                          makeDeleteServiceAccountEndpoint(s.ServiceAccount),
+		CreateNamespace:                               makeCreateNamespace(s.Kube),
 	}
 }
 
@@ -217,6 +219,7 @@ type Handlers struct {
 	DeletePolicy                                  http.Handler
 	CreateServiceAccount                          http.Handler
 	DeleteServiceAccount                          http.Handler
+	CreateNamespace                               http.Handler
 }
 
 // EncodeResponseType defines a type for responses
@@ -313,6 +316,7 @@ func MakeHandlers(responseType EncodeResponseType, endpoints Endpoints) *Handler
 		DeletePolicy:                                  newServer(endpoints.DeletePolicy, decodeStructRequest(&api.DeletePolicyOpts{})),
 		CreateServiceAccount:                          newServer(endpoints.CreateServiceAccount, decodeStructRequest(&api.CreateServiceAccountOpts{})),
 		DeleteServiceAccount:                          newServer(endpoints.DeleteServiceAccount, decodeStructRequest(&api.DeleteServiceAccountOpts{})),
+		CreateNamespace:                               newServer(endpoints.CreateNamespace, decodeStructRequest(&api.CreateNamespaceOpts{})),
 	}
 }
 
@@ -428,6 +432,7 @@ func AttachRoutes(handlers *Handlers) http.Handler {
 				r.Method(http.MethodDelete, "/", handlers.DeleteExternalSecrets)
 			})
 			r.Route("/namespaces", func(r chi.Router) {
+				r.Method(http.MethodPost, "/", handlers.CreateNamespace)
 				r.Method(http.MethodDelete, "/", handlers.DeleteNamespace)
 			})
 			r.Route("/storageclasses", func(r chi.Router) {
@@ -598,6 +603,7 @@ func InstrumentEndpoints(logger *logrus.Logger) EndpointOption {
 			DeletePolicy:                                  logmd.Logging(logger, managedPoliciesTag, "delete")(endpoints.DeletePolicy),
 			CreateServiceAccount:                          logmd.Logging(logger, serviceAccountsTag, "create")(endpoints.CreateServiceAccount),
 			DeleteServiceAccount:                          logmd.Logging(logger, serviceAccountsTag, "delete")(endpoints.DeleteServiceAccount),
+			CreateNamespace:                               logmd.Logging(logger, strings.Join([]string{kubeTag, namespaceTag}, "/"), "create")(endpoints.CreateNamespace),
 		}
 	}
 }

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -77,6 +77,8 @@ type Endpoints struct {
 	DeleteHelmRelease                             endpoint.Endpoint
 	CreatePolicy                                  endpoint.Endpoint
 	DeletePolicy                                  endpoint.Endpoint
+	CreateServiceAccount                          endpoint.Endpoint
+	DeleteServiceAccount                          endpoint.Endpoint
 }
 
 // MakeEndpoints returns the endpoints initialised with their
@@ -145,6 +147,8 @@ func MakeEndpoints(s Services) Endpoints {
 		DeleteHelmRelease:                             makeDeleteHelmRelease(s.Helm),
 		CreatePolicy:                                  makeCreatePolicyEndpoint(s.ManagedPolicy),
 		DeletePolicy:                                  makeDeletePolicyEndpoint(s.ManagedPolicy),
+		CreateServiceAccount:                          makeCreateServiceAccountEndpoint(s.ServiceAccount),
+		DeleteServiceAccount:                          makeDeleteServiceAccountEndpoint(s.ServiceAccount),
 	}
 }
 
@@ -211,6 +215,8 @@ type Handlers struct {
 	DeleteHelmRelease                             http.Handler
 	CreatePolicy                                  http.Handler
 	DeletePolicy                                  http.Handler
+	CreateServiceAccount                          http.Handler
+	DeleteServiceAccount                          http.Handler
 }
 
 // EncodeResponseType defines a type for responses
@@ -305,6 +311,8 @@ func MakeHandlers(responseType EncodeResponseType, endpoints Endpoints) *Handler
 		DeleteHelmRelease:                             newServer(endpoints.DeleteHelmRelease, decodeDeleteHelmRelease),
 		CreatePolicy:                                  newServer(endpoints.CreatePolicy, decodeStructRequest(&api.CreatePolicyOpts{})),
 		DeletePolicy:                                  newServer(endpoints.DeletePolicy, decodeStructRequest(&api.DeletePolicyOpts{})),
+		CreateServiceAccount:                          newServer(endpoints.CreateServiceAccount, decodeStructRequest(&api.CreateServiceAccountOpts{})),
+		DeleteServiceAccount:                          newServer(endpoints.DeleteServiceAccount, decodeStructRequest(&api.DeleteServiceAccountOpts{})),
 	}
 }
 
@@ -351,6 +359,8 @@ func AttachRoutes(handlers *Handlers) http.Handler {
 			})
 		})
 		r.Route("/serviceaccounts", func(r chi.Router) {
+			r.Method(http.MethodPost, "/", handlers.CreateServiceAccount)
+			r.Method(http.MethodDelete, "/", handlers.DeleteServiceAccount)
 			r.Route("/externalsecrets", func(r chi.Router) {
 				r.Method(http.MethodPost, "/", handlers.CreateExternalSecretsServiceAccount)
 				r.Method(http.MethodDelete, "/", handlers.DeleteExternalSecretsServiceAccount)
@@ -586,6 +596,8 @@ func InstrumentEndpoints(logger *logrus.Logger) EndpointOption {
 			DeleteHelmRelease:                             logmd.Logging(logger, strings.Join([]string{helmTag, releasesTag}, "/"), "delete")(endpoints.DeleteHelmRelease),
 			CreatePolicy:                                  logmd.Logging(logger, managedPoliciesTag, "create")(endpoints.CreatePolicy),
 			DeletePolicy:                                  logmd.Logging(logger, managedPoliciesTag, "delete")(endpoints.DeletePolicy),
+			CreateServiceAccount:                          logmd.Logging(logger, serviceAccountsTag, "create")(endpoints.CreateServiceAccount),
+			DeleteServiceAccount:                          logmd.Logging(logger, serviceAccountsTag, "delete")(endpoints.DeleteServiceAccount),
 		}
 	}
 }

--- a/pkg/api/core/run/helm_run.go
+++ b/pkg/api/core/run/helm_run.go
@@ -157,6 +157,7 @@ func (r *helmRun) createHelmChart(id api.ID, chart *helm.Chart) (*api.Helm, erro
 
 func (r *helmRun) CreateKubePromStack(opts api.CreateKubePrometheusStackOpts) (*api.Helm, error) {
 	chart := kubepromstack.New(config.DefaultChartApplyTimeout, &kubepromstack.Values{
+		GrafanaServiceAccountName:          opts.GrafanaCloudWatchServiceAccountName,
 		GrafanaCertificateARN:              opts.CertificateARN,
 		GrafanaHostname:                    opts.Hostname,
 		AuthHostname:                       opts.AuthHostname,

--- a/pkg/api/core/service_kube.go
+++ b/pkg/api/core/service_kube.go
@@ -12,6 +12,20 @@ type kubeService struct {
 	store api.KubeStore
 }
 
+func (k *kubeService) CreateNamespace(_ context.Context, opts api.CreateNamespaceOpts) (*api.Namespace, error) {
+	err := opts.Validate()
+	if err != nil {
+		return nil, errors.E(err, "validating inputs", errors.Invalid)
+	}
+
+	ns, err := k.run.CreateNamespace(opts)
+	if err != nil {
+		return nil, errors.E(err, "creating namespace", errors.Internal)
+	}
+
+	return ns, nil
+}
+
 func (k *kubeService) ScaleDeployment(_ context.Context, opts api.ScaleDeploymentOpts) error {
 	err := opts.Validate()
 	if err != nil {

--- a/pkg/api/core/service_managedpolicy.go
+++ b/pkg/api/core/service_managedpolicy.go
@@ -11,6 +11,34 @@ type managedPolicyService struct {
 	provider api.ManagedPolicyCloudProvider
 }
 
+func (m *managedPolicyService) CreatePolicy(_ context.Context, opts api.CreatePolicyOpts) (*api.ManagedPolicy, error) {
+	err := opts.Validate()
+	if err != nil {
+		return nil, errors.E(err, "validating inputs", errors.Invalid)
+	}
+
+	p, err := m.provider.CreatePolicy(opts)
+	if err != nil {
+		return nil, errors.E(err, "creating managed policy", errors.Internal)
+	}
+
+	return p, nil
+}
+
+func (m *managedPolicyService) DeletePolicy(_ context.Context, opts api.DeletePolicyOpts) error {
+	err := opts.Validate()
+	if err != nil {
+		return errors.E(err, "validating inputs", errors.Invalid)
+	}
+
+	err = m.provider.DeletePolicy(opts)
+	if err != nil {
+		return errors.E(err, "deleting managed policy", errors.Internal)
+	}
+
+	return nil
+}
+
 func (m *managedPolicyService) CreateBlockstoragePolicy(_ context.Context, opts api.CreateBlockstoragePolicy) (*api.ManagedPolicy, error) {
 	err := opts.Validate()
 	if err != nil {

--- a/pkg/api/core/service_serviceaccount.go
+++ b/pkg/api/core/service_serviceaccount.go
@@ -17,19 +17,51 @@ type serviceAccount struct {
 }
 
 var errDeleteServiceAccount = func(err error) error {
-	return errors.E(err, "failed to delete service account", errors.Internal)
+	return errors.E(err, "deleting service account", errors.Internal)
 }
 
 var errCreateServiceAccount = func(err error) error {
-	return errors.E(err, "failed to create service account", errors.Internal)
+	return errors.E(err, "creating service account", errors.Internal)
 }
 
 var errInvalidInputs = func(err error) error {
-	return errors.E(err, "failed to validate inputs", errors.Invalid)
+	return errors.E(err, "validating inputs", errors.Invalid)
 }
 
 var errBuildServiceAccount = func(err error) error {
-	return errors.E(err, "failed to build service account config", errors.Internal)
+	return errors.E(err, "building service account config", errors.Internal)
+}
+
+func (c *serviceAccount) CreateServiceAccount(_ context.Context, opts api.CreateServiceAccountOpts) (*api.ServiceAccount, error) {
+	err := opts.Validate()
+	if err != nil {
+		return nil, errInvalidInputs(err)
+	}
+
+	err = c.run.CreateServiceAccount(opts.Config)
+	if err != nil {
+		return nil, errCreateServiceAccount(err)
+	}
+
+	return &api.ServiceAccount{
+		ID:        opts.ID,
+		PolicyArn: opts.PolicyArn,
+		Config:    opts.Config,
+	}, nil
+}
+
+func (c *serviceAccount) DeleteServiceAccount(_ context.Context, opts api.DeleteServiceAccountOpts) error {
+	err := opts.Validate()
+	if err != nil {
+		return errInvalidInputs(err)
+	}
+
+	err = c.run.DeleteServiceAccount(opts.Config)
+	if err != nil {
+		return errDeleteServiceAccount(err)
+	}
+
+	return nil
 }
 
 func (c *serviceAccount) CreateBlockstorageServiceAccount(_ context.Context, opts api.CreateBlockstorageServiceAccountOpts) (*api.ServiceAccount, error) {
@@ -48,7 +80,7 @@ func (c *serviceAccount) CreateBlockstorageServiceAccount(_ context.Context, opt
 		return nil, errBuildServiceAccount(err)
 	}
 
-	account, err := c.createServiceAccount(opts.CreateServiceAccountOpts, config)
+	account, err := c.createServiceAccount(opts.CreateServiceAccountBaseOpts, config)
 	if err != nil {
 		return nil, errCreateServiceAccount(err)
 	}
@@ -96,7 +128,7 @@ func (c *serviceAccount) CreateAutoscalerServiceAccount(_ context.Context, opts 
 		return nil, errBuildServiceAccount(err)
 	}
 
-	account, err := c.createServiceAccount(opts.CreateServiceAccountOpts, config)
+	account, err := c.createServiceAccount(opts.CreateServiceAccountBaseOpts, config)
 	if err != nil {
 		return nil, errCreateServiceAccount(err)
 	}
@@ -216,7 +248,7 @@ func (c *serviceAccount) CreateExternalDNSServiceAccount(_ context.Context, opts
 		return nil, errBuildServiceAccount(err)
 	}
 
-	account, err := c.createServiceAccount(opts.CreateServiceAccountOpts, config)
+	account, err := c.createServiceAccount(opts.CreateServiceAccountBaseOpts, config)
 	if err != nil {
 		return nil, errCreateServiceAccount(err)
 	}
@@ -240,7 +272,7 @@ func (c *serviceAccount) CreateAlbIngressControllerServiceAccount(_ context.Cont
 		return nil, errBuildServiceAccount(err)
 	}
 
-	account, err := c.createServiceAccount(opts.CreateServiceAccountOpts, config)
+	account, err := c.createServiceAccount(opts.CreateServiceAccountBaseOpts, config)
 	if err != nil {
 		return nil, errCreateServiceAccount(err)
 	}
@@ -265,7 +297,7 @@ func (c *serviceAccount) CreateAWSLoadBalancerControllerServiceAccount(_ context
 		return nil, errBuildServiceAccount(err)
 	}
 
-	account, err := c.createServiceAccount(opts.CreateServiceAccountOpts, config)
+	account, err := c.createServiceAccount(opts.CreateServiceAccountBaseOpts, config)
 	if err != nil {
 		return nil, errCreateServiceAccount(err)
 	}
@@ -313,7 +345,7 @@ func (c *serviceAccount) CreateExternalSecretsServiceAccount(_ context.Context, 
 		return nil, errBuildServiceAccount(err)
 	}
 
-	account, err := c.createServiceAccount(opts.CreateServiceAccountOpts, config)
+	account, err := c.createServiceAccount(opts.CreateServiceAccountBaseOpts, config)
 	if err != nil {
 		return nil, errCreateServiceAccount(err)
 	}
@@ -321,7 +353,7 @@ func (c *serviceAccount) CreateExternalSecretsServiceAccount(_ context.Context, 
 	return account, nil
 }
 
-func (c *serviceAccount) createServiceAccount(opts api.CreateServiceAccountOpts, config *v1alpha5.ClusterConfig) (*api.ServiceAccount, error) {
+func (c *serviceAccount) createServiceAccount(opts api.CreateServiceAccountBaseOpts, config *v1alpha5.ClusterConfig) (*api.ServiceAccount, error) {
 	err := c.run.CreateServiceAccount(config)
 	if err != nil {
 		return nil, errors.E(err, "failed to create service account", errors.Internal)

--- a/pkg/api/core/service_serviceaccount.go
+++ b/pkg/api/core/service_serviceaccount.go
@@ -45,6 +45,7 @@ func (c *serviceAccount) CreateServiceAccount(_ context.Context, opts api.Create
 
 	return &api.ServiceAccount{
 		ID:        opts.ID,
+		Name:      opts.Name,
 		PolicyArn: opts.PolicyArn,
 		Config:    opts.Config,
 	}, nil

--- a/pkg/api/core/transport.go
+++ b/pkg/api/core/transport.go
@@ -3,8 +3,10 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
+	kit "github.com/go-kit/kit/transport/http"
 	"github.com/oslokommune/okctl/pkg/api"
 )
 
@@ -17,4 +19,17 @@ func decodeIDRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	}
 
 	return id, nil
+}
+
+// decodeStructRequest can be expanded in the future to act on a given type
+// of `Accept` header, e.g., for marshalling from yaml or other formats.
+func decodeStructRequest(v interface{}) kit.DecodeRequestFunc {
+	return func(_ context.Context, r *http.Request) (interface{}, error) {
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			return nil, fmt.Errorf("decoding request as json: %w", err)
+		}
+
+		return v, nil
+	}
 }

--- a/pkg/api/core/transport_test.go
+++ b/pkg/api/core/transport_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDecodeStruct provides a simple struct
+// for testing the decoder
+type TestDecodeStruct struct {
+	Name string
+}
+
+func TestDecodeStructRequest(t *testing.T) {
+	testCases := []struct {
+		name      string
+		into      interface{}
+		request   *http.Request
+		expectErr bool
+		expect    interface{}
+	}{
+		{
+			name: "Should work",
+			into: &TestDecodeStruct{},
+			request: httptest.NewRequest(
+				"",
+				"/something",
+				strings.NewReader(`{"Name": "Bob"}`),
+			),
+			expect: &TestDecodeStruct{
+				Name: "Bob",
+			},
+		},
+		{
+			name: "Should fail",
+			into: &TestDecodeStruct{},
+			request: httptest.NewRequest(
+				"",
+				"/something",
+				strings.NewReader(""),
+			),
+			expectErr: true,
+			expect:    "decoding request as json: EOF",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := decodeStructRequest(tc.into)(context.Background(), tc.request)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expect, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expect, got)
+			}
+		})
+	}
+}

--- a/pkg/api/helm_api.go
+++ b/pkg/api/helm_api.go
@@ -142,22 +142,24 @@ func (o CreateArgoCDOpts) Validate() error {
 
 // CreateKubePrometheusStackOpts defines the required inputs
 type CreateKubePrometheusStackOpts struct {
-	ID                     ID
-	CertificateARN         string
-	Hostname               string
-	AuthHostname           string
-	ClientID               string
-	SecretsConfigName      string
-	SecretsCookieSecretKey string
-	SecretsClientSecretKey string
-	SecretsAdminUserKey    string
-	SecretsAdminPassKey    string
+	ID                                  ID
+	GrafanaCloudWatchServiceAccountName string
+	CertificateARN                      string
+	Hostname                            string
+	AuthHostname                        string
+	ClientID                            string
+	SecretsConfigName                   string
+	SecretsCookieSecretKey              string
+	SecretsClientSecretKey              string
+	SecretsAdminUserKey                 string
+	SecretsAdminPassKey                 string
 }
 
 // Validate the inputs
 func (o CreateKubePrometheusStackOpts) Validate() error {
 	return validation.ValidateStruct(&o,
 		validation.Field(&o.ID, validation.Required),
+		validation.Field(&o.GrafanaCloudWatchServiceAccountName, validation.Required),
 		validation.Field(&o.CertificateARN, validation.Required),
 		validation.Field(&o.Hostname, validation.Required),
 		validation.Field(&o.AuthHostname, validation.Required),

--- a/pkg/api/kube_api.go
+++ b/pkg/api/kube_api.go
@@ -105,6 +105,29 @@ func (d Data) Validate() error {
 	)
 }
 
+// Namespace contains the data for a namespace
+type Namespace struct {
+	ID        ID
+	Namespace string
+	Labels    map[string]string
+	Manifest  []byte
+}
+
+// CreateNamespaceOpts contains the required inputs
+type CreateNamespaceOpts struct {
+	ID        ID
+	Namespace string
+	Labels    map[string]string
+}
+
+// Validate the inputs
+func (o CreateNamespaceOpts) Validate() error {
+	return validation.ValidateStruct(&o,
+		validation.Field(&o.ID, validation.Required),
+		validation.Field(&o.Namespace, validation.Required),
+	)
+}
+
 // DeleteNamespaceOpts provides the inputs
 type DeleteNamespaceOpts struct {
 	ID        ID
@@ -205,6 +228,7 @@ type KubeService interface {
 	CreateConfigMap(ctx context.Context, opts CreateConfigMapOpts) (*ConfigMap, error)
 	DeleteConfigMap(ctx context.Context, opts DeleteConfigMapOpts) error
 	ScaleDeployment(ctx context.Context, opts ScaleDeploymentOpts) error
+	CreateNamespace(ctx context.Context, opts CreateNamespaceOpts) (*Namespace, error)
 }
 
 // KubeRun provides kube deployment run layer
@@ -217,6 +241,7 @@ type KubeRun interface {
 	CreateConfigMap(opts CreateConfigMapOpts) (*ConfigMap, error)
 	DeleteConfigMap(opts DeleteConfigMapOpts) error
 	ScaleDeployment(opts ScaleDeploymentOpts) error
+	CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error)
 }
 
 // KubeStore provides kube store layer

--- a/pkg/api/managedpolicy_api.go
+++ b/pkg/api/managedpolicy_api.go
@@ -87,6 +87,40 @@ func (o CreateBlockstoragePolicy) Validate() error {
 	)
 }
 
+// CreatePolicyOpts contains all the required inputs for
+// creating a managed policy
+type CreatePolicyOpts struct {
+	ID                     ID
+	StackName              string
+	PolicyOutputName       string
+	CloudFormationTemplate []byte
+}
+
+// Validate the required inputs
+func (o CreatePolicyOpts) Validate() error {
+	return validation.ValidateStruct(&o,
+		validation.Field(&o.ID, validation.Required),
+		validation.Field(&o.StackName, validation.Required),
+		validation.Field(&o.PolicyOutputName, validation.Required),
+		validation.Field(&o.CloudFormationTemplate, validation.Required),
+	)
+}
+
+// DeletePolicyOpts contains all the required inputs
+// for deleting a managed policy
+type DeletePolicyOpts struct {
+	ID        ID
+	StackName string
+}
+
+// Validate the required inputs
+func (o DeletePolicyOpts) Validate() error {
+	return validation.ValidateStruct(&o,
+		validation.Field(&o.ID, validation.Required),
+		validation.Field(&o.StackName, validation.Required),
+	)
+}
+
 // ManagedPolicyService defines the service layer for managed policies
 type ManagedPolicyService interface {
 	CreateExternalSecretsPolicy(ctx context.Context, opts CreateExternalSecretsPolicyOpts) (*ManagedPolicy, error)
@@ -101,6 +135,8 @@ type ManagedPolicyService interface {
 	DeleteAutoscalerPolicy(ctx context.Context, id ID) error
 	CreateBlockstoragePolicy(ctx context.Context, opts CreateBlockstoragePolicy) (*ManagedPolicy, error)
 	DeleteBlockstoragePolicy(ctx context.Context, id ID) error
+	CreatePolicy(ctx context.Context, opts CreatePolicyOpts) (*ManagedPolicy, error)
+	DeletePolicy(ctx context.Context, opts DeletePolicyOpts) error
 }
 
 // ManagedPolicyCloudProvider defines the cloud provider layer for managed policies
@@ -117,6 +153,8 @@ type ManagedPolicyCloudProvider interface {
 	DeleteAutoscalerPolicy(id ID) error
 	CreateBlockstoragePolicy(opts CreateBlockstoragePolicy) (*ManagedPolicy, error)
 	DeleteBlockstoragePolicy(id ID) error
+	CreatePolicy(opts CreatePolicyOpts) (*ManagedPolicy, error)
+	DeletePolicy(opts DeletePolicyOpts) error
 }
 
 // ManagedPolicyStore defines the storage layer for managed policies

--- a/pkg/api/serviceaccount_api.go
+++ b/pkg/api/serviceaccount_api.go
@@ -11,6 +11,7 @@ import (
 // ServiceAccount holds state for a service account
 type ServiceAccount struct {
 	ID        ID
+	Name      string
 	PolicyArn string
 	Config    *v1alpha5.ClusterConfig
 }
@@ -97,6 +98,7 @@ func (o CreateBlockstorageServiceAccountOpts) Validate() error {
 // for creating a new service account
 type CreateServiceAccountOpts struct {
 	ID        ID
+	Name      string
 	PolicyArn string
 	Config    *v1alpha5.ClusterConfig
 }
@@ -105,6 +107,7 @@ type CreateServiceAccountOpts struct {
 func (o CreateServiceAccountOpts) Validate() error {
 	return validation.ValidateStruct(&o,
 		validation.Field(&o.ID, validation.Required),
+		validation.Field(&o.Name, validation.Required),
 		validation.Field(&o.PolicyArn, validation.Required),
 		validation.Field(&o.Config, validation.Required),
 	)
@@ -114,6 +117,7 @@ func (o CreateServiceAccountOpts) Validate() error {
 // for deleting a service account
 type DeleteServiceAccountOpts struct {
 	ID     ID
+	Name   string
 	Config *v1alpha5.ClusterConfig
 }
 
@@ -121,6 +125,7 @@ type DeleteServiceAccountOpts struct {
 func (o DeleteServiceAccountOpts) Validate() error {
 	return validation.ValidateStruct(&o,
 		validation.Field(&o.ID, validation.Required),
+		validation.Field(&o.Name, validation.Required),
 		validation.Field(&o.Config, validation.Required),
 	)
 }

--- a/pkg/api/serviceaccount_api.go
+++ b/pkg/api/serviceaccount_api.go
@@ -15,14 +15,14 @@ type ServiceAccount struct {
 	Config    *v1alpha5.ClusterConfig
 }
 
-// CreateServiceAccountOpts contains opts shared state
-type CreateServiceAccountOpts struct {
+// CreateServiceAccountBaseOpts contains opts shared state
+type CreateServiceAccountBaseOpts struct {
 	ID        ID
 	PolicyArn string
 }
 
 // ValidateStruct validates the shared state
-func (o CreateServiceAccountOpts) ValidateStruct() error {
+func (o CreateServiceAccountBaseOpts) ValidateStruct() error {
 	return validation.ValidateStruct(&o,
 		validation.Field(&o.ID, validation.Required),
 		validation.Field(&o.PolicyArn, validation.Required),
@@ -32,7 +32,7 @@ func (o CreateServiceAccountOpts) ValidateStruct() error {
 // CreateExternalSecretsServiceAccountOpts contains the configuration
 // for creating a external secrets service account
 type CreateExternalSecretsServiceAccountOpts struct {
-	CreateServiceAccountOpts
+	CreateServiceAccountBaseOpts
 }
 
 // Validate the options
@@ -43,7 +43,7 @@ func (o CreateExternalSecretsServiceAccountOpts) Validate() error {
 // CreateAlbIngressControllerServiceAccountOpts contains the configuration
 // for creating an alb ingress controller service account
 type CreateAlbIngressControllerServiceAccountOpts struct {
-	CreateServiceAccountOpts
+	CreateServiceAccountBaseOpts
 }
 
 // Validate the options
@@ -54,7 +54,7 @@ func (o CreateAlbIngressControllerServiceAccountOpts) Validate() error {
 // CreateAWSLoadBalancerControllerServiceAccountOpts contains the configuration
 // for creating an alb ingress controller service account
 type CreateAWSLoadBalancerControllerServiceAccountOpts struct {
-	CreateServiceAccountOpts
+	CreateServiceAccountBaseOpts
 }
 
 // Validate the options
@@ -65,7 +65,7 @@ func (o CreateAWSLoadBalancerControllerServiceAccountOpts) Validate() error {
 // CreateExternalDNSServiceAccountOpts contains the configuration
 // for creating an external dns service account
 type CreateExternalDNSServiceAccountOpts struct {
-	CreateServiceAccountOpts
+	CreateServiceAccountBaseOpts
 }
 
 // Validate the input
@@ -75,7 +75,7 @@ func (o CreateExternalDNSServiceAccountOpts) Validate() error {
 
 // CreateAutoscalerServiceAccountOpts contains the required inputs
 type CreateAutoscalerServiceAccountOpts struct {
-	CreateServiceAccountOpts
+	CreateServiceAccountBaseOpts
 }
 
 // Validate the inputs
@@ -85,12 +85,44 @@ func (o CreateAutoscalerServiceAccountOpts) Validate() error {
 
 // CreateBlockstorageServiceAccountOpts contains the required inputs
 type CreateBlockstorageServiceAccountOpts struct {
-	CreateServiceAccountOpts
+	CreateServiceAccountBaseOpts
 }
 
 // Validate the inputs
 func (o CreateBlockstorageServiceAccountOpts) Validate() error {
 	return o.ValidateStruct()
+}
+
+// CreateServiceAccountOpts contains the inputs required
+// for creating a new service account
+type CreateServiceAccountOpts struct {
+	ID        ID
+	PolicyArn string
+	Config    *v1alpha5.ClusterConfig
+}
+
+// Validate the provided inputs
+func (o CreateServiceAccountOpts) Validate() error {
+	return validation.ValidateStruct(&o,
+		validation.Field(&o.ID, validation.Required),
+		validation.Field(&o.PolicyArn, validation.Required),
+		validation.Field(&o.Config, validation.Required),
+	)
+}
+
+// DeleteServiceAccountOpts contains the inputs required
+// for deleting a service account
+type DeleteServiceAccountOpts struct {
+	ID     ID
+	Config *v1alpha5.ClusterConfig
+}
+
+// Validate the provided inputs
+func (o DeleteServiceAccountOpts) Validate() error {
+	return validation.ValidateStruct(&o,
+		validation.Field(&o.ID, validation.Required),
+		validation.Field(&o.Config, validation.Required),
+	)
 }
 
 // ServiceAccountService provides the interface for all service account operations
@@ -107,6 +139,8 @@ type ServiceAccountService interface {
 	DeleteAutoscalerServiceAccount(context.Context, ID) error
 	CreateBlockstorageServiceAccount(context.Context, CreateBlockstorageServiceAccountOpts) (*ServiceAccount, error)
 	DeleteBlockstorageServiceAccount(context.Context, ID) error
+	CreateServiceAccount(ctx context.Context, opts CreateServiceAccountOpts) (*ServiceAccount, error)
+	DeleteServiceAccount(ctx context.Context, opts DeleteServiceAccountOpts) error
 }
 
 // ServiceAccountRun provides the interface for running operations

--- a/pkg/cfn/builder_test.go
+++ b/pkg/cfn/builder_test.go
@@ -62,6 +62,11 @@ func TestBuilderAndComposers(t *testing.T) {
 			composer: components.NewPublicCertificateComposer("test.oslo.systems.", "AZ12345"),
 		},
 		{
+			name:     "Builder with CloudwatchDatasourcePolicyComposer",
+			golden:   "cloudwatch-datasource-cf.yaml",
+			composer: components.NewCloudwatchDatasourcePolicyComposer("repo", "env"),
+		},
+		{
 			name:   "Builder with UserPool composer",
 			golden: "userpool.yaml",
 			composer: components.NewUserPool(

--- a/pkg/cfn/namer.go
+++ b/pkg/cfn/namer.go
@@ -15,6 +15,7 @@ const (
 	DefaultStackNameBlockstoragePolicyID              = "blockstoragepolicy"
 	DefaultStackNameAlbIngressControllerPolicyID      = "albingresscontrollerpolicy"
 	DefaultStackNameAWSLoadBalancerControllerPolicyID = "awsloadbalancercontrollerpolicy"
+	DefaultStackNameCloudwatchDatasourceID            = "cloudwatchdatasource"
 	DefaultStackNameExternalDNSPolicyID               = "externaldns"
 	DefaultStackNameDomainID                          = "domain"
 	DefaultStackNameCertificateID                     = "certificate"
@@ -67,6 +68,16 @@ func (n *StackNamer) BlockstoragePolicy(repository, env string) string {
 	return fmt.Sprintf("%s-%s-%s-%s",
 		DefaultStackNamePrefix,
 		DefaultStackNameBlockstoragePolicyID,
+		repository,
+		env,
+	)
+}
+
+// CloudwatchDatasource returns the stack name of an Blockstorage policy
+func (n *StackNamer) CloudwatchDatasource(repository, env string) string {
+	return fmt.Sprintf("%s-%s-%s-%s",
+		DefaultStackNamePrefix,
+		DefaultStackNameCloudwatchDatasourceID,
 		repository,
 		env,
 	)

--- a/pkg/cfn/testdata/cloudwatch-datasource-cf.yaml.golden
+++ b/pkg/cfn/testdata/cloudwatch-datasource-cf.yaml.golden
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: 2010-09-09
+Outputs:
+  CloudwatchDatasourcePolicy:
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-CloudwatchDatasourcePolicy
+    Value:
+      Ref: CloudwatchDatasourcePolicy
+Resources:
+  CloudwatchDatasourcePolicy:
+    Properties:
+      Description: Service account policy for reading cloudwatch metrics and logs
+        from grafana
+      ManagedPolicyName: okctl-repo-env-CloudwatchDatasourceServiceAccountPolicy
+      PolicyDocument:
+        Statement:
+        - Action:
+          - cloudwatch:DescribeAlarmsForMetric
+          - cloudwatch:DescribeAlarmHistory
+          - cloudwatch:DescribeAlarms
+          - cloudwatch:ListMetrics
+          - cloudwatch:GetMetricStatistics
+          - cloudwatch:GetMetricData
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - logs:DescribeLogGroups
+          - logs:GetLogGroupFields
+          - logs:StartQuery
+          - logs:StopQuery
+          - logs:GetQueryResults
+          - logs:GetLogEvents
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - ec2:DescribeTags
+          - ec2:DescribeInstances
+          - ec2:DescribeRegions
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - tag:GetResources
+          Effect: Allow
+          Resource:
+          - '*'
+        Version: 2012-10-17
+    Type: AWS::IAM::ManagedPolicy

--- a/pkg/client/core/api/rest/managedpolicy_rest.go
+++ b/pkg/client/core/api/rest/managedpolicy_rest.go
@@ -1,0 +1,29 @@
+package rest
+
+import (
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+)
+
+// ManagedPoliciesTarget defines the REST API Route
+const ManagedPoliciesTarget = "managedpolicies/"
+
+type managedPolicyAPI struct {
+	client *HTTPClient
+}
+
+func (m *managedPolicyAPI) CreatePolicy(opts api.CreatePolicyOpts) (*api.ManagedPolicy, error) {
+	into := &api.ManagedPolicy{}
+	return into, m.client.DoPost(ManagedPoliciesTarget, &opts, into)
+}
+
+func (m *managedPolicyAPI) DeletePolicy(opts api.DeletePolicyOpts) error {
+	return m.client.DoDelete(ManagedPoliciesTarget, &opts)
+}
+
+// NewManagedPolicyAPI returns an initialised API client
+func NewManagedPolicyAPI(client *HTTPClient) client.ManagedPolicyAPI {
+	return &managedPolicyAPI{
+		client: client,
+	}
+}

--- a/pkg/client/core/api/rest/manifest_rest.go
+++ b/pkg/client/core/api/rest/manifest_rest.go
@@ -25,6 +25,11 @@ type manifestAPI struct {
 	client *HTTPClient
 }
 
+func (a *manifestAPI) CreateNamespace(opts api.CreateNamespaceOpts) (*api.Namespace, error) {
+	into := &api.Namespace{}
+	return into, a.client.DoPost(TargetKubeNamespace, &opts, into)
+}
+
 func (a *manifestAPI) ScaleDeployment(opts api.ScaleDeploymentOpts) error {
 	return a.client.DoPost(TargetKubeScaleDeployment, &opts, nil)
 }

--- a/pkg/client/core/api/rest/serviceaccount_rest.go
+++ b/pkg/client/core/api/rest/serviceaccount_rest.go
@@ -1,0 +1,29 @@
+package rest
+
+import (
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+)
+
+// ServiceAccountsTarget defines the REST API Route
+const ServiceAccountsTarget = "serviceaccounts/"
+
+type serviceAccountAPI struct {
+	client *HTTPClient
+}
+
+func (m *serviceAccountAPI) CreateServiceAccount(opts api.CreateServiceAccountOpts) (*api.ServiceAccount, error) {
+	into := &api.ServiceAccount{}
+	return into, m.client.DoPost(ServiceAccountsTarget, &opts, into)
+}
+
+func (m *serviceAccountAPI) DeleteServiceAccount(opts api.DeleteServiceAccountOpts) error {
+	return m.client.DoDelete(ServiceAccountsTarget, &opts)
+}
+
+// NewServiceAccountAPI returns an initialised API client
+func NewServiceAccountAPI(client *HTTPClient) client.ServiceAccountAPI {
+	return &serviceAccountAPI{
+		client: client,
+	}
+}

--- a/pkg/client/core/report/console/managedpolicy_console.go
+++ b/pkg/client/core/report/console/managedpolicy_console.go
@@ -1,0 +1,38 @@
+package console
+
+import (
+	"io"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/client/store"
+	"github.com/oslokommune/okctl/pkg/spinner"
+)
+
+type managedPolicyReport struct {
+	console *Console
+}
+
+func (m *managedPolicyReport) ReportCreatePolicy(policy *api.ManagedPolicy, report *store.Report) error {
+	return m.console.Report(
+		report.Actions,
+		"managed-policy",
+		aurora.Green(policy.StackName).String(),
+	)
+}
+
+func (m *managedPolicyReport) ReportDeletePolicy(stackName string, report *store.Report) error {
+	return m.console.Report(
+		report.Actions,
+		"managed-policy",
+		aurora.Green(stackName).String(),
+	)
+}
+
+// NewManagedPolicyReport returns an initialised reporter
+func NewManagedPolicyReport(out io.Writer, spinner spinner.Spinner) client.ManagedPolicyReport {
+	return &managedPolicyReport{
+		console: New(out, spinner),
+	}
+}

--- a/pkg/client/core/report/console/manifest_console.go
+++ b/pkg/client/core/report/console/manifest_console.go
@@ -15,6 +15,22 @@ type manifestReport struct {
 	console *Console
 }
 
+func (r *manifestReport) RemoveNamespace(namespace string, report *store.Report) error {
+	return r.console.Report(
+		report.Actions,
+		"manifest",
+		fmt.Sprintf("%s (%s)", aurora.Green("namespace").String(), namespace),
+	)
+}
+
+func (r *manifestReport) SaveNamespace(namespace *client.Namespace, report *store.Report) error {
+	return r.console.Report(
+		report.Actions,
+		"manifest",
+		fmt.Sprintf("%s (%s)", aurora.Green("namespace").String(), namespace.Namespace),
+	)
+}
+
 func (r *manifestReport) SaveConfigMap(secret *client.ConfigMap, report *store.Report) error {
 	return r.console.Report(
 		report.Actions,

--- a/pkg/client/core/report/console/serviceaccount_console.go
+++ b/pkg/client/core/report/console/serviceaccount_console.go
@@ -1,0 +1,38 @@
+package console
+
+import (
+	"io"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/client/store"
+	"github.com/oslokommune/okctl/pkg/spinner"
+)
+
+type serviceAccountReport struct {
+	console *Console
+}
+
+func (r *serviceAccountReport) ReportCreateServiceAccount(s *api.ServiceAccount, report *store.Report) error {
+	return r.console.Report(
+		report.Actions,
+		"service-account",
+		aurora.Green(s.Name).String(),
+	)
+}
+
+func (r *serviceAccountReport) ReportDeleteServiceAccount(name string, report *store.Report) error {
+	return r.console.Report(
+		report.Actions,
+		"service-account",
+		aurora.Green(name).String(),
+	)
+}
+
+// NewServiceAccountReport returns an initialised reporter
+func NewServiceAccountReport(out io.Writer, spinner spinner.Spinner) client.ServiceAccountReport {
+	return &serviceAccountReport{
+		console: New(out, spinner),
+	}
+}

--- a/pkg/client/core/service_albingresscontroller_client.go
+++ b/pkg/client/core/service_albingresscontroller_client.go
@@ -67,7 +67,7 @@ func (s *albIngressControllerService) CreateALBIngressController(_ context.Conte
 	}
 
 	account, err := s.api.CreateAlbIngressControllerServiceAccount(api.CreateAlbIngressControllerServiceAccountOpts{
-		CreateServiceAccountOpts: api.CreateServiceAccountOpts{
+		CreateServiceAccountBaseOpts: api.CreateServiceAccountBaseOpts{
 			ID:        opts.ID,
 			PolicyArn: policy.PolicyARN,
 		},

--- a/pkg/client/core/service_autoscaler.go
+++ b/pkg/client/core/service_autoscaler.go
@@ -68,7 +68,7 @@ func (s *autoscalerService) CreateAutoscaler(_ context.Context, opts client.Crea
 	}
 
 	sa, err := s.api.CreateAutoscalerServiceAccount(api.CreateAutoscalerServiceAccountOpts{
-		CreateServiceAccountOpts: api.CreateServiceAccountOpts{
+		CreateServiceAccountBaseOpts: api.CreateServiceAccountBaseOpts{
 			ID:        opts.ID,
 			PolicyArn: policy.PolicyARN,
 		},

--- a/pkg/client/core/service_awsloadbalancercontroller_client.go
+++ b/pkg/client/core/service_awsloadbalancercontroller_client.go
@@ -68,7 +68,7 @@ func (s *awsLoadBalancerControllerService) CreateAWSLoadBalancerController(_ con
 	}
 
 	account, err := s.api.CreateAWSLoadBalancerControllerServiceAccount(api.CreateAWSLoadBalancerControllerServiceAccountOpts{
-		CreateServiceAccountOpts: api.CreateServiceAccountOpts{
+		CreateServiceAccountBaseOpts: api.CreateServiceAccountBaseOpts{
 			ID:        opts.ID,
 			PolicyArn: policy.PolicyARN,
 		},

--- a/pkg/client/core/service_blockstorage.go
+++ b/pkg/client/core/service_blockstorage.go
@@ -72,7 +72,7 @@ func (s *blockstorageService) CreateBlockstorage(ctx context.Context, opts clien
 	}
 
 	sa, err := s.api.CreateBlockstorageServiceAccount(api.CreateBlockstorageServiceAccountOpts{
-		CreateServiceAccountOpts: api.CreateServiceAccountOpts{
+		CreateServiceAccountBaseOpts: api.CreateServiceAccountBaseOpts{
 			ID:        opts.ID,
 			PolicyArn: policy.PolicyARN,
 		},

--- a/pkg/client/core/service_externaldns_client.go
+++ b/pkg/client/core/service_externaldns_client.go
@@ -67,7 +67,7 @@ func (s *externalDNSService) CreateExternalDNS(_ context.Context, opts client.Cr
 	}
 
 	account, err := s.api.CreateExternalDNSServiceAccount(api.CreateExternalDNSServiceAccountOpts{
-		CreateServiceAccountOpts: api.CreateServiceAccountOpts{
+		CreateServiceAccountBaseOpts: api.CreateServiceAccountBaseOpts{
 			ID:        opts.ID,
 			PolicyArn: policy.PolicyARN,
 		},

--- a/pkg/client/core/service_externalsecrets.go
+++ b/pkg/client/core/service_externalsecrets.go
@@ -68,7 +68,7 @@ func (s *externalSecretsService) CreateExternalSecrets(_ context.Context, opts c
 	}
 
 	sa, err := s.api.CreateExternalSecretsServiceAccount(api.CreateExternalSecretsServiceAccountOpts{
-		CreateServiceAccountOpts: api.CreateServiceAccountOpts{
+		CreateServiceAccountBaseOpts: api.CreateServiceAccountBaseOpts{
 			ID:        opts.ID,
 			PolicyArn: policy.PolicyARN,
 		},

--- a/pkg/client/core/service_managedpolicy_client.go
+++ b/pkg/client/core/service_managedpolicy_client.go
@@ -1,0 +1,87 @@
+package core
+
+import (
+	"context"
+
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/spinner"
+)
+
+type managedPolicyService struct {
+	spinner spinner.Spinner
+	api     client.ManagedPolicyAPI
+	store   client.ManagedPolicyStore
+	report  client.ManagedPolicyReport
+}
+
+func (m *managedPolicyService) CreatePolicy(_ context.Context, opts api.CreatePolicyOpts) (*api.ManagedPolicy, error) {
+	err := m.spinner.Start("managed-policy")
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = m.spinner.Stop()
+	}()
+
+	p, err := m.api.CreatePolicy(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	report, err := m.store.SaveCreatePolicy(p)
+	if err != nil {
+		return nil, err
+	}
+
+	err = m.report.ReportCreatePolicy(p, report)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (m *managedPolicyService) DeletePolicy(_ context.Context, opts api.DeletePolicyOpts) error {
+	err := m.spinner.Start("managed-policy")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = m.spinner.Stop()
+	}()
+
+	err = m.api.DeletePolicy(opts)
+	if err != nil {
+		return err
+	}
+
+	report, err := m.store.RemoveDeletePolicy(opts.StackName)
+	if err != nil {
+		return err
+	}
+
+	err = m.report.ReportDeletePolicy(opts.StackName, report)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewManagedPolicyService returns an initialised service
+func NewManagedPolicyService(
+	spinner spinner.Spinner,
+	api client.ManagedPolicyAPI,
+	store client.ManagedPolicyStore,
+	report client.ManagedPolicyReport,
+) client.ManagedPolicyService {
+	return &managedPolicyService{
+		spinner: spinner,
+		api:     api,
+		store:   store,
+		report:  report,
+	}
+}

--- a/pkg/client/core/service_monitoring_client.go
+++ b/pkg/client/core/service_monitoring_client.go
@@ -518,16 +518,17 @@ func (s *monitoringService) CreateKubePromStack(ctx context.Context, opts client
 	}
 
 	chart, err := s.api.CreateKubePromStack(api.CreateKubePrometheusStackOpts{
-		ID:                     opts.ID,
-		CertificateARN:         cert.CertificateARN,
-		Hostname:               cert.Domain,
-		AuthHostname:           opts.AuthDomain,
-		ClientID:               poolClient.ClientID,
-		SecretsConfigName:      secretsCfgName,
-		SecretsCookieSecretKey: cookieSecret.Name,
-		SecretsClientSecretKey: clientSecret.Name,
-		SecretsAdminUserKey:    adminUser.Name,
-		SecretsAdminPassKey:    adminPass.Name,
+		ID:                                  opts.ID,
+		GrafanaCloudWatchServiceAccountName: config.DefaultGrafanaCloudWatchDatasourceName,
+		CertificateARN:                      cert.CertificateARN,
+		Hostname:                            cert.Domain,
+		AuthHostname:                        opts.AuthDomain,
+		ClientID:                            poolClient.ClientID,
+		SecretsConfigName:                   secretsCfgName,
+		SecretsCookieSecretKey:              cookieSecret.Name,
+		SecretsClientSecretKey:              clientSecret.Name,
+		SecretsAdminUserKey:                 adminUser.Name,
+		SecretsAdminPassKey:                 adminPass.Name,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/client/core/service_serviceaccount_client.go
+++ b/pkg/client/core/service_serviceaccount_client.go
@@ -1,0 +1,87 @@
+package core
+
+import (
+	"context"
+
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/spinner"
+)
+
+type serviceAccountService struct {
+	spinner spinner.Spinner
+	api     client.ServiceAccountAPI
+	store   client.ServiceAccountStore
+	report  client.ServiceAccountReport
+}
+
+func (m *serviceAccountService) CreateServiceAccount(_ context.Context, opts api.CreateServiceAccountOpts) (*api.ServiceAccount, error) {
+	err := m.spinner.Start("service-account")
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = m.spinner.Stop()
+	}()
+
+	p, err := m.api.CreateServiceAccount(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	report, err := m.store.SaveCreateServiceAccount(p)
+	if err != nil {
+		return nil, err
+	}
+
+	err = m.report.ReportCreateServiceAccount(p, report)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (m *serviceAccountService) DeleteServiceAccount(_ context.Context, opts api.DeleteServiceAccountOpts) error {
+	err := m.spinner.Start("service-account")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = m.spinner.Stop()
+	}()
+
+	err = m.api.DeleteServiceAccount(opts)
+	if err != nil {
+		return err
+	}
+
+	report, err := m.store.RemoveDeleteServiceAccount(opts.Name)
+	if err != nil {
+		return err
+	}
+
+	err = m.report.ReportDeleteServiceAccount(opts.Name, report)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewServiceAccountService returns an initialised service
+func NewServiceAccountService(
+	spinner spinner.Spinner,
+	api client.ServiceAccountAPI,
+	store client.ServiceAccountStore,
+	report client.ServiceAccountReport,
+) client.ServiceAccountService {
+	return &serviceAccountService{
+		spinner: spinner,
+		api:     api,
+		store:   store,
+		report:  report,
+	}
+}

--- a/pkg/client/core/store/filesystem/filesystem.go
+++ b/pkg/client/core/store/filesystem/filesystem.go
@@ -25,6 +25,7 @@ type ManagedPolicy struct {
 // be serialised to the output file
 type ServiceAccount struct {
 	ID        api.ID
+	Name      string
 	PolicyArn string
 }
 

--- a/pkg/client/core/store/filesystem/managedpolicy_filesystem.go
+++ b/pkg/client/core/store/filesystem/managedpolicy_filesystem.go
@@ -39,7 +39,7 @@ func (m *managedPolicyStore) RemoveDeletePolicy(stackName string) (*store.Report
 		Do()
 }
 
-// NewManagedPolicyStore
+// NewManagedPolicyStore returns an initialised store
 func NewManagedPolicyStore(paths Paths, fs *afero.Afero) client.ManagedPolicyStore {
 	return &managedPolicyStore{
 		paths: paths,

--- a/pkg/client/core/store/filesystem/managedpolicy_filesystem.go
+++ b/pkg/client/core/store/filesystem/managedpolicy_filesystem.go
@@ -1,0 +1,48 @@
+package filesystem
+
+import (
+	"path"
+
+	"github.com/gosimple/slug"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/client/store"
+	"github.com/spf13/afero"
+)
+
+type managedPolicyStore struct {
+	paths Paths
+	fs    *afero.Afero
+}
+
+func (m *managedPolicyStore) SaveCreatePolicy(p *api.ManagedPolicy) (*store.Report, error) {
+	return store.NewFileSystem(path.Join(m.paths.BaseDir, slug.Make(p.StackName)), m.fs).
+		StoreStruct(
+			m.paths.OutputFile,
+			&ManagedPolicy{
+				ID:        p.ID,
+				StackName: p.StackName,
+				PolicyARN: p.PolicyARN,
+			},
+			store.ToJSON(),
+		).
+		StoreBytes(m.paths.CloudFormationFile, p.CloudFormationTemplate).
+		Do()
+}
+
+func (m *managedPolicyStore) RemoveDeletePolicy(stackName string) (*store.Report, error) {
+	return store.NewFileSystem(path.Join(m.paths.BaseDir, slug.Make(stackName)), m.fs).
+		Remove(m.paths.OutputFile).
+		Remove(m.paths.CloudFormationFile).
+		AlterStore(store.SetBaseDir(m.paths.BaseDir)).
+		RemoveDir(slug.Make(stackName)).
+		Do()
+}
+
+// NewManagedPolicyStore
+func NewManagedPolicyStore(paths Paths, fs *afero.Afero) client.ManagedPolicyStore {
+	return &managedPolicyStore{
+		paths: paths,
+		fs:    fs,
+	}
+}

--- a/pkg/client/core/store/filesystem/serviceaccount_filesystem.go
+++ b/pkg/client/core/store/filesystem/serviceaccount_filesystem.go
@@ -39,7 +39,7 @@ func (m *serviceAccountStore) RemoveDeleteServiceAccount(name string) (*store.Re
 		Do()
 }
 
-// NewServiceAccountStore
+// NewServiceAccountStore returns an initialised store
 func NewServiceAccountStore(paths Paths, fs *afero.Afero) client.ServiceAccountStore {
 	return &serviceAccountStore{
 		paths: paths,

--- a/pkg/client/core/store/filesystem/serviceaccount_filesystem.go
+++ b/pkg/client/core/store/filesystem/serviceaccount_filesystem.go
@@ -1,0 +1,48 @@
+package filesystem
+
+import (
+	"path"
+
+	"github.com/gosimple/slug"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/client/store"
+	"github.com/spf13/afero"
+)
+
+type serviceAccountStore struct {
+	paths Paths
+	fs    *afero.Afero
+}
+
+func (m *serviceAccountStore) SaveCreateServiceAccount(p *api.ServiceAccount) (*store.Report, error) {
+	return store.NewFileSystem(path.Join(m.paths.BaseDir, slug.Make(p.Name)), m.fs).
+		StoreStruct(
+			m.paths.OutputFile,
+			&ServiceAccount{
+				ID:        p.ID,
+				Name:      p.Name,
+				PolicyArn: p.PolicyArn,
+			},
+			store.ToJSON(),
+		).
+		StoreStruct(m.paths.ConfigFile, p.Config, store.ToJSON()).
+		Do()
+}
+
+func (m *serviceAccountStore) RemoveDeleteServiceAccount(name string) (*store.Report, error) {
+	return store.NewFileSystem(path.Join(m.paths.BaseDir, slug.Make(name)), m.fs).
+		Remove(m.paths.OutputFile).
+		Remove(m.paths.ConfigFile).
+		AlterStore(store.SetBaseDir(m.paths.BaseDir)).
+		RemoveDir(slug.Make(name)).
+		Do()
+}
+
+// NewServiceAccountStore
+func NewServiceAccountStore(paths Paths, fs *afero.Afero) client.ServiceAccountStore {
+	return &serviceAccountStore{
+		paths: paths,
+		fs:    fs,
+	}
+}

--- a/pkg/client/managedpolicy_client.go
+++ b/pkg/client/managedpolicy_client.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"context"
+
+	"github.com/oslokommune/okctl/pkg/client/store"
+
+	"github.com/oslokommune/okctl/pkg/api"
+)
+
+// ManagedPolicyService implements the business logic
+type ManagedPolicyService interface {
+	CreatePolicy(ctx context.Context, opts api.CreatePolicyOpts) (*api.ManagedPolicy, error)
+	DeletePolicy(ctx context.Context, opts api.DeletePolicyOpts) error
+}
+
+// ManagedPolicyAPI invokes the remote API
+type ManagedPolicyAPI interface {
+	CreatePolicy(opts api.CreatePolicyOpts) (*api.ManagedPolicy, error)
+	DeletePolicy(opts api.DeletePolicyOpts) error
+}
+
+// ManagedPolicyStore provides a persistence layer
+type ManagedPolicyStore interface {
+	SaveCreatePolicy(policy *api.ManagedPolicy) (*store.Report, error)
+	RemoveDeletePolicy(stackName string) (*store.Report, error)
+}
+
+// ManagedPolicyReports provides output on the result
+type ManagedPolicyReport interface {
+	ReportCreatePolicy(policy *api.ManagedPolicy, report *store.Report) error
+	ReportDeletePolicy(stackName string, report *store.Report) error
+}

--- a/pkg/client/managedpolicy_client.go
+++ b/pkg/client/managedpolicy_client.go
@@ -26,7 +26,7 @@ type ManagedPolicyStore interface {
 	RemoveDeletePolicy(stackName string) (*store.Report, error)
 }
 
-// ManagedPolicyReports provides output on the result
+// ManagedPolicyReport provides output on the result
 type ManagedPolicyReport interface {
 	ReportCreatePolicy(policy *api.ManagedPolicy, report *store.Report) error
 	ReportDeletePolicy(stackName string, report *store.Report) error

--- a/pkg/client/manifest_client.go
+++ b/pkg/client/manifest_client.go
@@ -40,6 +40,14 @@ type ConfigMap struct {
 	Manifest  []byte
 }
 
+// Namespace is the content of a k8s namespace
+type Namespace struct {
+	ID        api.ID
+	Namespace string
+	Labels    map[string]string
+	Manifest  []byte
+}
+
 // CreateConfigMapOpts contains the required inputs
 type CreateConfigMapOpts struct {
 	ID        api.ID
@@ -69,6 +77,7 @@ type ManifestService interface {
 	CreateConfigMap(ctx context.Context, opts CreateConfigMapOpts) (*ConfigMap, error)
 	DeleteConfigMap(ctx context.Context, opts DeleteConfigMapOpts) error
 	ScaleDeployment(ctx context.Context, opts api.ScaleDeploymentOpts) error
+	CreateNamespace(ctx context.Context, opts api.CreateNamespaceOpts) (*Namespace, error)
 }
 
 // ManifestAPI invokes the API
@@ -80,6 +89,7 @@ type ManifestAPI interface {
 	CreateConfigMap(opts api.CreateConfigMapOpts) (*api.ConfigMap, error)
 	DeleteConfigMap(opts api.DeleteConfigMapOpts) error
 	ScaleDeployment(opts api.ScaleDeploymentOpts) error
+	CreateNamespace(opts api.CreateNamespaceOpts) (*api.Namespace, error)
 }
 
 // ManifestStore defines the storage layer
@@ -87,8 +97,10 @@ type ManifestStore interface {
 	SaveStorageClass(sc *StorageClass) (*store.Report, error)
 	SaveExternalSecret(externalSecret *ExternalSecret) (*store.Report, error)
 	RemoveExternalSecret(secrets map[string]string) (*store.Report, error)
-	SaveConfigMap(ConfigMap *ConfigMap) (*store.Report, error)
+	SaveConfigMap(configMap *ConfigMap) (*store.Report, error)
 	RemoveConfigMap(name, namespace string) (*store.Report, error)
+	SaveNamespace(namespace *Namespace) (*store.Report, error)
+	RemoveNamespace(namespace string) (*store.Report, error)
 }
 
 // ManifestReport defines the report layer
@@ -98,4 +110,6 @@ type ManifestReport interface {
 	RemoveExternalSecret(report *store.Report) error
 	SaveConfigMap(secret *ConfigMap, report *store.Report) error
 	RemoveConfigMap(report *store.Report) error
+	SaveNamespace(namespace *Namespace, report *store.Report) error
+	RemoveNamespace(namespace string, report *store.Report) error
 }

--- a/pkg/client/serviceaccount_client.go
+++ b/pkg/client/serviceaccount_client.go
@@ -26,7 +26,7 @@ type ServiceAccountStore interface {
 	RemoveDeleteServiceAccount(name string) (*store.Report, error)
 }
 
-// ServiceAccountReports provides output on the result
+// ServiceAccountReport provides output on the result
 type ServiceAccountReport interface {
 	ReportCreateServiceAccount(account *api.ServiceAccount, report *store.Report) error
 	ReportDeleteServiceAccount(name string, report *store.Report) error

--- a/pkg/client/serviceaccount_client.go
+++ b/pkg/client/serviceaccount_client.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"context"
+
+	"github.com/oslokommune/okctl/pkg/client/store"
+
+	"github.com/oslokommune/okctl/pkg/api"
+)
+
+// ServiceAccountService implements the business logic
+type ServiceAccountService interface {
+	CreateServiceAccount(ctx context.Context, opts api.CreateServiceAccountOpts) (*api.ServiceAccount, error)
+	DeleteServiceAccount(ctx context.Context, opts api.DeleteServiceAccountOpts) error
+}
+
+// ServiceAccountAPI invokes the remote API
+type ServiceAccountAPI interface {
+	CreateServiceAccount(opts api.CreateServiceAccountOpts) (*api.ServiceAccount, error)
+	DeleteServiceAccount(opts api.DeleteServiceAccountOpts) error
+}
+
+// ServiceAccountStore provides a persistence layer
+type ServiceAccountStore interface {
+	SaveCreateServiceAccount(account *api.ServiceAccount) (*store.Report, error)
+	RemoveDeleteServiceAccount(name string) (*store.Report, error)
+}
+
+// ServiceAccountReports provides output on the result
+type ServiceAccountReport interface {
+	ReportCreateServiceAccount(account *api.ServiceAccount, report *store.Report) error
+	ReportDeleteServiceAccount(name string, report *store.Report) error
+}

--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -322,6 +322,22 @@ func NewBlockstorageServiceAccount(clusterName, region, policyArn, permissionsBo
 	})
 }
 
+// NewCloudwatchDatasourceServiceAccount returns an initialised configuration
+// for creating a cluster CloudwatchDatasource service account
+func NewCloudwatchDatasourceServiceAccount(clusterName, region, policyArn, namespace, permissionsBoundaryArn string) (*v1alpha5.ClusterConfig, error) {
+	return NewServiceAccount(&ServiceAccountArgs{
+		ClusterName: clusterName,
+		Labels: map[string]string{
+			"aws-usage": "cluster-ops",
+		},
+		Name:                   "cloudwatch-datasource",
+		Namespace:              namespace,
+		PermissionsBoundaryArn: permissionsBoundaryArn,
+		PolicyArn:              policyArn,
+		Region:                 region,
+	})
+}
+
 // MinimalArgs contains the input arguments for creating a valid
 // cluster configuration
 type MinimalArgs struct {

--- a/pkg/clusterconfig/testdata/cloudwatch-datasource.golden
+++ b/pkg/clusterconfig/testdata/cloudwatch-datasource.golden
@@ -1,0 +1,19 @@
+apiVersion: eksctl.io/v1alpha5
+iam:
+  serviceAccounts:
+  - attachPolicyARNs:
+    - arn:aws:iam::123456789012:policy/somePolicy
+    metadata:
+      labels:
+        aws-usage: cluster-ops
+      name: cloudwatch-datasource
+      namespace: monitoring
+    permissionsBoundary: arn:aws:iam::123456789012:policy/oslokommune/oslokommune-boundary
+  withOIDC: true
+kind: ClusterConfig
+metadata:
+  name: test
+  region: eu-west-1
+  tags:
+    alpha.okctl.io/okctl-commit: unknown
+    alpha.okctl.io/okctl-version: dev

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,10 +50,11 @@ const (
 	DefaultChartApplyTimeout  = 5 * time.Minute
 	DefaultChartRemoveTimeout = 5 * time.Minute
 
-	DefaultGithubHost                     = "git@github.com"
-	DefaultArgoCDNamespace                = "argocd"
-	DefaultMonitoringNamespace            = "monitoring"
-	DefaultKubePrometheusStackGrafanaName = "kube-prometheus-stack-grafana"
+	DefaultGithubHost                      = "git@github.com"
+	DefaultArgoCDNamespace                 = "argocd"
+	DefaultMonitoringNamespace             = "monitoring"
+	DefaultKubePrometheusStackGrafanaName  = "kube-prometheus-stack-grafana"
+	DefaultGrafanaCloudWatchDatasourceName = "cloudwatch-datasource"
 
 	DefaultClusterConfig         = "cluster.yml"
 	DefaultClusterKubeConfig     = "kubeconfig"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -116,8 +116,10 @@ const (
 	DefaultKubeOutputsFile                          = "kube-outputs.json"
 	DefaultParameterBaseDir                         = "parameters"
 	DefaultParameterOutputsFile                     = "parameter-outputs.json"
+	DefaultPolicyBaseDir                            = "policies"
 	DefaultPolicyCloudFormationTemplateFile         = "policy-cf.yml"
 	DefaultPolicyOutputFile                         = "policy-outputs.json"
+	DefaultServiceAccountBaseDir                    = "service-accounts"
 	DefaultServiceAccountConfigFile                 = "service-account-config.yml"
 	DefaultServiceAccountOutputsFile                = "service-account-outputs.json"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ const (
 
 	DefaultGithubHost                      = "git@github.com"
 	DefaultArgoCDNamespace                 = "argocd"
+	DefaultFargateObservabilityNamespace   = "aws-observability"
 	DefaultMonitoringNamespace             = "monitoring"
 	DefaultKubePrometheusStackGrafanaName  = "kube-prometheus-stack-grafana"
 	DefaultGrafanaCloudWatchDatasourceName = "cloudwatch-datasource"
@@ -72,6 +73,9 @@ const (
 	DefaultVpcCloudFormationTemplate = "vpc-cf.yml"
 	DefaultVpcBaseDir                = "vpc"
 
+	DefaultNamespaceBaseDir                  = "namespaces"
+	DefaultNamespaceOutputFile               = "ns-output.json"
+	DefaultNamespaceConfigFile               = "ns-conf.yaml"
 	DefaultMonitoringBaseDir                 = "monitoring"
 	DefaultPromtailBaseDir                   = "promtail"
 	DefaultLokiBaseDir                       = "loki"

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -2,6 +2,8 @@
 // definitions
 package datasource
 
+import "github.com/aws/aws-sdk-go/aws"
+
 // Datasources contains a set of datasources
 type Datasources struct {
 	APIVersion  int          `json:"apiVersion"`
@@ -13,13 +15,31 @@ type Datasources struct {
 type Datasource struct {
 	Name      string                 `json:"name"`
 	Type      string                 `json:"type"`
-	Access    string                 `json:"access"`
-	OrgID     int                    `json:"orgId"`
-	URL       string                 `json:"url"`
-	BasicAuth bool                   `json:"basicAuth"`
+	Access    *string                `json:"access,omitempty"`
+	OrgID     *int                   `json:"orgId,omitempty"`
+	URL       *string                `json:"url,omitempty"`
+	BasicAuth *bool                  `json:"basicAuth,omitempty"`
 	JSONData  map[string]interface{} `json:"jsonData"`
-	Version   int                    `json:"version"`
-	Editable  bool                   `json:"editable"`
+	Version   *int                   `json:"version,omitempty"`
+	Editable  *bool                  `json:"editable,omitempty"`
+}
+
+// NewCloudWatch returns an initialised CloudWatch
+// datasource consumable by Grafana
+func NewCloudWatch(region string) *Datasources {
+	return &Datasources{
+		APIVersion: 1,
+		Datasources: []Datasource{
+			{
+				Name: "CloudWatch",
+				Type: "cloudwatch",
+				JSONData: map[string]interface{}{
+					"authType":      "default",
+					"defaultRegion": region,
+				},
+			},
+		},
+	}
 }
 
 // NewLoki returns an initialised Loki
@@ -31,15 +51,15 @@ func NewLoki() *Datasources {
 			{
 				Name:      "Loki",
 				Type:      "loki",
-				Access:    "proxy",
-				OrgID:     1,
-				URL:       "http://loki:3100",
-				BasicAuth: false,
+				Access:    aws.String("proxy"),
+				OrgID:     aws.Int(1),
+				URL:       aws.String("http://loki:3100"),
+				BasicAuth: aws.Bool(false),
 				JSONData: map[string]interface{}{
 					"tlsSkipVerify": true,
 				},
-				Version:  1,
-				Editable: false,
+				Version:  aws.Int(1),
+				Editable: aws.Bool(false),
 			},
 		},
 	}
@@ -54,15 +74,15 @@ func NewTempo() *Datasources {
 			{
 				Name:      "Tempo",
 				Type:      "tempo",
-				Access:    "proxy",
-				OrgID:     1,
-				URL:       "http://tempo:16686",
-				BasicAuth: false,
+				Access:    aws.String("proxy"),
+				OrgID:     aws.Int(1),
+				URL:       aws.String("http://tempo:16686"),
+				BasicAuth: aws.Bool(false),
 				JSONData: map[string]interface{}{
 					"tlsSkipVerify": true,
 				},
-				Version:  1,
-				Editable: false,
+				Version:  aws.Int(1),
+				Editable: aws.Bool(false),
 			},
 		},
 	}

--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -23,6 +23,10 @@ func TestNewDatasource(t *testing.T) {
 			name: "tempo",
 			ds:   datasource.NewTempo(),
 		},
+		{
+			name: "cloudwatch",
+			ds:   datasource.NewCloudWatch("eu-west-1"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/datasource/testdata/cloudwatch.golden
+++ b/pkg/datasource/testdata/cloudwatch.golden
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+- jsonData:
+    authType: default
+    defaultRegion: eu-west-1
+  name: CloudWatch
+  type: cloudwatch

--- a/pkg/helm/charts/kubepromstack/kubepromstack.go
+++ b/pkg/helm/charts/kubepromstack/kubepromstack.go
@@ -27,6 +27,7 @@ func New(timeout time.Duration, values *Values) *helm.Chart {
 
 // Values maps up the values.yaml file
 type Values struct {
+	GrafanaServiceAccountName          string
 	GrafanaCertificateARN              string
 	GrafanaHostname                    string
 	AuthHostname                       string
@@ -55,6 +56,8 @@ func (v *Values) RawYAML() ([]byte, error) {
 	return buff.Bytes(), nil
 }
 
+// valuesTemplate is based on the following values.yaml:
+// - https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
 // nolint: lll
 const valuesTemplate = `
 # Default values for kube-prometheus-stack.
@@ -620,6 +623,10 @@ alertmanager:
 grafana:
   enabled: true
   namespaceOverride: ""
+
+  serviceAccount:
+    create: false
+    name: {{.GrafanaServiceAccountName}}
 
   ## Deploy default dashboards.
   ##

--- a/pkg/helm/charts/kubepromstack/kubepromstack_test.go
+++ b/pkg/helm/charts/kubepromstack/kubepromstack_test.go
@@ -19,6 +19,7 @@ func TestValues(t *testing.T) {
 			name: "kubepromstack values are valid",
 			values: &kubepromstack.Values{
 				GrafanaCertificateARN:              "arn::1234567890/certificate/fake",
+				GrafanaServiceAccountName:          "cloudwatch-something",
 				GrafanaHostname:                    "grafana.okctl-test.oslo.systems",
 				AuthHostname:                       "auth.okctl-test.oslo.system",
 				ClientID:                           "12345dsfg456ty",

--- a/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
+++ b/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
@@ -563,6 +563,10 @@ grafana:
   enabled: true
   namespaceOverride: ""
 
+  serviceAccount:
+    create: false
+    name: cloudwatch-something
+
   ## Deploy default dashboards.
   ##
   defaultDashboardsEnabled: true

--- a/pkg/kube/manifests/namespace/namespace.go
+++ b/pkg/kube/manifests/namespace/namespace.go
@@ -13,13 +13,15 @@ import (
 // Namespace contains the state for creating a namespace
 type Namespace struct {
 	Namespace string
+	Labels    map[string]string
 	Ctx       context.Context
 }
 
 // New returns an initialised namespace creator
-func New(namespace string) *Namespace {
+func New(namespace string, labels map[string]string) *Namespace {
 	return &Namespace{
 		Namespace: namespace,
+		Labels:    labels,
 		Ctx:       context.Background(),
 	}
 }
@@ -83,7 +85,8 @@ func (n *Namespace) NamespaceManifest() *v1.Namespace {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: n.Namespace,
+			Name:   n.Namespace,
+			Labels: n.Labels,
 		},
 	}
 }

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -199,6 +199,34 @@ func (o *Okctl) ClientServices(spin spinner.Spinner) (*clientCore.Services, erro
 	}, nil
 }
 
+func (o *Okctl) managedPolicyService(outputDir string, spin spinner.Spinner) client.ManagedPolicyService {
+	return clientCore.NewManagedPolicyService(spin,
+		rest.NewManagedPolicyAPI(o.restClient),
+		clientFilesystem.NewManagedPolicyStore(
+			clientFilesystem.Paths{
+				OutputFile:         config.DefaultPolicyOutputFile,
+				CloudFormationFile: config.DefaultPolicyCloudFormationTemplateFile,
+				BaseDir:            path.Join(outputDir, config.DefaultPolicyBaseDir),
+			},
+			o.FileSystem,
+		),
+		console.NewManagedPolicyReport(o.Err, spin),
+	)
+}
+
+func (o *Okctl) serviceAccountService(outputDir string, spin spinner.Spinner) client.ServiceAccountService {
+	return clientCore.NewServiceAccountService(
+		spin,
+		rest.NewServiceAccountAPI(o.restClient),
+		clientFilesystem.NewServiceAccountStore(clientFilesystem.Paths{
+			OutputFile: config.DefaultServiceAccountOutputsFile,
+			ConfigFile: config.DefaultServiceAccountConfigFile,
+			BaseDir:    path.Join(outputDir, config.DefaultServiceAccountBaseDir),
+		}, o.FileSystem),
+		console.NewServiceAccountReport(o.Err, spin),
+	)
+}
+
 func (o *Okctl) monitoringService(outputDir string, spin spinner.Spinner) client.MonitoringService {
 	monitoringDir := path.Join(outputDir, config.DefaultMonitoringBaseDir)
 
@@ -242,6 +270,8 @@ func (o *Okctl) monitoringService(outputDir string, spin spinner.Spinner) client
 		o.identityManagerService(monitoringDir, spin.SubSpinner()),
 		o.manifestService(monitoringDir, spin.SubSpinner()),
 		o.paramService(monitoringDir, spin.SubSpinner()),
+		o.serviceAccountService(monitoringDir, spin.SubSpinner()),
+		o.managedPolicyService(monitoringDir, spin.SubSpinner()),
 	)
 }
 

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -366,6 +366,11 @@ func (o *Okctl) manifestService(outputDir string, spin spinner.Spinner) client.M
 		rest.NewManifestAPI(o.restClient),
 		clientFilesystem.NewManifestStore(
 			clientFilesystem.Paths{
+				OutputFile: config.DefaultNamespaceOutputFile,
+				ConfigFile: config.DefaultNamespaceConfigFile,
+				BaseDir:    path.Join(outputDir, config.DefaultNamespaceBaseDir),
+			},
+			clientFilesystem.Paths{
 				OutputFile: config.DefaultConfigMapOutputsFile,
 				ConfigFile: config.DefaultConfigMapConfigFile,
 				BaseDir:    path.Join(outputDir, config.DefaultConfigMapBaseDir),


### PR DESCRIPTION
Add CloudWatch as a data source to Grafana

## Description
This makes it possible to view the logs and metrics collected for the EKS control plane, RDS Postgres databases, Fargate pods and more from within Grafana.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
