### PR TITLE
[KM190] Enable logging of Fargate containers to cloud watch

### DIFF
--- a/docs/release_notes/0.0.45.md
+++ b/docs/release_notes/0.0.45.md
@@ -1,7 +1,6 @@
 # Release 0.0.45
 
 ## Features
-- #377: Adds support for cross environment applications with Kustomize
 
 ## Bugfixes
 

--- a/docs/release_notes/0.0.46.md
+++ b/docs/release_notes/0.0.46.md
@@ -1,6 +1,8 @@
 # Release 0.0.46
 
 ## Features
+- #377: Adds support for cross environment applications with Kustomize
+- #381: Enable logging of Fargate containers to cloud watch
 
 ## Bugfixes
 

--- a/pkg/apis/okctl.io/v1alpha1/provider_v1alpha1.go
+++ b/pkg/apis/okctl.io/v1alpha1/provider_v1alpha1.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/aws/aws-sdk-go/service/servicequotas/servicequotasiface"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
@@ -15,6 +16,7 @@ import (
 // CloudProvider defines the interface for interacting with
 // AWS cloud services
 type CloudProvider interface {
+	IAM() iamiface.IAMAPI
 	SSM() ssmiface.SSMAPI
 	EC2() ec2iface.EC2API
 	EKS() eksiface.EKSAPI

--- a/pkg/cfn/builder_test.go
+++ b/pkg/cfn/builder_test.go
@@ -67,6 +67,11 @@ func TestBuilderAndComposers(t *testing.T) {
 			composer: components.NewCloudwatchDatasourcePolicyComposer("repo", "env"),
 		},
 		{
+			name:     "Builder with FargateCloudWatchPolicy",
+			golden:   "fargate-cloudwatch.yaml",
+			composer: components.NewFargateCloudwatchPolicyComposer("repo", "env"),
+		},
+		{
 			name:   "Builder with UserPool composer",
 			golden: "userpool.yaml",
 			composer: components.NewUserPool(

--- a/pkg/cfn/namer.go
+++ b/pkg/cfn/namer.go
@@ -16,6 +16,7 @@ const (
 	DefaultStackNameAlbIngressControllerPolicyID      = "albingresscontrollerpolicy"
 	DefaultStackNameAWSLoadBalancerControllerPolicyID = "awsloadbalancercontrollerpolicy"
 	DefaultStackNameCloudwatchDatasourceID            = "cloudwatchdatasource"
+	DefaultStackNameFargateCloudwatchID               = "fargatecloudwatch"
 	DefaultStackNameExternalDNSPolicyID               = "externaldns"
 	DefaultStackNameDomainID                          = "domain"
 	DefaultStackNameCertificateID                     = "certificate"
@@ -78,6 +79,16 @@ func (n *StackNamer) CloudwatchDatasource(repository, env string) string {
 	return fmt.Sprintf("%s-%s-%s-%s",
 		DefaultStackNamePrefix,
 		DefaultStackNameCloudwatchDatasourceID,
+		repository,
+		env,
+	)
+}
+
+// FargateCloudwatch returns the stack name of an Blockstorage policy
+func (n *StackNamer) FargateCloudwatch(repository, env string) string {
+	return fmt.Sprintf("%s-%s-%s-%s",
+		DefaultStackNamePrefix,
+		DefaultStackNameFargateCloudwatchID,
 		repository,
 		env,
 	)

--- a/pkg/cfn/testdata/fargate-cloudwatch.yaml.golden
+++ b/pkg/cfn/testdata/fargate-cloudwatch.yaml.golden
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: 2010-09-09
+Outputs:
+  FargateCloudwatchPolicy:
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-FargateCloudwatchPolicy
+    Value:
+      Ref: FargateCloudwatchPolicy
+Resources:
+  FargateCloudwatchPolicy:
+    Properties:
+      Description: Service account policy for reading cloudwatch metrics and logs
+        from grafana
+      ManagedPolicyName: okctl-repo-env-FargateCloudwatchPolicy
+      PolicyDocument:
+        Statement:
+        - Action:
+          - logs:CreateLogStream
+          - logs:CreateLogGroup
+          - logs:DescribeLogStreams
+          - logs:PutLogEvents
+          Effect: Allow
+          Resource:
+          - '*'
+        Version: 2012-10-17
+    Type: AWS::IAM::ManagedPolicy

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -4,6 +4,10 @@ package cloud
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 
@@ -63,6 +67,7 @@ func NewFromSession(region, principalARN string, sess *session.Session) (*Provid
 		Provider: services,
 	}
 
+	services.iam = iam.New(sess)
 	services.cfn = cloudformation.New(sess)
 	services.ec2 = ec2.New(sess)
 	services.elbv2 = elbv2.New(sess)
@@ -103,6 +108,7 @@ func NewSession(region string, auth awsauth.Authenticator) (*session.Session, *a
 
 // Services stores access to the various AWS APIs
 type Services struct {
+	iam   iamiface.IAMAPI
 	cfn   cloudformationiface.CloudFormationAPI
 	ec2   ec2iface.EC2API
 	elbv2 elbv2iface.ELBV2API
@@ -115,6 +121,11 @@ type Services struct {
 
 	region       string
 	principalARN string
+}
+
+// IAM returns an interface to the IAM API
+func (s *Services) IAM() iamiface.IAMAPI {
+	return s.iam
 }
 
 // CloudFront returns an interface to the AWS CloudFront API

--- a/pkg/eksapi/eksapi.go
+++ b/pkg/eksapi/eksapi.go
@@ -1,0 +1,39 @@
+// Package eksapi provides some convenience functionality
+// for retrieving information about an AWS EKS cluster
+package eksapi
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+)
+
+// EKSAPI contains the required state for interacting
+// with the AWS EKS API
+type EKSAPI struct {
+	clusterName string
+	provider    v1alpha1.CloudProvider
+}
+
+// New returns an initialised EKS API client
+func New(clusterName string, provider v1alpha1.CloudProvider) *EKSAPI {
+	return &EKSAPI{
+		clusterName: clusterName,
+		provider:    provider,
+	}
+}
+
+// FargateProfilePodExecutionRoleARN retrieves the Fargate profile pod execution role ARN
+func (f *EKSAPI) FargateProfilePodExecutionRoleARN(profile string) (string, error) {
+	p, err := f.provider.EKS().DescribeFargateProfile(&eks.DescribeFargateProfileInput{
+		ClusterName:        aws.String(f.clusterName),
+		FargateProfileName: aws.String(profile),
+	})
+	if err != nil {
+		return "", fmt.Errorf("getting fargate profile: %w", err)
+	}
+
+	return *p.FargateProfile.PodExecutionRoleArn, nil
+}

--- a/pkg/eksapi/eksapi_test.go
+++ b/pkg/eksapi/eksapi_test.go
@@ -1,0 +1,50 @@
+package eksapi_test
+
+import (
+	"testing"
+
+	"github.com/oslokommune/okctl/pkg/eksapi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+
+	"github.com/oslokommune/okctl/pkg/mock"
+)
+
+func TestEKSAPIFargateProfilePodExecutionRoleARN(t *testing.T) {
+	testCases := []struct {
+		name      string
+		provider  v1alpha1.CloudProvider
+		expect    interface{}
+		expectErr bool
+	}{
+		{
+			name:      "Should work",
+			provider:  mock.NewGoodCloudProvider(),
+			expect:    mock.DefaultFargateProfilePodExecutionRoleARN,
+			expectErr: false,
+		},
+		{
+			name:      "Should fai",
+			provider:  mock.NewBadCloudProvider(),
+			expect:    "getting fargate profile: something bad",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := eksapi.New("something", tc.provider).FargateProfilePodExecutionRoleARN("something")
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expect, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expect, got)
+			}
+		})
+	}
+}

--- a/pkg/eksapi/eksapi_test.go
+++ b/pkg/eksapi/eksapi_test.go
@@ -25,7 +25,7 @@ func TestEKSAPIFargateProfilePodExecutionRoleARN(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:      "Should fai",
+			name:      "Should fail",
 			provider:  mock.NewBadCloudProvider(),
 			expect:    "getting fargate profile: something bad",
 			expectErr: true,

--- a/pkg/iamapi/iamapi.go
+++ b/pkg/iamapi/iamapi.go
@@ -1,0 +1,55 @@
+package iamapi
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+)
+
+// IAMAPI contains the required state for interacting
+// with the AWS IAM API
+type IAMAPI struct {
+	provider v1alpha1.CloudProvider
+}
+
+// New returns an initialised client
+func New(provider v1alpha1.CloudProvider) *IAMAPI {
+	return &IAMAPI{
+		provider: provider,
+	}
+}
+
+// AttachRolePolicy attaches the provided policy to the role
+func (i *IAMAPI) AttachRolePolicy(policyARN, roleARN string) error {
+	friendlyName, err := RoleFriendlyName(roleARN)
+	if err != nil {
+		return err
+	}
+
+	_, err = i.provider.IAM().AttachRolePolicy(&iam.AttachRolePolicyInput{
+		PolicyArn: aws.String(policyARN),
+		RoleName:  aws.String(friendlyName),
+	})
+	if err != nil {
+		return fmt.Errorf("attaching policy to role: %w", err)
+	}
+
+	return nil
+}
+
+// RoleFriendlyName returns the friendly name of the role
+// by extracting it from the provided ARN
+func RoleFriendlyName(roleARN string) (string, error) {
+	a, err := arn.Parse(roleARN)
+	if err != nil {
+		return "", fmt.Errorf("getting role friendly name: %w", err)
+	}
+
+	return strings.TrimPrefix(a.Resource, "role/"), nil
+}

--- a/pkg/iamapi/iamapi.go
+++ b/pkg/iamapi/iamapi.go
@@ -1,3 +1,5 @@
+// Package iamapi provides some convenience functions
+// for interacting with the AWS IAM API
 package iamapi
 
 import (

--- a/pkg/iamapi/iamapi_test.go
+++ b/pkg/iamapi/iamapi_test.go
@@ -1,0 +1,90 @@
+package iamapi_test
+
+import (
+	"testing"
+
+	"github.com/oslokommune/okctl/pkg/mock"
+
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+
+	"github.com/oslokommune/okctl/pkg/iamapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoleFriendlyName(t *testing.T) {
+	testCases := []struct {
+		name      string
+		roleARN   string
+		expect    interface{}
+		expectErr bool
+	}{
+		{
+			name:    "Should work",
+			roleARN: "arn:aws:iam::123456789012:role/eksctl-okctl-test-cluster-FargatePodExecutionRole-GHUSFFAKE",
+			expect:  "eksctl-okctl-test-cluster-FargatePodExecutionRole-GHUSFFAKE",
+		},
+		{
+			name:      "Should fail",
+			roleARN:   "notanarn",
+			expect:    "getting role friendly name: arn: invalid prefix",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := iamapi.RoleFriendlyName(tc.roleARN)
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expect, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expect, got)
+			}
+		})
+	}
+}
+
+func TestIAMAPIAttachRolePolicy(t *testing.T) {
+	testCases := []struct {
+		name      string
+		provider  v1alpha1.CloudProvider
+		policyARN string
+		roleARN   string
+		expect    interface{}
+		expectErr bool
+	}{
+		{
+			name:      "Should work",
+			provider:  mock.NewGoodCloudProvider(),
+			policyARN: "arn:iam:::policy/somethingFAHJFAKE",
+			roleARN:   mock.DefaultFargateProfilePodExecutionRoleARN,
+		},
+		{
+			name:      "Should fail",
+			provider:  mock.NewBadCloudProvider(),
+			policyARN: "arn:iam:::policy/somethingFAHJFAKE",
+			roleARN:   mock.DefaultFargateProfilePodExecutionRoleARN,
+			expect:    "attaching policy to role: something bad",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			err := iamapi.New(tc.provider).AttachRolePolicy(tc.policyARN, tc.roleARN)
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expect, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -277,6 +277,7 @@ func (o *Okctl) monitoringService(outputDir string, spin spinner.Spinner) client
 		o.paramService(monitoringDir, spin.SubSpinner()),
 		o.serviceAccountService(monitoringDir, spin.SubSpinner()),
 		o.managedPolicyService(monitoringDir, spin.SubSpinner()),
+		o.CloudProvider,
 	)
 }
 


### PR DESCRIPTION
Enable logging of Fargate containers to cloud watch

<img width="627" alt="image" src="https://user-images.githubusercontent.com/154348/110611949-01c69f80-8190-11eb-8e4c-2395bd315f0c.png">

## Description
By logging the Fargate containers to CloudWatch we can use the Grafana Cloudwatch data source to query on those logs also. Essentially, we end up getting all the logs in one "location" for introspection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
