### PR TITLE
KM230 👌 Convert apply application to reconciliation pattern

### DIFF
--- a/cmd/okctl/apply_application.go
+++ b/cmd/okctl/apply_application.go
@@ -91,7 +91,7 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 				Ctx:       o.Ctx,
 				Out:       o.Out,
 				ClusterID: *scaffoldOpts.ID,
-				// We should pass inn cluster fetched from state here when state rewrite is done
+				// TODO: should pass in cluster as done in the huge rewrite PR
 				Declaration: &v1alpha1.Cluster{
 					Github: v1alpha1.ClusterGithub{
 						Repository: commands.GetFirstGithubRepositoryURL(o.RepoStateWithEnv.GetGithub().Repositories),

--- a/cmd/okctl/apply_application.go
+++ b/cmd/okctl/apply_application.go
@@ -3,13 +3,18 @@ package main
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/commands"
+	"github.com/oslokommune/okctl/pkg/config/state"
+	"github.com/oslokommune/okctl/pkg/controller"
+	"github.com/oslokommune/okctl/pkg/controller/reconciler"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
 	"github.com/oslokommune/okctl/pkg/okctl"
 	"github.com/oslokommune/okctl/pkg/spinner"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -42,14 +47,11 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 
 			err := o.InitialiseWithOnlyEnv(environment)
 			if err != nil {
-				if errors.As(err, &okctl.ErrorEnvironmentNotFound{}) {
-					envError, ok := err.(okctl.ErrorEnvironmentNotFound)
-					if !ok {
-						return err
-					}
+				errEnvNotFound := &okctl.ErrorEnvironmentNotFound{}
 
-					fmt.Fprintln(o.Err, fmt.Sprintf("\nThe specified environment \"%s\" does not exist.", envError.TargetEnvironment))
-					fmt.Fprintln(o.Err, fmt.Sprintf("Available environments: %v\n", envError.AvailableEnvironments))
+				if errors.As(err, &errEnvNotFound) {
+					fmt.Fprintf(o.Err, "\nThe specified environment \"%s\" does not exist.", errEnvNotFound.TargetEnvironment)
+					fmt.Fprintf(o.Err, "Available environments: %v\n", errEnvNotFound.AvailableEnvironments)
 				}
 
 				return err
@@ -63,24 +65,12 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 				AWSAccountID: cluster.AWSAccountID,
 				Environment:  cluster.Environment,
 				Repository:   metadata.Name,
-				ClusterName:  cluster.Name,
+				ClusterName:  o.RepoStateWithEnv.GetClusterName(),
 			}
 
-			scaffoldOpts.In = o.In
-			scaffoldOpts.Out = o.Out
-			scaffoldOpts.ApplicationFilePath = opts.File
-			scaffoldOpts.RepoDir, err = o.GetRepoDir()
-			scaffoldOpts.OutputDir = metadata.OutputDir
+			scaffoldOpts.Application, err = commands.InferApplicationFromStdinOrFile(o.In, o.FileSystem, opts.File)
 			if err != nil {
-				return err
-			}
-
-			hostedZone := o.RepoStateWithEnv.GetPrimaryHostedZone()
-			scaffoldOpts.HostedZoneID = hostedZone.ID
-			scaffoldOpts.HostedZoneDomain = hostedZone.Domain
-
-			for _, repo := range cluster.Github.Repositories {
-				scaffoldOpts.IACRepoURL = repo.GitURL
+				return fmt.Errorf("inferring application from stdin or file: %w", err)
 			}
 
 			return nil
@@ -91,19 +81,71 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 				return fmt.Errorf("failed validating options: %w", err)
 			}
 
-			spin, _ := spinner.New("applying application", o.Out)
+			spin, _ := spinner.New("synchronizing ", o.Out)
 			services, _ := o.ClientServices(spin)
 
-			err = services.ApplicationService.ScaffoldApplication(o.Ctx, scaffoldOpts)
+			reconciliationManager := reconciler.NewCompositeReconciler(spin,
+				reconciler.NewApplicationReconciler(services.ApplicationService),
+			)
+
+			reconciliationManager.SetCommonMetadata(&resourcetree.CommonMetadata{
+				Ctx:       o.Ctx,
+				Out:       o.Out,
+				ClusterID: *scaffoldOpts.ID,
+				// We should pass inn cluster fetched from state here when state rewrite is done
+				Declaration: &v1alpha1.Cluster{
+					Github: v1alpha1.ClusterGithub{
+						Repository: getFirstGithubRepositoryURL(o.RepoStateWithEnv.GetGithub().Repositories),
+						OutputPath: o.RepoStateWithEnv.GetMetadata().OutputDir,
+					},
+				},
+			})
+
+			dependencyTree := controller.CreateApplicationResourceDependencyTree()
+
+			dependencyTree.SetStateRefresher(resourcetree.ResourceNodeTypeApplication, func(node *resourcetree.ResourceNode) {
+				primaryHostedZone := o.RepoStateWithEnv.GetPrimaryHostedZone()
+
+				node.ResourceState = &reconciler.ApplicationState{
+					Declaration: scaffoldOpts.Application,
+
+					PrimaryHostedZoneID:     primaryHostedZone.ID,
+					PrimaryHostedZoneDomain: primaryHostedZone.Domain,
+				}
+			})
+
+			err = synchronizeApplication(reconciliationManager, dependencyTree)
 			if err != nil {
-				return err
+				return fmt.Errorf("synchronizing application: %w", err)
 			}
 
-			return nil
+			return commands.WriteApplyApplicationSuccessMessage(
+				o.Out,
+				scaffoldOpts.Application.Name,
+				scaffoldOpts.OutputDir,
+			)
 		},
 	}
 
 	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "Specify the file path. Use \"-\" for stdin")
 
 	return cmd
