### PR TITLE
🐛 Fix externaldns type override

### DIFF
--- a/pkg/api/core/run/kube_run.go
+++ b/pkg/api/core/run/kube_run.go
@@ -1,15 +1,11 @@
 package run
 
 import (
-	stdlibErrors "errors"
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	v1 "github.com/oslokommune/okctl/pkg/kube/externalsecret/api/types/v1"
 
-	"github.com/mishudark/errors"
 	"github.com/oslokommune/okctl/pkg/kube/manifests/scale"
 
 	"github.com/oslokommune/okctl/pkg/kube/manifests/configmap"
@@ -310,13 +306,7 @@ func (k *kubeRun) CreateExternalDNSKubeDeployment(opts api.CreateExternalDNSKube
 
 	err = client.Watch(resources, 2*time.Minute) // nolint: gomnd
 	if err != nil {
-		wrappedErr := fmt.Errorf("failed while waiting for resources to be created: %w", err)
-
-		if stdlibErrors.Is(wrappedErr, wait.ErrWaitTimeout) {
-			return nil, errors.E(err, errors.Timeout)
-		}
-
-		return nil, wrappedErr
+		return nil, fmt.Errorf("failed while waiting for resources to be created: %w", err)
 	}
 
 	deployment, err := yaml.Marshal(ext.DeploymentManifest())

--- a/pkg/api/core/service_kube_test.go
+++ b/pkg/api/core/service_kube_test.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestEnsureTimeoutType(t *testing.T) {
+	// Had a case where the error kind got overridden. The service layer is supposed to convert what ever the lower
+	// levels return into meaningful errors for okctl
+	ks := NewKubeService(mockKubeRun{})
+
+	_, err := ks.CreateExternalDNSKubeDeployment(context.Background(), api.CreateExternalDNSKubeDeploymentOpts{
+		ID:           createValidID(),
+		HostedZoneID: "someid",
+		DomainFilter: "somefilter",
+	})
+
+	assert.True(t, errors.IsKind(err, errors.Timeout))
+}
+
+func createValidID() api.ID {
+	return api.ID{
+		Region:       "eu-west-1",
+		AWSAccountID: "123456789012",
+		Environment:  "test",
+		Repository:   "bugged",
+		ClusterName:  "bugged-test",
+	}
+}
+
+type mockKubeRun struct{}
+
+func (m mockKubeRun) CreateExternalDNSKubeDeployment(_ api.CreateExternalDNSKubeDeploymentOpts) (*api.ExternalDNSKube, error) {
+	return nil, wait.ErrWaitTimeout
+}
+
+func (m mockKubeRun) CreateStorageClass(_ api.CreateStorageClassOpts) (*api.StorageClassKube, error) {
+	panic("implement me")
+}
+
+func (m mockKubeRun) CreateExternalSecrets(_ api.CreateExternalSecretsOpts) (*api.ExternalSecretsKube, error) {
+	panic("implement me")
+}
+
+func (m mockKubeRun) DeleteExternalSecrets(_ api.DeleteExternalSecretsOpts) error {
+	panic("implement me")
+}
+
+func (m mockKubeRun) CreateConfigMap(_ api.CreateConfigMapOpts) (*api.ConfigMap, error) {
+	panic("implement me")
+}
+
+func (m mockKubeRun) CreateNamespace(_ api.CreateNamespaceOpts) (*api.Namespace, error) {
+	panic("implement me")
+}
+
+func (m mockKubeRun) DeleteNamespace(_ api.DeleteNamespaceOpts) error { panic("implement me") }
+func (m mockKubeRun) DeleteConfigMap(_ api.DeleteConfigMapOpts) error { panic("implement me") }
+func (m mockKubeRun) ScaleDeployment(_ api.ScaleDeploymentOpts) error { panic("implement me") }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Moves identification of a kubectl command error type into the service layer that calls it, in this case, externalDNS creation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Try #2 at [KM193](https://trello.com/c/7yhX8th6). Previous fix got overriden by the service layer, so moved the check and type setting into the service layer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
