### PR TITLE
KM241 🐛 Fix state DB timeout due to multiple write permission opens

### DIFF
--- a/cmd/okctl/scaffold.go
+++ b/cmd/okctl/scaffold.go
@@ -12,7 +12,7 @@ func buildScaffoldCommand(o *okctl.Okctl) *cobra.Command {
 	}
 
 	cmd.AddCommand(buildScaffoldClusterCommand(o))
-	cmd.AddCommand(buildCreateApplicationCommand(o))
+	cmd.AddCommand(buildScaffoldApplicationCommand(o))
 
 	return cmd
 }

--- a/cmd/okctl/scaffold_application.go
+++ b/cmd/okctl/scaffold_application.go
@@ -10,7 +10,7 @@ import (
 const requiredArgumentsForCreateApplicationCommand = 0
 
 // nolint: funlen
-func buildCreateApplicationCommand(o *okctl.Okctl) *cobra.Command {
+func buildScaffoldApplicationCommand(o *okctl.Okctl) *cobra.Command {
 	opts := commands.ScaffoldApplicationOpts{}
 
 	cmd := &cobra.Command{

--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -95,6 +95,13 @@ func venvRunE(o *okctl.Okctl, okctlEnvironment commands.OkctlEnvironment) error 
 		}
 	}()
 
+	// Close Storm so that okctl commands running in the venv subshell can access Storm state without hitting
+	// the exclusive lock limitation: https://github.com/etcd-io/bbolt#caveats--limitations
+	err = o.StormDB.Close()
+	if err != nil {
+		return fmt.Errorf("closing storm: %w", err)
+	}
+
 	err = printWelcomeMessage(o.Out, venv, okctlEnvironment)
 	if err != nil {
 		return fmt.Errorf("could not print welcome message: %w", err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

https://trello.com/c/TouXlQoZ/241-okctl-venv-fails-because-of-exclusive-locks

## Description
<!--- Describe your changes in detail -->

All/Most okctl commands fails in okctl venv because okctl venv uses `o.Initialise()`, which uses Storm, which puts an exclusive lock on the state database.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested manually, hard to unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
