### PR TITLE
KM196 🐛 Fix error due to ExternalDNS timing out

### DIFF
--- a/docs/release_notes/0.0.49.md
+++ b/docs/release_notes/0.0.49.md
@@ -3,5 +3,6 @@
 ## Features
 
 ## Bugfixes
+KM196: Add handling of timeout errors for ExternalDNS (#397)
 
 ## Other

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/magiconair/properties v1.8.2 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/miekg/dns v1.1.40
-	github.com/mishudark/errors v0.0.0-20190221111348-b16f7e94bb58
+	github.com/mishudark/errors v0.0.0-20210318113247-bd4e9ef2fc74
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -721,8 +721,8 @@ github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/le
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.40 h1:pyyPFfGMnciYUk/mXpKkVmeMQjfXqt3FAJ2hy7tPiLA=
 github.com/miekg/dns v1.1.40/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
-github.com/mishudark/errors v0.0.0-20190221111348-b16f7e94bb58 h1:GrgbFS8KSGgSqsMbLod+cg9b/rHhaIvp/LFayLtDtio=
-github.com/mishudark/errors v0.0.0-20190221111348-b16f7e94bb58/go.mod h1:a4Itg6NPUPc0Wt6nEc6X6UZwZf66ZSAWclh7ovJOyDw=
+github.com/mishudark/errors v0.0.0-20210318113247-bd4e9ef2fc74 h1:K81WbBbvpUDBN+coctEIX7LdOBtYShJ3vAlj94P1F9A=
+github.com/mishudark/errors v0.0.0-20210318113247-bd4e9ef2fc74/go.mod h1:62bY6L5EL0ejXpSneFOtK47WAJ/I+wHCsl4yQtaVRTc=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=

--- a/pkg/api/core/run/helm_run.go
+++ b/pkg/api/core/run/helm_run.go
@@ -145,7 +145,7 @@ func (r *helmRun) createHelmChart(id api.ID, chart *helm.Chart) (*api.Helm, erro
 
 	release, err := r.helm.Install(kubeConf.Path, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("nstalling chart: %w", err)
+		return nil, fmt.Errorf("installing chart: %w", err)
 	}
 
 	return &api.Helm{

--- a/pkg/api/core/run/kube_run.go
+++ b/pkg/api/core/run/kube_run.go
@@ -1,11 +1,15 @@
 package run
 
 import (
+	stdlibErrors "errors"
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	v1 "github.com/oslokommune/okctl/pkg/kube/externalsecret/api/types/v1"
 
+	"github.com/mishudark/errors"
 	"github.com/oslokommune/okctl/pkg/kube/manifests/scale"
 
 	"github.com/oslokommune/okctl/pkg/kube/manifests/configmap"
@@ -306,7 +310,13 @@ func (k *kubeRun) CreateExternalDNSKubeDeployment(opts api.CreateExternalDNSKube
 
 	err = client.Watch(resources, 2*time.Minute) // nolint: gomnd
 	if err != nil {
-		return nil, fmt.Errorf("failed while waiting for resources to be created: %w", err)
+		wrappedErr := fmt.Errorf("failed while waiting for resources to be created: %w", err)
+
+		if stdlibErrors.Is(wrappedErr, wait.ErrWaitTimeout) {
+			return nil, errors.E(err, errors.Timeout)
+		}
+
+		return nil, wrappedErr
 	}
 
 	deployment, err := yaml.Marshal(ext.DeploymentManifest())

--- a/pkg/client/core/api/rest/client.go
+++ b/pkg/client/core/api/rest/client.go
@@ -9,6 +9,10 @@ import (
 	"net/http"
 	"strings"
 
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+
+	"github.com/mishudark/errors"
+
 	"github.com/sanity-io/litter"
 )
 
@@ -41,6 +45,7 @@ func (c *HTTPClient) DoDelete(endpoint string, body interface{}) error {
 }
 
 // Do performs the request
+// nolint: funlen
 func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interface{}) error {
 	if c.Debug {
 		_, err := fmt.Fprintf(c.Progress, "client (method: %s, endpoint: %s) starting request: %s", method, endpoint, litter.Sdump(body))
@@ -72,7 +77,7 @@ func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interfac
 	}
 
 	if resp.StatusCode >= 400 { // nolint: gomnd
-		return fmt.Errorf("request failed with %s, because: %s", http.StatusText(resp.StatusCode), string(out))
+		return deserializeErrorPayload(out)
 	}
 
 	defer func() {
@@ -103,4 +108,38 @@ func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interfac
 
 func pretty(msg, method, endpoint string) string {
 	return fmt.Sprintf("%s: %s, %s", msg, method, endpoint)
+}
+
+type serializedError struct {
+	Detail map[string]interface{} `json:"detail,omitempty"`
+	Type   string                 `json:"type"`
+	Error  string                 `json:"error"`
+	Code   errors.Kind            `json:"code"`
+}
+
+func (s serializedError) Validate() error {
+	return validation.ValidateStruct(&s,
+		validation.Field(&s.Error, validation.Required),
+	)
+}
+
+// deserializeErrorPayload converts an JSON error payload from the backend to a structured error
+func deserializeErrorPayload(jsonContent []byte) error {
+	data := serializedError{}
+
+	err := json.Unmarshal(jsonContent, &data)
+	if err != nil {
+		return errors.E(
+			fmt.Errorf("unmarshalling error from server side: %w", err),
+			errors.Internal)
+	}
+
+	if err = data.Validate(); err != nil {
+		return errors.E(
+			fmt.Errorf("validating deserialized error with content %s: %w", string(jsonContent), err),
+			errors.Unmarshal,
+		)
+	}
+
+	return errors.E(errors.New(data.Error), data.Code, data.Detail)
 }

--- a/pkg/client/core/api/rest/client_test.go
+++ b/pkg/client/core/api/rest/client_test.go
@@ -1,0 +1,73 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mishudark/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+type testMarshalledErrorServer struct {
+	kind errors.Kind
+}
+
+func (t testMarshalledErrorServer) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
+	err := errors.E(errors.New("something bad happened"), t.kind)
+
+	raw, _ := json.Marshal(err)
+
+	// Must be >= 400 to trigger error
+	writer.WriteHeader(400)
+
+	_, _ = writer.Write(raw)
+}
+
+func TestErrorSerialization(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		withKind                            errors.Kind
+		expectDifferentAfterDeserialization bool
+	}{
+		{
+			name: "Should deserialize into Timeout error",
+
+			withKind: errors.Timeout,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(testMarshalledErrorServer{tc.withKind})
+
+			defer server.Close()
+
+			client := HTTPClient{
+				BaseURL: server.URL,
+				Client:  &http.Client{},
+			}
+
+			err := client.Do(http.MethodPost, "/dummy", "", "")
+
+			assert.True(t, errors.IsKind(err, tc.withKind))
+		})
+	}
+}
+
+func TestKindSanity(t *testing.T) {
+	server := httptest.NewServer(testMarshalledErrorServer{errors.Timeout})
+
+	client := HTTPClient{
+		BaseURL: server.URL,
+		Client:  &http.Client{},
+	}
+
+	err := client.Do(http.MethodPost, "/dummy", "", "")
+
+	assert.False(t, errors.IsKind(err, errors.Decrypt))
+}

--- a/pkg/controller/reconciler/externaldns_reconciler.go
+++ b/pkg/controller/reconciler/externaldns_reconciler.go
@@ -1,8 +1,9 @@
 package reconciler
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/mishudark/errors"
 
 	"github.com/oslokommune/okctl/pkg/client"
 	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
@@ -45,6 +46,8 @@ func (z *externalDNSReconciler) Reconcile(node *resourcetree.ResourceNode) (resu
 			Domain:       z.commonMetadata.Declaration.ClusterRootDomain,
 		})
 		if err != nil {
+			result.Requeue = errors.IsKind(err, errors.Timeout)
+
 			return result, fmt.Errorf("creating external DNS: %w", err)
 		}
 	case resourcetree.ResourceNodeStateAbsent:

--- a/pkg/controller/synchronize.go
+++ b/pkg/controller/synchronize.go
@@ -83,7 +83,7 @@ func handleNode(reconcilerManager reconciler.Reconciler, currentNode *resourcetr
 	for _, node := range currentNode.Children {
 		err = handleNode(reconcilerManager, node)
 		if err != nil {
-			return fmt.Errorf("handling node: %w", err)
+			return err
 		}
 	}
 

--- a/pkg/controller/synchronize.go
+++ b/pkg/controller/synchronize.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/oslokommune/okctl/pkg/config/constant"
 
-	"github.com/mishudark/errors"
 	"github.com/oslokommune/okctl/pkg/api"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 
@@ -64,18 +63,19 @@ func Synchronize(opts *SynchronizeOpts) error {
 }
 
 // handleNode knows how to run Reconcile() on every node of a ResourceNode tree
+//goland:noinspection GoNilness
 func handleNode(reconcilerManager reconciler.Reconciler, currentNode *resourcetree.ResourceNode) (err error) {
 	reconciliationResult := reconciler.ReconcilationResult{Requeue: true, RequeueAfter: 0 * time.Second}
 
 	for requeues := 0; reconciliationResult.Requeue; requeues++ {
 		if requeues == constant.DefaultMaxReconciliationRequeues {
-			return errors.New("maximum allowed reconciliation requeues reached")
+			return fmt.Errorf("maximum allowed reconciliation requeues reached: %w", err)
 		}
 
 		time.Sleep(reconciliationResult.RequeueAfter)
 
 		reconciliationResult, err = reconcilerManager.Reconcile(currentNode)
-		if err != nil {
+		if err != nil && !reconciliationResult.Requeue {
 			return fmt.Errorf("reconciling node: %w", err)
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Identifies a timeout as early as possible in the `kubectl` functionality
- Ensures the timeout error travels from the server to the client reconciler  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM196](https://trello.com/c/7yhX8th6/193-setup-requeue-for-waiterrwaittimeout-in-externaldns-reconciler-create)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added a failure point in a server side call for the first reconciler to run (primary hosted zone) and made sure I could identify the same type of error in the reconciler that called it. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
