### PR TITLE
KM218: Document how to delete cluster without kubectl cluster access

### DIFF
--- a/userdocs/src/getting-started/clean-up.md
+++ b/userdocs/src/getting-started/clean-up.md
@@ -33,11 +33,15 @@ and possible remedies.
 
 ### Delete all Kubernetes resources
 
+#### Using kubectl
+
+The following applies if you can access your cluster with `kubectl`.
+
 Delete everything in all namespaces except `kube-system`. In `kube-system`, some of the core components, such as 
 `AWS load balancer controller` are running. These controllers create AWS resources on your behalf. By removing all 
 resources from all namespaces, we allow these services to clean up themselves.
 
-#### MacOS
+*MacOS*
 
 ```bash
 for each in $(kubectl get ns -o jsonpath="{.items[*].metadata.name}" | grep -v kube-system);
@@ -46,7 +50,7 @@ do
 done
 ```
 
-#### Linux
+*Linux*
 
 ```bash
 for each in $(kubectl get ns -o jsonpath="{.items[*].metadata.name}" | tr ' ' \\n | grep -v kube-system);
@@ -54,6 +58,16 @@ do
   kubectl delete ns $each
 done
 ```
+
+#### Manually
+
+If you are not able to access the cluster with `kubectl`, you can delete the following through the AWS console instead:
+
+* EC2 -> Load Balancers -> Delete any load balancers with tags matching the name of your cluster (try the filter
+tag:elbv2.k8s.aws/cluster : mycluster-myenv)
+
+* EC2 -> Auto Scaling Groups -> Delete any auto scaling groups with a name matching your cluster
+
 
 ### Remove Fargate Profile
 

--- a/userdocs/src/help/common-issues.md
+++ b/userdocs/src/help/common-issues.md
@@ -1,23 +1,23 @@
-##Device authentication flow fails (Linux only)
+## Device authentication flow fails (Linux only)
 
 If you are unable to complete device authentication against github, you need to install `pass`
 This is because github token is stored in an encrypted keyring on your device.
 
 Install pass as described in the [Prerequisites](../../getting-started/prerequisites/#pass-linux-only).
 
-##okctl keeps trying to do the Github Device Authentication Flow while trying to do \<any action\>
+## okctl keeps trying to do the Github Device Authentication Flow while trying to do \<any action\>
 
 This is known to happen if `pass init <gpg-key-id>` has not been run after installing `pass`.
 
 Initialize `pass` as described in [Prerequisites](../../getting-started/prerequisites/#initialize-pass).
 
-##On `okctl delete cluster`, some resources are not deleted (automatic deletion is coming in a later version)
+## On `okctl delete cluster`, some resources are not deleted (automatic deletion is coming in a later version)
 
 Workaround: manually delete the following resources:
 
 * It is recommended to delete the infrastructure/<env> directory and .okctl.yaml file upon successful delete of cluster, as the last manual step.
 
-##okctl create cluster: Create identitypool fails / Re-create cluster within short timespan fails
+## okctl create cluster: Create identitypool fails / Re-create cluster within short timespan fails
 
 If you do the following:
 
@@ -33,7 +33,7 @@ Workaround: Wait for up to 15 minutes before creating cluster again.
 15 minutes is the TTL (Time to live, i.e. cache expiry) of the NS record. You can see this value in
 Route 53 -> Hosted zones -> Your domain -> NS record for your top domain -> Edit -> See TTL field.
 
-##okctl create cluster: Failed to create external secrets helm chart
+## okctl create cluster: Failed to create external secrets helm chart
 
 You get the following error (shortened):
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When deleting cluster manually, add case for when user cannot access cluster.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
