### PR TITLE
👌 Truncate log lines to 5000 bytes

### DIFF
--- a/pkg/middleware/logger/logger.go
+++ b/pkg/middleware/logger/logger.go
@@ -79,8 +79,25 @@ func (l *logging) ProcessResponse(err error, response interface{}, begin time.Ti
 			d = litter.Sdump(response)
 		}
 
-		l.log.Trace("response: ", d)
+		truncatedDump := Truncate(&d, 5000)
+		l.log.Trace("response: ", truncatedDump)
 	}
 
 	l.log.Debug("request completed in: ", time.Since(begin).String())
+}
+
+// Truncate truncates a string to the minimum of its length and the given max length
+func Truncate(s *string, maxLength int) string {
+	// This way of doing substrings assumes ASCII and doesn't support UTF-8.
+	// See https://stackoverflow.com/a/56129336
+	truncateLength := min(maxLength, len(*s))
+	return (*s)[:truncateLength]
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+
+	return y
 }

--- a/pkg/middleware/logger/logger_test.go
+++ b/pkg/middleware/logger/logger_test.go
@@ -76,3 +76,37 @@ func TestLogging(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncate(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		maxLength int
+		expected  string
+	}{
+		{
+			name:      "Should truncate string",
+			input:     "1234567890",
+			maxLength: 5,
+			expected:  "12345",
+		},
+		{
+			name:      "Should keep string if it's equal to maxLength",
+			input:     "1234567890",
+			maxLength: 10,
+			expected:  "1234567890",
+		},
+		{
+			name:      "Should keep string if it's over maxLength",
+			input:     "1234567890",
+			maxLength: 11,
+			expected:  "1234567890",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, logger.Truncate(&tc.input, tc.maxLength))
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It's quite hard to read the log from the nightly these days, it is 87MB. I found single log line being 64MB!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I want to read the log using a regular editor or web gui, not having to resort to shell truncating magic to make sense of it.

[ ] TODO: Add release notes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
