### PR TITLE
[KM210] Don't use physical names for logical IDs

### DIFF
--- a/pkg/api/core/cloudprovider/aws/component_aws.go
+++ b/pkg/api/core/cloudprovider/aws/component_aws.go
@@ -16,7 +16,7 @@ type componentCloudProvider struct {
 }
 
 func (c *componentCloudProvider) CreateS3Bucket(opts *api.CreateS3BucketOpts) (*api.S3Bucket, error) {
-	composition := components.NewS3BucketComposer(opts.Name, opts.ID.ClusterName)
+	composition := components.NewS3BucketComposer(opts.Name, "S3Bucket")
 
 	template, err := cfn.New(composition).Build()
 	if err != nil {

--- a/pkg/api/core/cloudprovider/aws/component_aws.go
+++ b/pkg/api/core/cloudprovider/aws/component_aws.go
@@ -83,8 +83,8 @@ func (c *componentCloudProvider) CreatePostgresDatabase(opts *api.CreatePostgres
 	}
 
 	template, err = lambdafunction.PatchRotateLambda(
-		composer.NameResource("RDSPGRotater"),
-		composer.NameResource("RDSPGSMVPCEndpoint"),
+		composer.CloudFormationResourceName("RDSPGRotater"),
+		composer.CloudFormationResourceName("RDSPGSMVPCEndpoint"),
 		template,
 	)
 	if err != nil {
@@ -114,13 +114,13 @@ func (c *componentCloudProvider) CreatePostgresDatabase(opts *api.CreatePostgres
 	}
 
 	err = r.Outputs(opts.StackName, map[string]cfn.ProcessOutputFn{
-		fmt.Sprintf("%sEndpointAddress", composer.NameResource("RDSPostgres")): cfn.String(&p.EndpointAddress),
-		fmt.Sprintf("%sEndpointPort", composer.NameResource("RDSPostgres")):    cfn.Int(&p.EndpointPort),
-		fmt.Sprintf("%sGroupId", composer.NameResource("RDSPostgresOutgoing")): cfn.String(&p.OutgoingSecurityGroupID),
-		composer.NameResource("RDSInstanceAdmin"):                              cfn.String(&p.SecretsManagerAdminSecretARN),
-		composer.NameResource("RDSPGRotaterPolicy"):                            cfn.String(&p.LambdaPolicyARN),
-		fmt.Sprintf("%sArn", composer.NameResource("RDSPGRotaterRole")):        cfn.String(&p.LambdaRoleARN),
-		composer.NameResource("RDSPGRotater"):                                  cfn.String(&p.LambdaFunctionARN),
+		fmt.Sprintf("%sEndpointAddress", composer.CloudFormationResourceName("RDSPostgres")): cfn.String(&p.EndpointAddress),
+		fmt.Sprintf("%sEndpointPort", composer.CloudFormationResourceName("RDSPostgres")):    cfn.Int(&p.EndpointPort),
+		fmt.Sprintf("%sGroupId", composer.CloudFormationResourceName("RDSPostgresOutgoing")): cfn.String(&p.OutgoingSecurityGroupID),
+		composer.CloudFormationResourceName("RDSInstanceAdmin"):                              cfn.String(&p.SecretsManagerAdminSecretARN),
+		composer.CloudFormationResourceName("RDSPGRotaterPolicy"):                            cfn.String(&p.LambdaPolicyARN),
+		fmt.Sprintf("%sArn", composer.CloudFormationResourceName("RDSPGRotaterRole")):        cfn.String(&p.LambdaRoleARN),
+		composer.CloudFormationResourceName("RDSPGRotater"):                                  cfn.String(&p.LambdaFunctionARN),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("collecting stack outputs: %w", err)

--- a/pkg/cfn/builder_test.go
+++ b/pkg/cfn/builder_test.go
@@ -117,7 +117,7 @@ func TestBuilderAndComposers(t *testing.T) {
 		{
 			name:     "S3Bucket composer",
 			golden:   "s3-bucket.yaml",
-			composer: components.NewS3BucketComposer("myBucket", "cluster-dev"),
+			composer: components.NewS3BucketComposer("myBucket", "S3Bucket"),
 		},
 	}
 

--- a/pkg/cfn/builder_test.go
+++ b/pkg/cfn/builder_test.go
@@ -117,7 +117,7 @@ func TestBuilderAndComposers(t *testing.T) {
 		{
 			name:     "S3Bucket composer",
 			golden:   "s3-bucket.yaml",
-			composer: components.NewS3BucketComposer("myBucket", "cluster"),
+			composer: components.NewS3BucketComposer("myBucket", "cluster-dev"),
 		},
 	}
 

--- a/pkg/cfn/components/composer.go
+++ b/pkg/cfn/components/composer.go
@@ -1585,13 +1585,13 @@ func (c *RDSPostgresComposer) Compose() (*cfn.Composition, error) {
 // S3BucketComposer contains the state required for creating
 // the AWS S3 bucket
 type S3BucketComposer struct {
-	BucketName  string
-	ClusterName string
+	BucketName   string
+	ResourceName string
 }
 
 // ResourceBucketNameOutput returns the name of the resource
 func (s *S3BucketComposer) ResourceBucketNameOutput() string {
-	return fmt.Sprintf("%s%sS3Bucket", s.BucketName, strings.ReplaceAll(s.ClusterName, "-", ""))
+	return s.ResourceName
 }
 
 // Compose returns the outputs and resources
@@ -1608,10 +1608,10 @@ func (s *S3BucketComposer) Compose() (*cfn.Composition, error) {
 }
 
 // NewS3BucketComposer returns an initialised AWS S3 bucket composer
-func NewS3BucketComposer(bucketName, clusterName string) *S3BucketComposer {
+func NewS3BucketComposer(bucketName, resourceName string) *S3BucketComposer {
 	return &S3BucketComposer{
-		BucketName:  bucketName,
-		ClusterName: clusterName,
+		BucketName:   bucketName,
+		ResourceName: resourceName,
 	}
 }
 

--- a/pkg/cfn/components/composer.go
+++ b/pkg/cfn/components/composer.go
@@ -1580,7 +1580,7 @@ type S3BucketComposer struct {
 
 // ResourceBucketNameOutput returns the name of the resource
 func (s *S3BucketComposer) ResourceBucketNameOutput() string {
-	return fmt.Sprintf("%s%sS3Bucket", s.BucketName, s.ClusterName)
+	return fmt.Sprintf("%s%sS3Bucket", s.BucketName, strings.ReplaceAll(s.ClusterName, "-", ""))
 }
 
 // Compose returns the outputs and resources

--- a/pkg/cfn/components/lambdafunction/testdata/rotate-lambda-patched.yaml.golden
+++ b/pkg/cfn/components/lambdafunction/testdata/rotate-lambda-patched.yaml.golden
@@ -14,6 +14,7 @@ Resources:
       Code:
         S3Bucket: mybucket
         S3Key: mykey
+      Description: RDS Postgres Rotater
       Environment:
         Variables:
           SECRETS_MANAGER_ENDPOINT:
@@ -29,7 +30,6 @@ Resources:
                     - Fn::GetAtt:
                       - myVPCEndpoint
                       - DnsEntries
-      FunctionName: myrotater-Rotater
       Handler: lambda_function.lambda_handler
       Role:
         Fn::GetAtt:

--- a/pkg/cfn/components/lambdafunction/testdata/rotate-lambda.yaml.golden
+++ b/pkg/cfn/components/lambdafunction/testdata/rotate-lambda.yaml.golden
@@ -14,10 +14,10 @@ Resources:
       Code:
         S3Bucket: mybucket
         S3Key: mykey
+      Description: RDS Postgres Rotater
       Environment:
         Variables:
           SECRETS_MANAGER_ENDPOINT: eyAiRm46OlNlbGVjdCI6IFsgJ1x4MDAnLCAgImV5QWlSbTQ2T2tkbGRFRjBkQ0lnT2lCYklDSnRlVlpRUTBWdVpIQnZhVzUwSWl3Z0lrUnVjMFZ1ZEhKcFpYTWlJRjBnZlE9PSIgXSB9
-      FunctionName: myrotater-Rotater
       Handler: lambda_function.lambda_handler
       Role:
         Fn::GetAtt:

--- a/pkg/cfn/components/role/role.go
+++ b/pkg/cfn/components/role/role.go
@@ -12,6 +12,7 @@ import (
 
 // Role stores the state for a cloud formation iam role
 type Role struct {
+	RoleName                 string
 	StoredName               string
 	PermissionsBoundary      string
 	ManagedPolicyARNs        []string
@@ -40,7 +41,7 @@ func (r *Role) Resource() cloudformation.Resource {
 		AssumeRolePolicyDocument: r.AssumeRolePolicyDocument,
 		ManagedPolicyArns:        r.ManagedPolicyARNs,
 		PermissionsBoundary:      r.PermissionsBoundary,
-		RoleName:                 r.Name(),
+		RoleName:                 r.RoleName,
 	}
 
 	for policy, document := range r.Policies {
@@ -56,12 +57,13 @@ func (r *Role) Resource() cloudformation.Resource {
 // New returns an initialised IAM role
 // - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
 func New(
-	resourceName, permissionsBoundary string,
+	roleName, resourceName, permissionsBoundary string,
 	managedPolicyARNs []string,
 	assumeRolePolicyDocument interface{},
 	policies map[string]interface{},
 ) *Role {
 	return &Role{
+		RoleName:                 roleName,
 		StoredName:               resourceName,
 		PermissionsBoundary:      permissionsBoundary,
 		ManagedPolicyARNs:        managedPolicyARNs,

--- a/pkg/cfn/components/role/role_test.go
+++ b/pkg/cfn/components/role/role_test.go
@@ -16,6 +16,7 @@ func TestNew(t *testing.T) {
 			Golden: "role.json",
 			Content: role.New(
 				"myIAMRole",
+				"myIAMRole",
 				v1alpha1.PermissionsBoundaryARN("123456789012"),
 				[]string{"arn:::policy/some-policy"},
 				policydocument.PolicyDocument{

--- a/pkg/cfn/components/s3bucket/s3bucket_test.go
+++ b/pkg/cfn/components/s3bucket/s3bucket_test.go
@@ -1,1 +1,24 @@
-package s3bucket
+package s3bucket_test
+
+import (
+	"testing"
+
+	"github.com/oslokommune/okctl/pkg/cfn/components/s3bucket"
+
+	tstr "github.com/oslokommune/okctl/pkg/cfn/components/testing"
+)
+
+func TestNew(t *testing.T) {
+	testCases := []tstr.CloudFormationTemplateTestCase{
+		{
+			Name:   "S3Bucket",
+			Golden: "s3bucket.yaml",
+			Content: s3bucket.New(
+				"myResource",
+				"my-Bucket",
+			),
+		},
+	}
+
+	tstr.RunTests(t, testCases, nil)
+}

--- a/pkg/cfn/components/s3bucket/testdata/s3bucket.yaml.golden
+++ b/pkg/cfn/components/s3bucket/testdata/s3bucket.yaml.golden
@@ -1,14 +1,14 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
-  myS3Bucket:
+  myResource:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-myS3Bucket
+        Fn::Sub: ${AWS::StackName}-myResource
     Value:
-      Ref: myS3Bucket
+      Ref: myResource
 Resources:
-  myS3Bucket:
+  myResource:
     Properties:
       AccessControl: BucketOwnerFullControl
-      BucketName: lambda-code
+      BucketName: my-Bucket
     Type: AWS::S3::Bucket

--- a/pkg/cfn/components/securitygroup/securitygroup.go
+++ b/pkg/cfn/components/securitygroup/securitygroup.go
@@ -47,7 +47,7 @@ const (
 // NewPostgresOutgoing returns an initialised security group
 // that allows outgoing traffic from the pod or node to the
 // postgres subnets on the postgres port
-func NewPostgresOutgoing(resourceName, vpcID string, cidrs []string) *SecurityGroup {
+func NewPostgresOutgoing(groupName, resourceName, vpcID string, cidrs []string) *SecurityGroup {
 	egresses := make([]ec2.SecurityGroup_Egress, len(cidrs))
 
 	for i, cidr := range cidrs {
@@ -63,7 +63,7 @@ func NewPostgresOutgoing(resourceName, vpcID string, cidrs []string) *SecurityGr
 		StoredName: resourceName,
 		Group: &ec2.SecurityGroup{
 			GroupDescription:    "RDS Postgres Outgoing Security Group",
-			GroupName:           resourceName,
+			GroupName:           groupName,
 			SecurityGroupEgress: egresses,
 			VpcId:               vpcID,
 		},
@@ -72,7 +72,7 @@ func NewPostgresOutgoing(resourceName, vpcID string, cidrs []string) *SecurityGr
 
 // NewPostgresIncoming returns an initialised security group that
 // allows incoming traffic to the postgres database instance
-func NewPostgresIncoming(resourceName, vpcID string, sources ...cfn.Namer) *SecurityGroup {
+func NewPostgresIncoming(groupName, resourceName, vpcID string, sources ...cfn.Namer) *SecurityGroup {
 	ingresses := make([]ec2.SecurityGroup_Ingress, len(sources))
 
 	for i, source := range sources {
@@ -88,7 +88,7 @@ func NewPostgresIncoming(resourceName, vpcID string, sources ...cfn.Namer) *Secu
 		StoredName: resourceName,
 		Group: &ec2.SecurityGroup{
 			GroupDescription:     "RDS Postgres Incoming Security Group",
-			GroupName:            resourceName,
+			GroupName:            groupName,
 			SecurityGroupIngress: ingresses,
 			VpcId:                vpcID,
 		},
@@ -96,12 +96,12 @@ func NewPostgresIncoming(resourceName, vpcID string, sources ...cfn.Namer) *Secu
 }
 
 // NewRDSPGSMVPCEndpointIncoming allows incoming traffic to the VPC SM endpoint
-func NewRDSPGSMVPCEndpointIncoming(resourceName, vpcID string, source cfn.Namer) *SecurityGroup {
+func NewRDSPGSMVPCEndpointIncoming(groupName, resourceName, vpcID string, source cfn.Namer) *SecurityGroup {
 	return &SecurityGroup{
 		StoredName: resourceName,
 		Group: &ec2.SecurityGroup{
 			GroupDescription: "SecretsManager VPC Endpoint incoming",
-			GroupName:        resourceName,
+			GroupName:        groupName,
 			SecurityGroupIngress: []ec2.SecurityGroup_Ingress{
 				{
 					FromPort:              httpsPort,
@@ -117,7 +117,7 @@ func NewRDSPGSMVPCEndpointIncoming(resourceName, vpcID string, source cfn.Namer)
 
 // NewLambdaFunctionOutgoing allows the lambda function to communicate on the correct
 // ports and cidrs
-func NewLambdaFunctionOutgoing(resourceName, vpcID string, cidrs []string) *SecurityGroup {
+func NewLambdaFunctionOutgoing(groupName, resourceName, vpcID string, cidrs []string) *SecurityGroup {
 	egresses := []ec2.SecurityGroup_Egress{}
 
 	for _, cidr := range cidrs {
@@ -135,7 +135,7 @@ func NewLambdaFunctionOutgoing(resourceName, vpcID string, cidrs []string) *Secu
 		StoredName: resourceName,
 		Group: &ec2.SecurityGroup{
 			GroupDescription:    "Rotater lambda function outgoing Security Group",
-			GroupName:           resourceName,
+			GroupName:           groupName,
 			SecurityGroupEgress: egresses,
 			VpcId:               vpcID,
 		},

--- a/pkg/cfn/components/securitygroup/securitygroup_test.go
+++ b/pkg/cfn/components/securitygroup/securitygroup_test.go
@@ -14,6 +14,7 @@ func TestNew(t *testing.T) {
 			Golden: "postgres-incoming-sg.json",
 			Content: securitygroup.NewPostgresIncoming(
 				"myIncomingPG",
+				"myIncomingPG",
 				"vpcid-r3ufh3",
 				tstr.NewNameReferencer("mySourceSecurityGroup"),
 			),
@@ -22,6 +23,7 @@ func TestNew(t *testing.T) {
 			Name:   "PostgresOutgoing",
 			Golden: "postgres-outgoing-sg.json",
 			Content: securitygroup.NewPostgresOutgoing(
+				"myIncomingPG",
 				"myIncomingPG",
 				"vpcid-wof03ef3",
 				[]string{"192.168.1.0/20", "192.168.2.0/20"},

--- a/pkg/cfn/testdata/rds-postgres.yaml.golden
+++ b/pkg/cfn/testdata/rds-postgres.yaml.golden
@@ -1,71 +1,71 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
-  okctlclusterRDSInstanceAdmin:
+  RDSInstanceAdmin:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-okctlclusterRDSInstanceAdmin
+        Fn::Sub: ${AWS::StackName}-RDSInstanceAdmin
     Value:
-      Ref: okctlclusterRDSInstanceAdmin
-  okctlclusterRDSPGRotater:
+      Ref: RDSInstanceAdmin
+  RDSPGRotater:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-okctlclusterRDSPGRotater
+        Fn::Sub: ${AWS::StackName}-RDSPGRotater
     Value:
       Fn::GetAtt:
-      - okctlclusterRDSPGRotater
+      - RDSPGRotater
       - Arn
-  okctlclusterRDSPGRotaterPolicy:
+  RDSPGRotaterPolicy:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-okctlclusterRDSPGRotaterPolicy
+        Fn::Sub: ${AWS::StackName}-RDSPGRotaterPolicy
     Value:
-      Ref: okctlclusterRDSPGRotaterPolicy
-  okctlclusterRDSPGRotaterRoleArn:
+      Ref: RDSPGRotaterPolicy
+  RDSPGRotaterRoleArn:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-okctlclusterRDSPGRotaterRoleArn
+        Fn::Sub: ${AWS::StackName}-RDSPGRotaterRoleArn
     Value:
       Fn::GetAtt:
-      - okctlclusterRDSPGRotaterRole
+      - RDSPGRotaterRole
       - Arn
-  okctlclusterRDSPostgres:
+  RDSPostgres:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-okctlclusterRDSPostgres
+        Fn::Sub: ${AWS::StackName}-RDSPostgres
     Value:
-      Ref: okctlclusterRDSPostgres
-  okctlclusterRDSPostgresEndpointAddress:
+      Ref: RDSPostgres
+  RDSPostgresEndpointAddress:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-okctlclusterRDSPostgresEndpointAddress
+        Fn::Sub: ${AWS::StackName}-RDSPostgresEndpointAddress
     Value:
       Fn::GetAtt:
-      - okctlclusterRDSPostgres
+      - RDSPostgres
       - Endpoint.Address
-  okctlclusterRDSPostgresEndpointPort:
+  RDSPostgresEndpointPort:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-okctlclusterRDSPostgresEndpointPort
+        Fn::Sub: ${AWS::StackName}-RDSPostgresEndpointPort
     Value:
       Fn::GetAtt:
-      - okctlclusterRDSPostgres
+      - RDSPostgres
       - Endpoint.Port
-  okctlclusterRDSPostgresOutgoing:
+  RDSPostgresOutgoing:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-okctlclusterRDSPostgresOutgoing
+        Fn::Sub: ${AWS::StackName}-RDSPostgresOutgoing
     Value:
-      Ref: okctlclusterRDSPostgresOutgoing
-  okctlclusterRDSPostgresOutgoingGroupId:
+      Ref: RDSPostgresOutgoing
+  RDSPostgresOutgoingGroupId:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-okctlclusterRDSPostgresOutgoingGroupId
+        Fn::Sub: ${AWS::StackName}-RDSPostgresOutgoingGroupId
     Value:
       Fn::GetAtt:
-      - okctlclusterRDSPostgresOutgoing
+      - RDSPostgresOutgoing
       - GroupId
 Resources:
-  okctlclusterRDSInstanceAdmin:
+  RDSInstanceAdmin:
     Properties:
       GenerateSecretString:
         ExcludePunctuation: true
@@ -75,7 +75,7 @@ Resources:
         SecretStringTemplate: '{"username": "admin"}'
       Name: /okctl/cluster/postgres_admin
     Type: AWS::SecretsManager::Secret
-  okctlclusterRDSPGMonitoringRole:
+  RDSPGMonitoringRole:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -91,7 +91,7 @@ Resources:
       PermissionsBoundary: arn:aws:iam::123456789012:policy/oslokommune/oslokommune-boundary
       RoleName: okctlclusterRDSPGMonitoringRole
     Type: AWS::IAM::Role
-  okctlclusterRDSPGOutgoingSG:
+  RDSPGOutgoingSG:
     Properties:
       GroupDescription: Rotater lambda function outgoing Security Group
       GroupName: okctlclusterRDSPGOutgoingSG
@@ -114,7 +114,7 @@ Resources:
         ToPort: 5432
       VpcId: vpcid-w9ufe
     Type: AWS::EC2::SecurityGroup
-  okctlclusterRDSPGParamGroup:
+  RDSPGParamGroup:
     Properties:
       Description: Postgres 13 property group
       Family: postgres13
@@ -127,41 +127,41 @@ Resources:
         pg_stat_statements.track: all
         shared_preload_libraries: pg_stat_statements
     Type: AWS::RDS::DBParameterGroup
-  okctlclusterRDSPGRotater:
+  RDSPGRotater:
     Properties:
       Code: {}
+      Description: RDS Postgres Rotater
       Environment:
         Variables:
-          SECRETS_MANAGER_ENDPOINT: eyAiRm46OlNlbGVjdCI6IFsgJ1x4MDAnLCAgImV5QWlSbTQ2T2tkbGRFRjBkQ0lnT2lCYklDSnZhMk4wYkdOc2RYTjBaWEpTUkZOUVIxTk5WbEJEUlc1a2NHOXBiblFpTENBaVJHNXpSVzUwY21sbGN5SWdYU0I5IiBdIH0=
-      FunctionName: okctlclusterrdspgrotater-Rotater
+          SECRETS_MANAGER_ENDPOINT: eyAiRm46OlNlbGVjdCI6IFsgJ1x4MDAnLCAgImV5QWlSbTQ2T2tkbGRFRjBkQ0lnT2lCYklDSlNSRk5RUjFOTlZsQkRSVzVrY0c5cGJuUWlMQ0FpUkc1elJXNTBjbWxsY3lJZ1hTQjkiIF0gfQ==
       Handler: lambda_function.lambda_handler
       Role:
         Fn::GetAtt:
-        - okctlclusterRDSPGRotaterRole
+        - RDSPGRotaterRole
         - Arn
       Runtime: python3.8
       Timeout: 30
       VpcConfig:
         SecurityGroupIds:
         - Fn::GetAtt:
-          - okctlclusterRDSPGOutgoingSG
+          - RDSPGOutgoingSG
           - GroupId
         SubnetIds:
         - dbsubnetid-123okf
         - dbsubnetid-fjeo338
     Type: AWS::Lambda::Function
-  okctlclusterRDSPGRotaterPermission:
+  RDSPGRotaterPermission:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName:
         Fn::GetAtt:
-        - okctlclusterRDSPGRotater
+        - RDSPGRotater
         - Arn
       Principal: secretsmanager.amazonaws.com
     Type: AWS::Lambda::Permission
-  okctlclusterRDSPGRotaterPolicy:
+  RDSPGRotaterPolicy:
     Properties:
-      Description: okctlclusterRDSPGRotaterPolicy
+      Description: RDSPGRotaterPolicy
       ManagedPolicyName: okctlclusterRDSPGRotaterPolicy
       PolicyDocument:
         Statement:
@@ -174,14 +174,14 @@ Resources:
             StringEquals:
               secretsmanager:resource/AllowRotationLambdaArn:
                 Fn::GetAtt:
-                - okctlclusterRDSPGRotater
+                - RDSPGRotater
                 - Arn
           Effect: Allow
           Resource:
           - '*'
         Version: 2012-10-17
     Type: AWS::IAM::ManagedPolicy
-  okctlclusterRDSPGRotaterRole:
+  RDSPGRotaterRole:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -214,11 +214,11 @@ Resources:
         PolicyName: okctlclusterRDSPGRotaterPolicy
       RoleName: okctlclusterRDSPGRotaterRole
     Type: AWS::IAM::Role
-  okctlclusterRDSPGSMVPCEndpoint:
+  RDSPGSMVPCEndpoint:
     Properties:
       SecurityGroupIds:
       - Fn::GetAtt:
-        - okctlclusterRDSPGSMVPCEndpointSG
+        - RDSPGSMVPCEndpointSG
         - GroupId
       ServiceName:
         Fn::Sub: com.amazonaws.${AWS::Region}.secretsmanager
@@ -228,7 +228,7 @@ Resources:
       VpcEndpointType: Interface
       VpcId: vpcid-w9ufe
     Type: AWS::EC2::VPCEndpoint
-  okctlclusterRDSPGSMVPCEndpointSG:
+  RDSPGSMVPCEndpointSG:
     Properties:
       GroupDescription: SecretsManager VPC Endpoint incoming
       GroupName: okctlclusterRDSPGSMVPCEndpointSG
@@ -237,15 +237,15 @@ Resources:
         IpProtocol: tcp
         SourceSecurityGroupId:
           Fn::GetAtt:
-          - okctlclusterRDSPGOutgoingSG
+          - RDSPGOutgoingSG
           - GroupId
         ToPort: 443
       VpcId: vpcid-w9ufe
     Type: AWS::EC2::SecurityGroup
-  okctlclusterRDSPostgres:
+  RDSPostgres:
     DependsOn:
-    - okctlclusterRDSPGParamGroup
-    - okctlclusterRDSPGMonitoringRole
+    - RDSPGParamGroup
+    - RDSPGMonitoringRole
     Properties:
       AllocatedStorage: "20"
       AutoMinorVersionUpgrade: true
@@ -255,7 +255,7 @@ Resources:
       DBInstanceIdentifier: cluster-okctl
       DBName: okctl
       DBParameterGroupName:
-        Ref: okctlclusterRDSPGParamGroup
+        Ref: RDSPGParamGroup
       DBSubnetGroupName: myDBSubnetGroupName
       DeleteAutomatedBackups: true
       EnableCloudwatchLogsExports:
@@ -265,14 +265,14 @@ Resources:
       Engine: postgres
       EngineVersion: "13.1"
       MasterUserPassword:
-        Fn::Sub: '{{resolve:secretsmanager:${okctlclusterRDSInstanceAdmin}::password}}'
+        Fn::Sub: '{{resolve:secretsmanager:${RDSInstanceAdmin}::password}}'
       MasterUsername:
-        Fn::Sub: '{{resolve:secretsmanager:${okctlclusterRDSInstanceAdmin}::username}}'
+        Fn::Sub: '{{resolve:secretsmanager:${RDSInstanceAdmin}::username}}'
       MaxAllocatedStorage: 100
       MonitoringInterval: 10
       MonitoringRoleArn:
         Fn::GetAtt:
-        - okctlclusterRDSPGMonitoringRole
+        - RDSPGMonitoringRole
         - Arn
       MultiAZ: true
       PerformanceInsightsRetentionPeriod: 7
@@ -284,10 +284,10 @@ Resources:
       UseDefaultProcessorFeatures: true
       VPCSecurityGroups:
       - Fn::GetAtt:
-        - okctlclusterRDSPostgresIncoming
+        - RDSPostgresIncoming
         - GroupId
     Type: AWS::RDS::DBInstance
-  okctlclusterRDSPostgresIncoming:
+  RDSPostgresIncoming:
     Properties:
       GroupDescription: RDS Postgres Incoming Security Group
       GroupName: okctlclusterRDSPostgresIncoming
@@ -296,19 +296,19 @@ Resources:
         IpProtocol: tcp
         SourceSecurityGroupId:
           Fn::GetAtt:
-          - okctlclusterRDSPostgresOutgoing
+          - RDSPostgresOutgoing
           - GroupId
         ToPort: 5432
       - FromPort: 5432
         IpProtocol: tcp
         SourceSecurityGroupId:
           Fn::GetAtt:
-          - okctlclusterRDSPGOutgoingSG
+          - RDSPGOutgoingSG
           - GroupId
         ToPort: 5432
       VpcId: vpcid-w9ufe
     Type: AWS::EC2::SecurityGroup
-  okctlclusterRDSPostgresOutgoing:
+  RDSPostgresOutgoing:
     Properties:
       GroupDescription: RDS Postgres Outgoing Security Group
       GroupName: okctlclusterRDSPostgresOutgoing
@@ -323,11 +323,11 @@ Resources:
         ToPort: 5432
       VpcId: vpcid-w9ufe
     Type: AWS::EC2::SecurityGroup
-  okctlclusterSecretTargetAttachment:
+  SecretTargetAttachment:
     Properties:
       SecretId:
-        Ref: okctlclusterRDSInstanceAdmin
+        Ref: RDSInstanceAdmin
       TargetId:
-        Ref: okctlclusterRDSPostgres
+        Ref: RDSPostgres
       TargetType: AWS::RDS::DBInstance
     Type: AWS::SecretsManager::SecretTargetAttachment

--- a/pkg/cfn/testdata/s3-bucket.yaml.golden
+++ b/pkg/cfn/testdata/s3-bucket.yaml.golden
@@ -1,13 +1,13 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
-  myBucketclusterdevS3Bucket:
+  S3Bucket:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-myBucketclusterdevS3Bucket
+        Fn::Sub: ${AWS::StackName}-S3Bucket
     Value:
-      Ref: myBucketclusterdevS3Bucket
+      Ref: S3Bucket
 Resources:
-  myBucketclusterdevS3Bucket:
+  S3Bucket:
     Properties:
       AccessControl: BucketOwnerFullControl
       BucketName: myBucket

--- a/pkg/cfn/testdata/s3-bucket.yaml.golden
+++ b/pkg/cfn/testdata/s3-bucket.yaml.golden
@@ -1,13 +1,13 @@
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
-  myBucketclusterS3Bucket:
+  myBucketclusterdevS3Bucket:
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-myBucketclusterS3Bucket
+        Fn::Sub: ${AWS::StackName}-myBucketclusterdevS3Bucket
     Value:
-      Ref: myBucketclusterS3Bucket
+      Ref: myBucketclusterdevS3Bucket
 Resources:
-  myBucketclusterS3Bucket:
+  myBucketclusterdevS3Bucket:
     Properties:
       AccessControl: BucketOwnerFullControl
       BucketName: myBucket


### PR DESCRIPTION
Don't use physical names for logical IDs

## Description
CloudFormation stacks are scoped by their stack name, so there is no need to give the logical IDs unique names. The physical names and IDs of the resources themselves do need this though.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