+}
+
+func synchronizeApplication(reconcilerManager reconciler.Reconciler, tree *resourcetree.ResourceNode) error {
+	tree.ApplyFunction(setAllToPresent, tree)
+
+	return controller.HandleNode(reconcilerManager, tree)
+}
+
+func setAllToPresent(receiver *resourcetree.ResourceNode, _ *resourcetree.ResourceNode) {
+	receiver.State = resourcetree.ResourceNodeStatePresent
+}
+
+func getFirstGithubRepositoryURL(repositories map[string]state.GithubRepository) string {
+	for _, repo := range repositories {
+		return repo.GitURL
+	}
+
+	return "N/A"
 }

--- a/docs/release_notes/0.0.54.md
+++ b/docs/release_notes/0.0.54.md
@@ -6,3 +6,4 @@
 
 ## Other
 - Truncate log lines to 5000 bytes (#436, #444, #454)
+GH456: Refacator apply application to use operator pattern

--- a/pkg/client/application_client.go
+++ b/pkg/client/application_client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"io"
 
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 
@@ -11,28 +10,30 @@ import (
 	"github.com/oslokommune/okctl/pkg/client/store"
 )
 
+const (
+	maxPortNumber = 65535
+	minPortNumber = 0
+	minReplicas   = 0
+)
+
 // ScaffoldApplicationOpts contains information necessary to scaffold application resources
 type ScaffoldApplicationOpts struct {
-	In  io.Reader
-	Out io.Writer
-
-	ApplicationFilePath string
-	RepoDir             string
-	OutputDir           string
+	OutputDir string
 
 	ID               *api.ID
 	HostedZoneID     string
 	HostedZoneDomain string
 	IACRepoURL       string
+	Application      OkctlApplication
 }
 
 // Validate ensures presented data is valid
 func (o *ScaffoldApplicationOpts) Validate() error {
 	return validation.ValidateStruct(o,
-		validation.Field(&o.ApplicationFilePath, validation.Required),
 		validation.Field(&o.ID, validation.Required),
 		validation.Field(&o.HostedZoneID, validation.Required),
 		validation.Field(&o.IACRepoURL, validation.Required),
+		validation.Field(&o.Application, validation.Required),
 	)
 }
 
@@ -67,14 +68,14 @@ func (o OkctlApplication) HasService() bool {
 // Validate knows if the application is valid or not
 func (o OkctlApplication) Validate() error {
 	return validation.ValidateStruct(&o,
-		validation.Field(&o.Name, validation.Required, is.DNSName),
+		validation.Field(&o.Name, validation.Required, is.Subdomain),
 		validation.Field(&o.Namespace, validation.Required, is.DNSName),
-		validation.Field(&o.Image, validation.Required, is.DNSName),
+		validation.Field(&o.Image, validation.Required),
 		validation.Field(&o.Version, validation.Required),
-		validation.Field(&o.ImagePullSecret, validation.Required, is.DNSName),
+		validation.Field(&o.ImagePullSecret, is.DNSName),
 		validation.Field(&o.SubDomain, is.Subdomain),
-		validation.Field(&o.Port, is.Port),
-		validation.Field(&o.Replicas, validation.Min(0)),
+		validation.Field(&o.Port, validation.Min(minPortNumber), validation.Max(maxPortNumber)),
+		validation.Field(&o.Replicas, validation.Min(minReplicas)),
 	)
 }
 

--- a/pkg/client/application_client_test.go
+++ b/pkg/client/application_client_test.go
@@ -1,0 +1,96 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func generateValidApplication() OkctlApplication {
+	return OkctlApplication{
+		Name:            "test-app",
+		Namespace:       "test",
+		Image:           "testimage",
+		Version:         "latest",
+		ImagePullSecret: "sometoken",
+		SubDomain:       "testapp",
+		Port:            80,
+		Replicas:        1,
+		Environment:     nil,
+		Volumes:         nil,
+	}
+}
+
+// nolint: funlen
+func TestOkctlApplicationValidation(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		withApplication func() OkctlApplication
+
+		expectFail    bool
+		expectedError string
+	}{
+		{
+			name: "Sanity check",
+
+			withApplication: generateValidApplication,
+
+			expectFail: false,
+		},
+		{
+			name: "Should allow images from Docker hub",
+
+			withApplication: func() OkctlApplication {
+				app := generateValidApplication()
+
+				app.Image = "postgres"
+
+				return app
+			},
+
+			expectFail: false,
+		},
+		{
+			name: "Should allow images from GHCR",
+
+			withApplication: func() OkctlApplication {
+				app := generateValidApplication()
+
+				app.Image = "ghcr.io/oslokommune/test-app"
+
+				return app
+			},
+
+			expectFail: false,
+		},
+		{
+			name: "Should allow images from ECR",
+
+			withApplication: func() OkctlApplication {
+				app := generateValidApplication()
+
+				app.Image = "012345678912.dkr.ecr.eu-west-1.amazonaws.com/cluster-test-testapp"
+
+				return app
+			},
+
+			expectFail: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.withApplication().Validate()
+
+			if !tc.expectFail {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+				assert.Equal(t, tc.expectedError, err.Error())
+			}
+		})
+	}
+}

