### PR TITLE
🐛 Fix truncate log not working

### DIFF
--- a/docs/release_notes/0.0.54.md
+++ b/docs/release_notes/0.0.54.md
@@ -5,4 +5,4 @@
 ## Bugfixes
 
 ## Other
-- Truncate log lines to 5000 bytes (#436, #444)
+- Truncate log lines to 5000 bytes (#436, #444, #454)

--- a/pkg/truncate/truncate.go
+++ b/pkg/truncate/truncate.go
@@ -3,8 +3,14 @@ package truncate
 
 import "fmt"
 
+const truncateFormat = "XXXtruncated%dbytesXXX"
+
 // String truncates a string to the minimum of its length and the given max length
 func String(s *string, maxLength int) string {
+	if s == nil {
+		return ""
+	}
+
 	// This way of doing substrings assumes ASCII and doesn't support UTF-8.
 	// See https://stackoverflow.com/a/56129336
 	truncateLength := min(maxLength, len(*s))
@@ -12,7 +18,7 @@ func String(s *string, maxLength int) string {
 
 	if len(*s) > truncateLength {
 		bytesTruncated := len(*s) - truncateLength
-		truncated += fmt.Sprintf(" [truncated %d bytes]", bytesTruncated)
+		truncated += fmt.Sprintf(truncateFormat, bytesTruncated)
 	}
 
 	return truncated
@@ -20,13 +26,17 @@ func String(s *string, maxLength int) string {
 
 // Bytes truncates a byte array to the minimum of its length and the given max length
 func Bytes(b []byte, maxLength int) []byte {
+	if b == nil {
+		return []byte{}
+	}
+
 	truncateLength := min(maxLength, len(b))
 
 	truncated := b[:truncateLength]
 
 	if len(b) > truncateLength {
 		bytesTruncated := len(b) - truncateLength
-		truncateInfo := fmt.Sprintf(" [truncated %d bytes]", bytesTruncated)
+		truncateInfo := fmt.Sprintf(truncateFormat, bytesTruncated)
 		truncated = append(truncated, truncateInfo...)
 	}
 

--- a/pkg/truncate/truncate_test.go
+++ b/pkg/truncate/truncate_test.go
@@ -18,13 +18,13 @@ func TestTruncate(t *testing.T) {
 			name:      "Should truncate string",
 			input:     "1234567890",
 			maxLength: 5,
-			expected:  "12345 [truncated 5 bytes]",
+			expected:  "12345XXXtruncated5bytesXXX",
 		},
 		{
 			name:      "Should truncate some other string",
 			input:     "1234567890",
 			maxLength: 7,
-			expected:  "1234567 [truncated 3 bytes]",
+			expected:  "1234567XXXtruncated3bytesXXX",
 		},
 		{
 			name:      "Should keep string if it's equal to maxLength",
@@ -39,6 +39,7 @@ func TestTruncate(t *testing.T) {
 			expected:  "1234567890",
 		},
 	}
+
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -54,4 +55,22 @@ func TestTruncate(t *testing.T) {
 			assert.Equal(t, expectedBytes, truncatedBytes)
 		})
 	}
+}
+
+func TestTruncateNil(t *testing.T) {
+	t.Run("Should return empty values if receiving nil", func(t *testing.T) {
+		assert.Equal(t, "", truncate.String(nil, 5))
+		assert.Equal(t, []byte{}, truncate.Bytes(nil, 5))
+	})
+}
+
+func TestTruncateSideEffects(t *testing.T) {
+	t.Run("Should not modify original byte array", func(t *testing.T) {
+		b := []byte("hello")
+		expected := []byte("hello")
+
+		truncate.Bytes(b, 3)
+
+		assert.Equal(t, expected, b)
+	})
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

#436 and #444 introduced a fatal bug where okctl apply cluster doesn't work anymore. Whenever the log is truncated, okctl aborts with error

```
Error: synchronizing declaration with state: reconciling node: creating vpc: failed to parse response: illegal base64 data at input byte 4805
```

Not sure why, but logging anything but base64 characters results in this error, so the solution is to only log base64-characters.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I verified that this fix ran OK on the nightly github action workflow, and with apply cluster locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
