### PR TITLE
✅ Add default dnsPolicy to apply application podspec

### DIFF
--- a/docs/release_notes/0.0.56.md
+++ b/docs/release_notes/0.0.56.md
@@ -1,0 +1,6 @@
+# Release 0.0.56
+
+## Features
+
+## Changes
+✅ Add default dns policy to `apply application`

--- a/pkg/client/core/testdata/deployment.yaml.golden
+++ b/pkg/client/core/testdata/deployment.yaml.golden
@@ -19,6 +19,7 @@ spec:
         volumeMounts:
         - mountPath: /path/to/mount/volume
           name: my-app-pathtomountvolume
+      dnsPolicy: Default
       volumes:
       - name: my-app-pathtomountvolume
         persistentVolumeClaim:

--- a/pkg/scaffold/resources/deployment.go
+++ b/pkg/scaffold/resources/deployment.go
@@ -54,7 +54,8 @@ func generateDefaultDeployment() appsv1.Deployment {
 					Annotations: nil,
 				},
 				Spec: corev1.PodSpec{
-					Volumes: nil,
+					DNSPolicy: corev1.DNSDefault,
+					Volumes:   nil,
 				},
 			},
 		},


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This seems to be required to request resources from a pod to outside of the cluster.

See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

At a bare minimum, it is necessary to reach RDS. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Connecting to RDS is not possible from a pod without a dnsPolicy set.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