--- a/pkg/client/core/service_application_client.go
+++ b/pkg/client/core/service_application_client.go
@@ -3,17 +3,11 @@ package core
 import (
 	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"path"
-	"path/filepath"
 
 	"github.com/oslokommune/okctl/pkg/config/constant"
 
-	"github.com/oslokommune/okctl/pkg/spinner"
 	"github.com/spf13/afero"
-
-	"sigs.k8s.io/yaml"
 
 	kaex "github.com/oslokommune/kaex/pkg/api"
 	"github.com/oslokommune/okctl/pkg/api"
@@ -25,7 +19,6 @@ import (
 
 type applicationService struct {
 	fs     *afero.Afero
-	spin   spinner.Spinner
 	paths  clientFilesystem.Paths
 	cert   client.CertificateService
 	store  client.ApplicationStore
@@ -46,14 +39,6 @@ func (s *applicationService) createCertificate(ctx context.Context, id *api.ID, 
 	return cert.CertificateARN, nil
 }
 
-func writeSuccessMessage(writer io.Writer, applicationName string, argoCDResourcePath string) {
-	fmt.Fprintf(writer, "\nSuccessfully scaffolded %s\n", applicationName)
-	fmt.Fprintln(writer, "To deploy your application:")
-	fmt.Fprintln(writer, "\t1. Commit and push the changes done by okctl")
-	fmt.Fprintf(writer, "\t2. Run kubectl apply -f %s\n", argoCDResourcePath)
-	fmt.Fprintf(writer, "If using an ingress, it can take up to five minutes for the routing to configure\n")
-}
-
 // ScaffoldApplication turns a file path into Kubernetes resources
 // nolint: funlen
 func (s *applicationService) ScaffoldApplication(ctx context.Context, opts *client.ScaffoldApplicationOpts) error {
@@ -62,16 +47,7 @@ func (s *applicationService) ScaffoldApplication(ctx context.Context, opts *clie
 		return err
 	}
 
-	err = s.spin.Start("Scaffolding application")
-
-	defer func() {
-		err = s.spin.Stop()
-	}()
-
-	okctlApp, err := inferApplicationFromStdinOrFile(opts.In, s.fs, opts.ApplicationFilePath)
-	if err != nil {
-		return err
-	}
+	okctlApp := opts.Application
 
 	// See function comment
 	app := okctlApplicationToKaexApplication(okctlApp, opts.HostedZoneDomain)
@@ -124,16 +100,12 @@ func (s *applicationService) ScaffoldApplication(ctx context.Context, opts *clie
 		return err
 	}
 
-	argoCDResourcePath := path.Join(relativeApplicationDir, "argocd-application.yaml")
-	writeSuccessMessage(opts.Out, app.Name, argoCDResourcePath)
-
 	return nil
 }
 
 // NewApplicationService initializes a new Scaffold application service
 func NewApplicationService(
 	fs *afero.Afero,
-	spin spinner.Spinner,
 	paths clientFilesystem.Paths,
 	cert client.CertificateService,
 	store client.ApplicationStore,
@@ -141,44 +113,11 @@ func NewApplicationService(
 ) client.ApplicationService {
 	return &applicationService{
 		fs:     fs,
-		spin:   spin,
 		paths:  paths,
 		cert:   cert,
 		store:  store,
 		report: state,
 	}
-}
-
-func inferApplicationFromStdinOrFile(stdin io.Reader, fs *afero.Afero, path string) (client.OkctlApplication, error) {
-	var (
-		err         error
-		app         client.OkctlApplication
-		inputReader io.Reader
-	)
-
-	switch path {
-	case "-":
-		inputReader = stdin
-	default:
-		inputReader, err = fs.Open(filepath.Clean(path))
-		if err != nil {
-			return app, fmt.Errorf("opening application file: %w", err)
-		}
-	}
-
-	var buf []byte
-
-	buf, err = ioutil.ReadAll(inputReader)
-	if err != nil {
-		return app, fmt.Errorf("reading application file: %w", err)
-	}
-
-	err = yaml.Unmarshal(buf, &app)
-	if err != nil {
-		return app, fmt.Errorf("parsing application yaml: %w", err)
-	}
-
-	return app, nil
 }
 
 // I'm assuming we'll be making enough customizations down the line to have our own okctlApplication, but for now

--- a/pkg/client/core/testdata/argocd-application.yaml.golden
+++ b/pkg/client/core/testdata/argocd-application.yaml.golden
@@ -9,7 +9,7 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: applications/my-app/overlays/test
+    path: infrastructure/applications/my-app/overlays/test
     repoURL: git@dummy.com:test/repo.git
     targetRevision: HEAD
   syncPolicy:

--- a/pkg/commands/apply_application.go
+++ b/pkg/commands/apply_application.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"text/template"
+
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/config/constant"
+	"github.com/spf13/afero"
+
+	"sigs.k8s.io/yaml"
+)
+
+// InferApplicationFromStdinOrFile returns an okctl application based on input. The function will parse input either
+// from the reader or from the fs based on if path is a path or if it is "-". "-" represents stdin
+func InferApplicationFromStdinOrFile(stdin io.Reader, fs *afero.Afero, path string) (client.OkctlApplication, error) {
+	var (
+		err         error
+		app         client.OkctlApplication
+		inputReader io.Reader
+	)
+
+	switch path {
+	case "-":
+		inputReader = stdin
+	default:
+		inputReader, err = fs.Open(filepath.Clean(path))
+		if err != nil {
+			return app, fmt.Errorf("opening application file: %w", err)
+		}
+	}
+
+	var buf []byte
+
+	buf, err = ioutil.ReadAll(inputReader)
+	if err != nil {
+		return app, fmt.Errorf("reading application file: %w", err)
+	}
+
+	err = yaml.Unmarshal(buf, &app)
+	if err != nil {
+		return app, fmt.Errorf("parsing application yaml: %w", err)
+	}
+
+	return app, nil
+}
+
+// WriteApplyApplicationSuccessMessage produces a relevant message for successfully reconciling an application
+func WriteApplyApplicationSuccessMessage(writer io.Writer, applicationName, outputDir string) error {
+	argoCDResourcePath := path.Join(
+		outputDir,
+		constant.DefaultApplicationsOutputDir,
+		applicationName,
+		"argocd-application.yaml",
+	)
+
+	templateString := `
+	Successfully scaffolded {{ .ApplicationName }}
+	To deploy your application:
+		1. Commit and push the changes done by okctl
+		2. Run kubectl apply -f {{ .ArgoCDResourcePath }}
+	If using an ingress, it can take up to five minutes for the routing to configure
+`
+
+	tmpl, err := template.New("t").Parse(templateString)
+	if err != nil {
+		return err
+	}
+
+	var tmplBuffer bytes.Buffer
+
+	err = tmpl.Execute(&tmplBuffer, struct {
+		ApplicationName    string
+		ArgoCDResourcePath string
+	}{
+		ApplicationName:    applicationName,
+		ArgoCDResourcePath: argoCDResourcePath,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(writer, tmplBuffer.String())
+
+	return nil
+}

--- a/pkg/controller/convert.go
+++ b/pkg/controller/convert.go
@@ -95,6 +95,15 @@ func CreateResourceDependencyTree() (root *resourcetree.ResourceNode) {
 	return root
 }
 
+// CreateApplicationResourceDependencyTree creates a dependency tree for applications
+func CreateApplicationResourceDependencyTree() (root *resourcetree.ResourceNode) {
+	root = createNode(nil, resourcetree.ResourceNodeTypeGroup)
+
+	createNode(root, resourcetree.ResourceNodeTypeApplication)
+
+	return root
+}
+
 func createNode(parent *resourcetree.ResourceNode, nodeType resourcetree.ResourceNodeType) (child *resourcetree.ResourceNode) {
 	child = &resourcetree.ResourceNode{
 		Type:     nodeType,

--- a/pkg/controller/reconciler/application_reconciler.go
+++ b/pkg/controller/reconciler/application_reconciler.go
@@ -1,0 +1,66 @@
+package reconciler
+
+import (
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/controller/resourcetree"
+)
+
+// ApplicationState contains information only available at runtime
+type ApplicationState struct {
+	Declaration client.OkctlApplication
+
+	PrimaryHostedZoneID     string
+	PrimaryHostedZoneDomain string
+}
+
+// applicationReconciler contains service and metadata for the relevant resource
+type applicationReconciler struct {
+	commonMetadata *resourcetree.CommonMetadata
+
+	client client.ApplicationService
+}
+
+// NodeType returns the relevant ResourceNodeType for this reconciler
+func (a *applicationReconciler) NodeType() resourcetree.ResourceNodeType {
+	return resourcetree.ResourceNodeTypeApplication
+}
+
+// SetCommonMetadata saves common metadata for use in Reconcile()
+func (a *applicationReconciler) SetCommonMetadata(metadata *resourcetree.CommonMetadata) {
+	a.commonMetadata = metadata
+}
+
+// Reconcile knows how to do what is necessary to ensure the desired state is achieved
+func (a *applicationReconciler) Reconcile(node *resourcetree.ResourceNode) (ReconcilationResult, error) {
+	state, ok := node.ResourceState.(*ApplicationState)
+	if !ok {
+		return ReconcilationResult{}, errors.New("casting application state")
+	}
+
+	switch node.State {
+	case resourcetree.ResourceNodeStatePresent:
+		err := a.client.ScaffoldApplication(a.commonMetadata.Ctx, &client.ScaffoldApplicationOpts{
+			OutputDir:        a.commonMetadata.Declaration.Github.OutputPath,
+			ID:               &a.commonMetadata.ClusterID,
+			HostedZoneID:     state.PrimaryHostedZoneID,
+			HostedZoneDomain: state.PrimaryHostedZoneDomain,
+			IACRepoURL:       a.commonMetadata.Declaration.Github.Repository,
+			Application:      state.Declaration,
+		})
+		if err != nil {
+			return ReconcilationResult{}, err
+		}
+	case resourcetree.ResourceNodeStateAbsent:
+		return ReconcilationResult{}, errors.New("deletion of applications is not implemented")
+	}
+
+	return ReconcilationResult{}, nil
+}
+
+// NewApplicationReconciler creates a new reconciler for the VPC resource
+func NewApplicationReconciler(client client.ApplicationService) Reconciler {
+	return &applicationReconciler{
+		client: client,
+	}
+}

--- a/pkg/controller/resourcetree/tree.go
+++ b/pkg/controller/resourcetree/tree.go
@@ -53,6 +53,8 @@ const (
 	ResourceNodeTypeUsers
 	// ResourceNodeTypePostgres represents the postgres databases we want to add to the cluster
 	ResourceNodeTypePostgres
+	// ResourceNodeTypeApplication represents an okctl application resoure
+	ResourceNodeTypeApplication
 )
 
 // ResourceNodeTypeToString knows how to convert a Resource Node type to a human readable string

--- a/pkg/controller/synchronize.go
+++ b/pkg/controller/synchronize.go
@@ -60,12 +60,12 @@ func Synchronize(opts *SynchronizeOpts) error {
 		_, _ = fmt.Fprintf(opts.Out, "Present resources in difference tree (what should be generated): \n%s\n\n", diffTree.String())
 	}
 
-	return handleNode(opts.ReconciliationManager, diffTree)
+	return HandleNode(opts.ReconciliationManager, diffTree)
 }
 
-// handleNode knows how to run Reconcile() on every node of a ResourceNode tree
+// HandleNode knows how to run Reconcile() on every node of a ResourceNode tree
 //goland:noinspection GoNilness
-func handleNode(reconcilerManager reconciler.Reconciler, currentNode *resourcetree.ResourceNode) (err error) {
+func HandleNode(reconcilerManager reconciler.Reconciler, currentNode *resourcetree.ResourceNode) (err error) {
 	reconciliationResult := reconciler.ReconcilationResult{Requeue: true, RequeueAfter: 0 * time.Second}
 
 	for requeues := 0; reconciliationResult.Requeue; requeues++ {
@@ -82,7 +82,7 @@ func handleNode(reconcilerManager reconciler.Reconciler, currentNode *resourcetr
 	}
 
 	for _, node := range currentNode.Children {
-		err = handleNode(reconcilerManager, node)
+		err = HandleNode(reconcilerManager, node)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/synchronize_test.go
+++ b/pkg/controller/synchronize_test.go
@@ -96,7 +96,7 @@ func TestHandleNode(t *testing.T) {
 
 			node := &resourcetree.ResourceNode{}
 
-			err := handleNode(dummy, node)
+			err := HandleNode(dummy, node)
 			if tc.expectErr {
 				assert.NotNil(t, err)
 			} else {
@@ -135,7 +135,7 @@ func TestReceivedErrorAfterRequeues(t *testing.T) {
 		expectError                error
 	}{
 		{
-			name: "Should break out of handleNode immediately when requeue is false",
+			name: "Should break out of HandleNode immediately when requeue is false",
 
 			withResults: []reconciler.ReconcilationResult{{Requeue: false}},
 
@@ -143,7 +143,7 @@ func TestReceivedErrorAfterRequeues(t *testing.T) {
 			expectError:                errors.New("reconciling node: dummy err"),
 		},
 		{
-			name: "Should break out of handleNode after second reconciliation when requeues are true, false",
+			name: "Should break out of HandleNode after second reconciliation when requeues are true, false",
 
 			withResults: []reconciler.ReconcilationResult{{Requeue: true}, {Requeue: false}},
 
@@ -158,7 +158,7 @@ func TestReceivedErrorAfterRequeues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := &mockAlwaysErrorReconciler{ReconciliationResult: tc.withResults}
 
-			err := handleNode(r, &resourcetree.ResourceNode{Type: resourcetree.ResourceNodeTypeGroup})
+			err := HandleNode(r, &resourcetree.ResourceNode{Type: resourcetree.ResourceNodeTypeGroup})
 			assert.NotNil(t, err)
 
 			assert.Equal(t, tc.expectErrorAfterIterations, r.iteration)

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -601,7 +601,6 @@ func (o *Okctl) awsLoadBalancerControllerService(outputDir string, spin spinner.
 func (o *Okctl) applicationService(infrastructureOutputDir, applicationOutputDir string, spin spinner.Spinner) client.ApplicationService {
 	return clientCore.NewApplicationService(
 		o.FileSystem,
-		spin,
 		clientFilesystem.Paths{
 			BaseDir: applicationOutputDir,
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes `apply application` use the reconciler/operator pattern as in `apply cluster`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM230](https://trello.com/c/xbYLxDEe)

Julius likes this pattern. (Also it provides a more "natural" way to introduce more features to an application, f.eks ECR)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
