### PR TITLE
KM215: Validate cluster declaration's clusterRootDomain

### DIFF
--- a/docs/release_notes/0.0.55.md
+++ b/docs/release_notes/0.0.55.md
@@ -7,3 +7,4 @@
 ## Other
 KM214: Add users configuration to scaffold cluster
 KM213: Add database configuration to scaffold cluster
+KM215: Validate cluster declaration's clusterRootDomain properly (#467)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d // indirect
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/apparentlymart/go-cidr v1.1.0
+	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/asdine/storm/v3 v3.2.1
 	github.com/aws/aws-sdk-go v1.38.21
 	github.com/awslabs/goformation/v4 v4.18.3

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d // indirect
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/apparentlymart/go-cidr v1.1.0
-	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/asdine/storm/v3 v3.2.1
 	github.com/aws/aws-sdk-go v1.38.21
 	github.com/awslabs/goformation/v4 v4.18.3

--- a/pkg/apis/okctl.io/v1alpha1/cluster_v1alpha1.go
+++ b/pkg/apis/okctl.io/v1alpha1/cluster_v1alpha1.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/asaskevich/govalidator"
+
 	"github.com/oslokommune/okctl/pkg/config/constant"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -62,7 +64,10 @@ type Cluster struct {
 // Validate calls each members Validate function
 func (c Cluster) Validate() error {
 	return validation.ValidateStruct(&c,
-		validation.Field(&c.ClusterRootDomain, validation.Required, is.LowerCase),
+		validation.Field(&c.ClusterRootDomain,
+			validation.Required,
+			is.LowerCase,
+			validation.NewStringRule(govalidator.IsDNSName, fmt.Sprintf("invalid domain name: '%s'", c.ClusterRootDomain))),
 		validation.Field(&c.Metadata),
 		validation.Field(&c.Github),
 		validation.Field(&c.VPC),

--- a/pkg/apis/okctl.io/v1alpha1/cluster_v1alpha1.go
+++ b/pkg/apis/okctl.io/v1alpha1/cluster_v1alpha1.go
@@ -295,21 +295,21 @@ func ClusterTypeMeta() metav1.TypeMeta {
 	}
 }
 
-// NewDefaultCluster returns a cluster definition with sensible defaults
-func NewDefaultCluster(name, org, repo, accountID string) Cluster {
+// NewCluster returns a Cluster with sensible defaults
+func NewCluster() Cluster {
 	return Cluster{
 		TypeMeta: ClusterTypeMeta(),
 		Metadata: ClusterMeta{
-			Name:      name,
-			Region:    "eu-west-1",
-			AccountID: accountID,
+			Name:      "",
+			Region:    constant.DefaultAwsRegion,
+			AccountID: "",
 		},
 		Github: ClusterGithub{
-			Organisation: org,
-			Repository:   repo,
+			Organisation: constant.DefaultGithubOrganization,
+			Repository:   "",
 			OutputPath:   constant.DefaultOutputDirectory,
 		},
-		ClusterRootDomain: fmt.Sprintf("%s.oslo.systems", name),
+		ClusterRootDomain: "",
 		VPC: &ClusterVPC{
 			CIDR:             constant.DefaultClusterCIDR,
 			HighAvailability: true,

--- a/pkg/apis/okctl.io/v1alpha1/cluster_v1alpha1.go
+++ b/pkg/apis/okctl.io/v1alpha1/cluster_v1alpha1.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/asaskevich/govalidator"
-
 	"github.com/oslokommune/okctl/pkg/config/constant"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -67,7 +65,8 @@ func (c Cluster) Validate() error {
 		validation.Field(&c.ClusterRootDomain,
 			validation.Required,
 			is.LowerCase,
-			validation.NewStringRule(govalidator.IsDNSName, fmt.Sprintf("invalid domain name: '%s'", c.ClusterRootDomain))),
+			is.DNSName.Error(fmt.Sprintf("invalid domain name: '%s'", c.ClusterRootDomain)),
+		),
 		validation.Field(&c.Metadata),
 		validation.Field(&c.Github),
 		validation.Field(&c.VPC),

--- a/pkg/apis/okctl.io/v1alpha1/cluster_validation_test.go
+++ b/pkg/apis/okctl.io/v1alpha1/cluster_validation_test.go
@@ -1,0 +1,116 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+// nolint: funlen
+func TestValidateCluster(t *testing.T) {
+	testCases := []struct {
+		name        string
+		withCluster func() v1alpha1.Cluster
+		expectError string
+	}{
+		{
+			name:        "Should pass when everything is A-ok",
+			withCluster: newPassingCluster,
+			expectError: "",
+		},
+		{
+			name: "Should fail when name is empty",
+			withCluster: func() v1alpha1.Cluster {
+				c := newPassingCluster()
+
+				c.Metadata.Name = ""
+
+				return c
+			},
+			expectError: "metadata: (name: cannot be blank.).",
+		},
+		{
+			name: "Should fail if clusterRootDomain is missing",
+			withCluster: func() v1alpha1.Cluster {
+				c := newPassingCluster()
+
+				c.ClusterRootDomain = ""
+
+				return c
+			},
+			expectError: "clusterRootDomain: cannot be blank.",
+		},
+		{
+			name: "Should fail if clusterRootDomain have improper casing",
+			withCluster: func() v1alpha1.Cluster {
+				c := newPassingCluster()
+
+				c.ClusterRootDomain = "ThisIsNotAllowed.oslo.systems"
+
+				return c
+			},
+			expectError: "clusterRootDomain: must be in lower case.",
+		},
+		{
+			name: "Cluster with argocd enabled, cognito disabled",
+			withCluster: func() v1alpha1.Cluster {
+				c := newPassingCluster()
+
+				c.Integrations.Cognito = false
+
+				return c
+			},
+			expectError: "integrations: (cognito: is required when argocd is enabled.).",
+		},
+		{
+			// This happens when the user doesn't provide a clusterRootDomain
+			name: "Should fail if clusterRootDomain starts with dash",
+			withCluster: func() v1alpha1.Cluster {
+				c := newPassingCluster()
+
+				c.ClusterRootDomain = "-.oslo.systems"
+
+				return c
+			},
+			expectError: "clusterRootDomain: invalid domain name: '-.oslo.systems'.",
+		},
+		{
+			// This happens when the user doesn't provide a clusterRootDomain
+			name: "Should fail if clusterRootDomain contains space",
+			withCluster: func() v1alpha1.Cluster {
+				c := newPassingCluster()
+
+				c.ClusterRootDomain = "hel lo.oslo.systems"
+
+				return c
+			},
+			expectError: "clusterRootDomain: invalid domain name: 'hel lo.oslo.systems'.",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.withCluster().Validate()
+
+			if tc.expectError != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectError, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func newPassingCluster() v1alpha1.Cluster {
+	return newCluster(
+		"myCluster",
+		"mycluster-dev.oslo.systems",
+		"my-organization",
+		"my-github-repo",
+		"123456789012",
+	)
+}

--- a/pkg/commands/applycluster.go
+++ b/pkg/commands/applycluster.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
-	"github.com/oslokommune/okctl/pkg/config/constant"
-
 	"sigs.k8s.io/yaml"
 )
 
@@ -36,12 +34,7 @@ func InferClusterFromStdinOrFile(stdin io.Reader, path string) (*v1alpha1.Cluste
 		cluster v1alpha1.Cluster
 	)
 
-	cluster = v1alpha1.NewDefaultCluster(
-		"",
-		constant.DefaultGithubOrganization,
-		"",
-		"",
-	)
+	cluster = v1alpha1.NewCluster()
 
 	_, err = io.Copy(&buffer, inputReader)
 	if err != nil {

--- a/pkg/config/constant/api.go
+++ b/pkg/config/constant/api.go
@@ -33,6 +33,7 @@ const (
 	DefaultChartApplyTimeout  = 5 * time.Minute
 	DefaultChartRemoveTimeout = 5 * time.Minute
 
+	DefaultAwsRegion                       = "eu-west-1"
 	DefaultGithubHost                      = "git@github.com"
 	DefaultGithubOrganization              = "oslokommune"
 	DefaultFargateObservabilityNamespace   = "aws-observability"

--- a/pkg/config/load/repository.go
+++ b/pkg/config/load/repository.go
@@ -35,7 +35,7 @@ func buildRepoDataLoader(configFile string, _ func(v *viper.Viper)) config.DataL
 			return fmt.Errorf("couldn't find config file: %s", cfgFile)
 		}
 
-		declaration := v1alpha1.NewDefaultCluster("", "", "", "")
+		declaration := v1alpha1.NewCluster()
 
 		_, err = store.NewFileSystem(repoDir, cfg.FileSystem).
 			GetStruct(configFile, &declaration, store.FromYAML()).

--- a/pkg/controller/convert_test.go
+++ b/pkg/controller/convert_test.go
@@ -20,7 +20,7 @@ func TestTreeCreators(t *testing.T) {
 		{
 			name: "Should produce equal trees when all is enabled",
 			declaration: func() *v1alpha1.Cluster {
-				declaration := v1alpha1.NewDefaultCluster("", "", "", "")
+				declaration := v1alpha1.NewCluster()
 
 				return &declaration
 			},
@@ -46,7 +46,7 @@ func TestTreeCreators(t *testing.T) {
 		{
 			name: "Should produce equal trees when all but ExternalDNS is enabled",
 			declaration: func() *v1alpha1.Cluster {
-				declaration := v1alpha1.NewDefaultCluster("", "", "", "")
+				declaration := v1alpha1.NewCluster()
 				declaration.Integrations.ExternalDNS = false
 
 				return &declaration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds stricter validation of clusterRootDomain.

## Description
See https://trello.com/c/OVTiSgFr/215-okctl-apply-cluster-validate-clusteryaml-properly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
