### PR TITLE
Km196 fix missing policy arn

### DIFF
--- a/cmd/okctl/delete.go
+++ b/cmd/okctl/delete.go
@@ -60,6 +60,15 @@ type DeleteClusterOpts struct {
 // Validate the inputs
 func (o *DeleteClusterOpts) Validate() error {
 	return validation.ValidateStruct(o,
+		validation.Field(&o.ClusterName, validation.NewStringRule(
+			func(s string) bool {
+				return fmt.Sprintf("%s-%s", o.Repository, o.Environment) == s
+			},
+			fmt.Sprintf(
+				`internal error: cluster name needs to be in the format repository-environment, but was "%s"`,
+				o.ClusterName,
+			),
+		)),
 		validation.Field(&o.Environment, validation.Required),
 		validation.Field(&o.AWSAccountID, validation.Required),
 		validation.Field(&o.Region, validation.Required),
@@ -103,7 +112,7 @@ including VPC, this is a highly destructive operation.`,
 			opts.Region = meta.Region
 			opts.AWSAccountID = cluster.AWSAccountID
 			opts.Environment = cluster.Environment
-			opts.ClusterName = cluster.Name
+			opts.ClusterName = o.RepoStateWithEnv.GetClusterName()
 
 			err = opts.Validate()
 			if err != nil {

--- a/cmd/okctl/delete_test.go
+++ b/cmd/okctl/delete_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func createValidOptsBuilder() *DeleteClusterOptsBuilder {
+	return &DeleteClusterOptsBuilder{
+		opts: DeleteClusterOpts{
+			Region:       "eu-west-1",
+			AWSAccountID: "123456789012",
+			Environment:  "test",
+			Repository:   "kjoremiljo",
+			ClusterName:  "kjoremiljo-test",
+		},
+	}
+}
+
+type DeleteClusterOptsBuilder struct {
+	opts DeleteClusterOpts
+}
+
+func (b *DeleteClusterOptsBuilder) ClusterName(newName string) *DeleteClusterOptsBuilder {
+	b.opts.ClusterName = newName
+
+	return b
+}
+
+func TestKM170(t *testing.T) {
+	// Ensures that the expected format of opts.ClusterName is correct. This bug was due to using the
+	// o.RepoStateWithEnv.GetCluster().Name instead of o.RepoStateWithEnv.GetClusterName()
+	testCases := []struct {
+		name string
+
+		withOpts  *DeleteClusterOptsBuilder
+		expectErr string
+	}{
+		{
+			name: "Should pass with all required and valid opts",
+
+			withOpts: createValidOptsBuilder(),
+		},
+		{
+			name: "Should break if clustername doesnt equal name-env",
+
+			withOpts:  createValidOptsBuilder().ClusterName("thiswontwork"),
+			expectErr: `ClusterName: internal error: cluster name needs to be in the format repository-environment, but was "thiswontwork".`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.withOpts.opts.Validate()
+
+			if tc.expectErr != "" {
+				assert.Error(t, err, tc.expectErr)
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}

--- a/docs/release_notes/0.0.48.md
+++ b/docs/release_notes/0.0.48.md
@@ -3,5 +3,7 @@
 ## Features
 
 ## Bugfixes
+- 26db212 KM196 🐛 Fix policyArn cannot be blank problem in delete cluster
+- f2c5cd5 KM170 🐛 Fix flaky cluster name bug
 
 ## Other

--- a/pkg/client/core/service_monitoring_client.go
+++ b/pkg/client/core/service_monitoring_client.go
@@ -433,7 +433,7 @@ func (s *monitoringService) DeleteKubePromStack(ctx context.Context, opts client
 	cc, err := clusterconfig.NewCloudwatchDatasourceServiceAccount(
 		opts.ID.ClusterName,
 		opts.ID.Region,
-		"",
+		"N/A",
 		constant.DefaultMonitoringNamespace,
 		v1alpha1.PermissionsBoundaryARN(opts.ID.AWSAccountID),
 	)

--- a/pkg/client/core/service_monitoring_client_test.go
+++ b/pkg/client/core/service_monitoring_client_test.go
@@ -1,0 +1,272 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/client/store"
+	"github.com/oslokommune/okctl/pkg/config/state"
+	"github.com/oslokommune/okctl/pkg/mock"
+	"github.com/oslokommune/okctl/pkg/spinner"
+	"github.com/stretchr/testify/assert"
+)
+
+type clusterConfigRetrieverFn func(config *v1alpha5.ClusterConfig)
+
+func createMonitoringService(retriever clusterConfigRetrieverFn) client.MonitoringService {
+	var stdout bytes.Buffer
+
+	spin, _ := spinner.New("test", &stdout)
+
+	return NewMonitoringService(
+		spin,
+		mockAPI{},
+		mockStore{},
+		mockState{},
+		mockReport{},
+		mockCertService{},
+		mockIdentityManagerService{},
+		mockManifestService{},
+		mockParameterService{},
+		mockServiceAccountService{retrieverFn: retriever},
+		mockManagedPolicyService{},
+		mock.NewCloudProvider(),
+	)
+}
+
+func TestKM196(t *testing.T) {
+	// Policy ARN was an invalid value and it wasnt caught until runtime
+	var clusterConfig *v1alpha5.ClusterConfig
+
+	monitoringService := createMonitoringService(func(config *v1alpha5.ClusterConfig) {
+		clusterConfig = config
+	})
+
+	err := monitoringService.DeleteKubePromStack(context.Background(), client.DeleteKubePromStackOpts{
+		ID: api.ID{
+			Region:       "eu-west-1",
+			AWSAccountID: "123456789012",
+			Environment:  "test",
+			Repository:   "something",
+			ClusterName:  "something",
+		},
+		Domain: "test.oslo.systems",
+	})
+	assert.Nil(t, err)
+
+	assert.NotEmpty(t, clusterConfig.IAM.ServiceAccounts[0].AttachPolicyARNs[0])
+}
+
+type mockAPI struct{}
+
+func (m mockAPI) CreateKubePromStack(_ api.CreateKubePrometheusStackOpts) (*api.Helm, error) {
+	panic("implement me")
+}
+
+func (m mockAPI) DeleteKubePromStack(_ api.DeleteHelmReleaseOpts) error {
+	return nil
+}
+
+func (m mockAPI) CreateLoki(_ client.CreateLokiOpts) (*api.Helm, error) { panic("implement me") }
+
+func (m mockAPI) DeleteLoki(_ api.DeleteHelmReleaseOpts) error { panic("implement me") }
+
+func (m mockAPI) CreatePromtail(_ client.CreatePromtailOpts) (*api.Helm, error) {
+	panic("implement me")
+}
+
+func (m mockAPI) DeletePromtail(_ api.DeleteHelmReleaseOpts) error { panic("implement me") }
+
+func (m mockAPI) CreateTempo(_ api.CreateHelmReleaseOpts) (*api.Helm, error) { panic("implement me") }
+
+func (m mockAPI) DeleteTempo(_ api.DeleteHelmReleaseOpts) error { panic("implement me") }
+
+type mockStore struct{}
+
+func (m mockStore) SaveKubePromStack(_ *client.KubePromStack) (*store.Report, error) {
+	panic("implement me")
+}
+
+func (m mockStore) RemoveKubePromStack(_ api.ID) (*store.Report, error) {
+	return nil, nil
+}
+
+func (m mockStore) SaveLoki(_ *client.Loki) (*store.Report, error) {
+	panic("implement me")
+}
+
+func (m mockStore) RemoveLoki(_ api.ID) (*store.Report, error) {
+	panic("implement me")
+}
+
+func (m mockStore) SavePromtail(_ *client.Promtail) (*store.Report, error) {
+	panic("implement me")
+}
+
+func (m mockStore) RemovePromtail(_ api.ID) (*store.Report, error) {
+	panic("implement me")
+}
+
+func (m mockStore) SaveTempo(_ *client.Tempo) (*store.Report, error) {
+	panic("implement me")
+}
+
+func (m mockStore) RemoveTempo(_ api.ID) (*store.Report, error) {
+	panic("implement me")
+}
+
+type mockState struct{}
+
+func (m mockState) SaveKubePromStack(_ *client.KubePromStack) (*store.Report, error) {
+	panic("implement me")
+}
+
+func (m mockState) RemoveKubePromStack(_ api.ID) (*store.Report, error) {
+	return nil, nil
+}
+
+type mockReport struct{}
+
+func (m mockReport) ReportSaveKubePromStack(_ *client.KubePromStack, _ []*store.Report) error {
+	panic("implement me")
+}
+
+func (m mockReport) ReportRemoveKubePromStack(_ []*store.Report) error {
+	return nil
+}
+
+func (m mockReport) ReportSaveLoki(_ *client.Loki, _ *store.Report) error {
+	panic("implement me")
+}
+
+func (m mockReport) ReportRemoveLoki(_ *store.Report) error {
+	panic("implement me")
+}
+
+func (m mockReport) ReportSavePromtail(_ *client.Promtail, _ *store.Report) error {
+	panic("implement me")
+}
+
+func (m mockReport) ReportRemovePromtail(_ *store.Report) error {
+	panic("implement me")
+}
+
+func (m mockReport) ReportSaveTempo(_ *client.Tempo, _ *store.Report) error {
+	panic("implement me")
+}
+
+func (m mockReport) ReportRemoveTempo(_ *store.Report) error {
+	panic("implement me")
+}
+
+type mockCertService struct{}
+
+func (m mockCertService) CreateCertificate(_ context.Context, _ api.CreateCertificateOpts) (*api.Certificate, error) {
+	panic("implement me")
+}
+
+func (m mockCertService) DeleteCertificate(_ context.Context, _ api.DeleteCertificateOpts) error {
+	return nil
+}
+
+func (m mockCertService) DeleteCognitoCertificate(_ context.Context, _ api.DeleteCognitoCertificateOpts) error {
+	panic("implement me")
+}
+
+type mockIdentityManagerService struct{}
+
+func (m mockIdentityManagerService) CreateIdentityPool(_ context.Context, _ api.CreateIdentityPoolOpts) (*api.IdentityPool, error) {
+	panic("implement me")
+}
+
+func (m mockIdentityManagerService) CreateIdentityPoolClient(_ context.Context, _ api.CreateIdentityPoolClientOpts) (*api.IdentityPoolClient, error) {
+	panic("implement me")
+}
+
+func (m mockIdentityManagerService) CreateIdentityPoolUser(_ context.Context, _ client.CreateIdentityPoolUserOpts) (*api.IdentityPoolUser, error) {
+	panic("implement me")
+}
+
+func (m mockIdentityManagerService) DeleteIdentityPool(_ context.Context, _ api.ID) error {
+	panic("implement me")
+}
+
+func (m mockIdentityManagerService) DeleteIdentityPoolClient(_ context.Context, _ api.DeleteIdentityPoolClientOpts) error {
+	return nil
+}
+
+type mockManifestService struct{}
+
+func (m mockManifestService) DeleteNamespace(_ context.Context, _ api.DeleteNamespaceOpts) error {
+	return nil
+}
+
+func (m mockManifestService) CreateStorageClass(_ context.Context, _ api.CreateStorageClassOpts) (*client.StorageClass, error) {
+	panic("implement me")
+}
+
+func (m mockManifestService) CreateExternalSecret(_ context.Context, _ client.CreateExternalSecretOpts) (*client.ExternalSecret, error) {
+	panic("implement me")
+}
+
+func (m mockManifestService) DeleteExternalSecret(_ context.Context, _ client.DeleteExternalSecretOpts) error {
+	return nil
+}
+
+func (m mockManifestService) CreateConfigMap(_ context.Context, _ client.CreateConfigMapOpts) (*client.ConfigMap, error) {
+	panic("implement me")
+}
+
+func (m mockManifestService) DeleteConfigMap(_ context.Context, _ client.DeleteConfigMapOpts) error {
+	return nil
+}
+
+func (m mockManifestService) ScaleDeployment(_ context.Context, _ api.ScaleDeploymentOpts) error {
+	panic("implement me")
+}
+
+func (m mockManifestService) CreateNamespace(_ context.Context, _ api.CreateNamespaceOpts) (*client.Namespace, error) {
+	panic("implement me")
+}
+
+type mockParameterService struct{}
+
+func (m mockParameterService) CreateSecret(_ context.Context, _ api.CreateSecretOpts) (*api.SecretParameter, error) {
+	panic("implement me")
+}
+
+func (m mockParameterService) DeleteSecret(_ context.Context, _ api.DeleteSecretOpts) error {
+	return nil
+}
+
+func (m mockParameterService) DeleteAllsecrets(_ context.Context, _ state.Cluster) error {
+	panic("implement me")
+}
+
+type mockServiceAccountService struct {
+	retrieverFn clusterConfigRetrieverFn
+}
+
+func (m mockServiceAccountService) CreateServiceAccount(_ context.Context, _ api.CreateServiceAccountOpts) (*api.ServiceAccount, error) {
+	panic("implement me")
+}
+
+func (m mockServiceAccountService) DeleteServiceAccount(_ context.Context, opts api.DeleteServiceAccountOpts) error {
+	m.retrieverFn(opts.Config)
+
+	return nil
+}
+
+type mockManagedPolicyService struct{}
+
+func (m mockManagedPolicyService) CreatePolicy(_ context.Context, _ api.CreatePolicyOpts) (*api.ManagedPolicy, error) {
+	panic("implement me")
+}
+
+func (m mockManagedPolicyService) DeletePolicy(_ context.Context, _ api.DeletePolicyOpts) error {
+	return nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- KM196: Added a dummy text to pass the "not empty validation
- KM170: Ensured `delete cluster` acquires the cluster name for its api.ID struct the same way as `apply cluster` and `delete cluster`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM196](https://trello.com/c/qyONSvVs/196-fix-broken-nightly-due-to-blank-policy-arn-in-deletion)
[KM170](https://trello.com/c/WrwMpUVK/170-fix-cluster-name-bug)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
