### PR TITLE
KM225: Truncate client log

### DIFF
--- a/docs/release_notes/0.0.54.md
+++ b/docs/release_notes/0.0.54.md
@@ -5,4 +5,4 @@
 ## Bugfixes
 
 ## Other
-- Truncate log lines to 5000 bytes (#436)
+- Truncate log lines to 5000 bytes (#436, #444)

--- a/pkg/client/core/api/rest/client.go
+++ b/pkg/client/core/api/rest/client.go
@@ -88,7 +88,7 @@ func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interfac
 	const logLineMaxlength = 3000
 	if into != nil {
 		if c.Debug {
-			truncatedOut := truncate.TruncateBytes(out, logLineMaxlength)
+			truncatedOut := truncate.Bytes(out, logLineMaxlength)
 			_, err = fmt.Fprintf(c.Progress, "client (method: %s, endpoint: %s) received data: %s", method, endpoint, truncatedOut)
 			if err != nil {
 				return fmt.Errorf("failed to write debug output: %w", err)
@@ -102,7 +102,7 @@ func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interfac
 	}
 
 	if c.Debug {
-		truncatedOut := truncate.TruncateBytes(out, logLineMaxlength)
+		truncatedOut := truncate.Bytes(out, logLineMaxlength)
 		_, err = io.Copy(c.Progress, strings.NewReader(string(truncatedOut)))
 		if err != nil {
 			return fmt.Errorf("%s: %w", pretty("failed to write progress for", method, endpoint), err)

--- a/pkg/client/core/api/rest/client.go
+++ b/pkg/client/core/api/rest/client.go
@@ -86,7 +86,7 @@ func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interfac
 		err = resp.Body.Close()
 	}()
 
-	const logLineMaxlength = 3500
+	const logLineMaxlength = 5000
 
 	if into != nil {
 		if c.Debug {

--- a/pkg/client/core/api/rest/client.go
+++ b/pkg/client/core/api/rest/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/oslokommune/okctl/pkg/truncate"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -84,9 +85,11 @@ func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interfac
 		err = resp.Body.Close()
 	}()
 
+	const logLineMaxlength = 3000
 	if into != nil {
 		if c.Debug {
-			_, err = fmt.Fprintf(c.Progress, "client (method: %s, endpoint: %s) received data: %s", method, endpoint, out)
+			truncatedOut := truncate.TruncateBytes(out, logLineMaxlength)
+			_, err = fmt.Fprintf(c.Progress, "client (method: %s, endpoint: %s) received data: %s", method, endpoint, truncatedOut)
 			if err != nil {
 				return fmt.Errorf("failed to write debug output: %w", err)
 			}
@@ -99,7 +102,8 @@ func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interfac
 	}
 
 	if c.Debug {
-		_, err = io.Copy(c.Progress, strings.NewReader(string(out)))
+		truncatedOut := truncate.TruncateBytes(out, logLineMaxlength)
+		_, err = io.Copy(c.Progress, strings.NewReader(string(truncatedOut)))
 		if err != nil {
 			return fmt.Errorf("%s: %w", pretty("failed to write progress for", method, endpoint), err)
 		}

--- a/pkg/client/core/api/rest/client.go
+++ b/pkg/client/core/api/rest/client.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/oslokommune/okctl/pkg/truncate"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/oslokommune/okctl/pkg/truncate"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 
@@ -85,10 +86,12 @@ func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interfac
 		err = resp.Body.Close()
 	}()
 
-	const logLineMaxlength = 3000
+	const logLineMaxlength = 3500
+
 	if into != nil {
 		if c.Debug {
 			truncatedOut := truncate.Bytes(out, logLineMaxlength)
+
 			_, err = fmt.Fprintf(c.Progress, "client (method: %s, endpoint: %s) received data: %s", method, endpoint, truncatedOut)
 			if err != nil {
 				return fmt.Errorf("failed to write debug output: %w", err)
@@ -103,6 +106,7 @@ func (c *HTTPClient) Do(method, endpoint string, body interface{}, into interfac
 
 	if c.Debug {
 		truncatedOut := truncate.Bytes(out, logLineMaxlength)
+
 		_, err = io.Copy(c.Progress, strings.NewReader(string(truncatedOut)))
 		if err != nil {
 			return fmt.Errorf("%s: %w", pretty("failed to write progress for", method, endpoint), err)

--- a/pkg/middleware/logger/logger.go
+++ b/pkg/middleware/logger/logger.go
@@ -80,7 +80,7 @@ func (l *logging) ProcessResponse(err error, response interface{}, begin time.Ti
 			d = litter.Sdump(response)
 		}
 
-		truncatedDump := truncate.Truncate(&d, 5000)
+		truncatedDump := truncate.String(&d, 5000)
 		l.log.Trace("response: ", truncatedDump)
 	}
 

--- a/pkg/middleware/logger/logger.go
+++ b/pkg/middleware/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 
 import (
 	"context"
+	"github.com/oslokommune/okctl/pkg/truncate"
 	"strings"
 	"time"
 
@@ -79,25 +80,9 @@ func (l *logging) ProcessResponse(err error, response interface{}, begin time.Ti
 			d = litter.Sdump(response)
 		}
 
-		truncatedDump := Truncate(&d, 5000)
+		truncatedDump := truncate.Truncate(&d, 5000)
 		l.log.Trace("response: ", truncatedDump)
 	}
 
 	l.log.Debug("request completed in: ", time.Since(begin).String())
-}
-
-// Truncate truncates a string to the minimum of its length and the given max length
-func Truncate(s *string, maxLength int) string {
-	// This way of doing substrings assumes ASCII and doesn't support UTF-8.
-	// See https://stackoverflow.com/a/56129336
-	truncateLength := min(maxLength, len(*s))
-	return (*s)[:truncateLength]
-}
-
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-
-	return y
 }

--- a/pkg/middleware/logger/logger.go
+++ b/pkg/middleware/logger/logger.go
@@ -81,7 +81,7 @@ func (l *logging) ProcessResponse(err error, response interface{}, begin time.Ti
 			d = litter.Sdump(response)
 		}
 
-		truncatedDump := truncate.String(&d, 3500)
+		truncatedDump := truncate.String(&d, 5000)
 		l.log.Trace("response: ", truncatedDump)
 	}
 

--- a/pkg/middleware/logger/logger.go
+++ b/pkg/middleware/logger/logger.go
@@ -3,9 +3,10 @@ package logger
 
 import (
 	"context"
-	"github.com/oslokommune/okctl/pkg/truncate"
 	"strings"
 	"time"
+
+	"github.com/oslokommune/okctl/pkg/truncate"
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/sanity-io/litter"
@@ -80,7 +81,7 @@ func (l *logging) ProcessResponse(err error, response interface{}, begin time.Ti
 			d = litter.Sdump(response)
 		}
 
-		truncatedDump := truncate.String(&d, 5000)
+		truncatedDump := truncate.String(&d, 3500)
 		l.log.Trace("response: ", truncatedDump)
 	}
 

--- a/pkg/middleware/logger/logger_test.go
+++ b/pkg/middleware/logger/logger_test.go
@@ -76,37 +76,3 @@ func TestLogging(t *testing.T) {
 		})
 	}
 }
-
-func TestTruncate(t *testing.T) {
-	testCases := []struct {
-		name      string
-		input     string
-		maxLength int
-		expected  string
-	}{
-		{
-			name:      "Should truncate string",
-			input:     "1234567890",
-			maxLength: 5,
-			expected:  "12345",
-		},
-		{
-			name:      "Should keep string if it's equal to maxLength",
-			input:     "1234567890",
-			maxLength: 10,
-			expected:  "1234567890",
-		},
-		{
-			name:      "Should keep string if it's over maxLength",
-			input:     "1234567890",
-			maxLength: 11,
-			expected:  "1234567890",
-		},
-	}
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, logger.Truncate(&tc.input, tc.maxLength))
-		})
-	}
-}

--- a/pkg/truncate/truncate.go
+++ b/pkg/truncate/truncate.go
@@ -1,3 +1,4 @@
+// Package truncate implements truncating variables
 package truncate
 
 import "fmt"

--- a/pkg/truncate/truncate.go
+++ b/pkg/truncate/truncate.go
@@ -1,0 +1,24 @@
+package truncate
+
+// Truncate truncates a string to the minimum of its length and the given max length
+func Truncate(s *string, maxLength int) string {
+	// This way of doing substrings assumes ASCII and doesn't support UTF-8.
+	// See https://stackoverflow.com/a/56129336
+	truncateLength := min(maxLength, len(*s))
+	return (*s)[:truncateLength]
+}
+// Truncate truncates a byte array to the minimum of its length and the given max length
+func TruncateBytes(b []byte, maxLength int) []byte {
+	// This way of doing substrings assumes ASCII and doesn't support UTF-8.
+	// See https://stackoverflow.com/a/56129336
+	truncateLength := min(maxLength, len(b))
+	return b[:truncateLength]
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+
+	return y
+}

--- a/pkg/truncate/truncate.go
+++ b/pkg/truncate/truncate.go
@@ -1,18 +1,35 @@
 package truncate
 
-// Truncate truncates a string to the minimum of its length and the given max length
-func Truncate(s *string, maxLength int) string {
+import "fmt"
+
+// String truncates a string to the minimum of its length and the given max length
+func String(s *string, maxLength int) string {
 	// This way of doing substrings assumes ASCII and doesn't support UTF-8.
 	// See https://stackoverflow.com/a/56129336
 	truncateLength := min(maxLength, len(*s))
-	return (*s)[:truncateLength]
+	truncated := (*s)[:truncateLength]
+
+	if len(*s) > truncateLength {
+		bytesTruncated := len(*s) - truncateLength
+		truncated += fmt.Sprintf(" [truncated %d bytes]", bytesTruncated)
+	}
+
+	return truncated
 }
-// Truncate truncates a byte array to the minimum of its length and the given max length
-func TruncateBytes(b []byte, maxLength int) []byte {
-	// This way of doing substrings assumes ASCII and doesn't support UTF-8.
-	// See https://stackoverflow.com/a/56129336
+
+// Bytes truncates a byte array to the minimum of its length and the given max length
+func Bytes(b []byte, maxLength int) []byte {
 	truncateLength := min(maxLength, len(b))
-	return b[:truncateLength]
+
+	truncated := b[:truncateLength]
+
+	if len(b) > truncateLength {
+		bytesTruncated := len(b) - truncateLength
+		truncateInfo := fmt.Sprintf(" [truncated %d bytes]", bytesTruncated)
+		truncated = append(truncated, truncateInfo...)
+	}
+
+	return truncated
 }
 
 func min(x, y int) int {

--- a/pkg/truncate/truncate_test.go
+++ b/pkg/truncate/truncate_test.go
@@ -17,7 +17,13 @@ func TestTruncate(t *testing.T) {
 			name:      "Should truncate string",
 			input:     "1234567890",
 			maxLength: 5,
-			expected:  "12345",
+			expected:  "12345 [truncated 5 bytes]",
+		},
+		{
+			name:      "Should truncate some other string",
+			input:     "1234567890",
+			maxLength: 7,
+			expected:  "1234567 [truncated 3 bytes]",
 		},
 		{
 			name:      "Should keep string if it's equal to maxLength",
@@ -35,13 +41,13 @@ func TestTruncate(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			// Test Truncate string
-			truncatedString := truncate.Truncate(&tc.input, tc.maxLength)
+			// Test String string
+			truncatedString := truncate.String(&tc.input, tc.maxLength)
 			assert.Equal(t, tc.expected, truncatedString)
 
-			// Test Truncate bytes
+			// Test String bytes
 			inputBytes := []byte(tc.input)
-			truncatedBytes := truncate.TruncateBytes(inputBytes, tc.maxLength)
+			truncatedBytes := truncate.Bytes(inputBytes, tc.maxLength)
 			expectedBytes := []byte(tc.expected)
 			assert.Equal(t, expectedBytes, truncatedBytes)
 		})

--- a/pkg/truncate/truncate_test.go
+++ b/pkg/truncate/truncate_test.go
@@ -1,9 +1,10 @@
 package truncate_test
 
 import (
+	"testing"
+
 	"github.com/oslokommune/okctl/pkg/truncate"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestTruncate(t *testing.T) {
@@ -48,6 +49,7 @@ func TestTruncate(t *testing.T) {
 			// Test String bytes
 			inputBytes := []byte(tc.input)
 			truncatedBytes := truncate.Bytes(inputBytes, tc.maxLength)
+
 			expectedBytes := []byte(tc.expected)
 			assert.Equal(t, expectedBytes, truncatedBytes)
 		})

--- a/pkg/truncate/truncate_test.go
+++ b/pkg/truncate/truncate_test.go
@@ -1,0 +1,49 @@
+package truncate_test
+
+import (
+	"github.com/oslokommune/okctl/pkg/truncate"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTruncate(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		maxLength int
+		expected  string
+	}{
+		{
+			name:      "Should truncate string",
+			input:     "1234567890",
+			maxLength: 5,
+			expected:  "12345",
+		},
+		{
+			name:      "Should keep string if it's equal to maxLength",
+			input:     "1234567890",
+			maxLength: 10,
+			expected:  "1234567890",
+		},
+		{
+			name:      "Should keep string if it's over maxLength",
+			input:     "1234567890",
+			maxLength: 11,
+			expected:  "1234567890",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Test Truncate string
+			truncatedString := truncate.Truncate(&tc.input, tc.maxLength)
+			assert.Equal(t, tc.expected, truncatedString)
+
+			// Test Truncate bytes
+			inputBytes := []byte(tc.input)
+			truncatedBytes := truncate.TruncateBytes(inputBytes, tc.maxLength)
+			expectedBytes := []byte(tc.expected)
+			assert.Equal(t, expectedBytes, truncatedBytes)
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Truncate client log to maximum 5000 bytes per log line.

## Description
<!--- Describe your changes in detail -->
#436 truncated the server side log, this is client side.

This PR might crop useful info, but we'll try and see, and revert or adjust the "truncate max length" if that's the case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our logs are still full of noise, making it hard to read.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
