### PR TITLE
KM251: add nil check for fargate quota datapoint

### DIFF
--- a/docs/release_notes/0.0.56.md
+++ b/docs/release_notes/0.0.56.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Bugfixes
+Fix crash on fargate quota check if there are already no running fargate nodes
 
 ## Changes
 ✅ Add default dns policy to `apply application`

--- a/pkg/servicequota/fargatecheck.go
+++ b/pkg/servicequota/fargatecheck.go
@@ -90,8 +90,12 @@ func (e *FargateCheck) CheckAvailability() (*Result, error) {
 	}
 
 	quota := int(*q.Quota.Value)
-	count := int(*data.Datapoints[0].Maximum)
-	available := quota - count
+	available := quota
+
+	if data.Datapoints != nil {
+		count := int(*data.Datapoints[0].Maximum)
+		available = quota - count
+	}
 
 	return &Result{
 		Required:    e.required,


### PR DESCRIPTION
## Description
If you run apply cluster on a new account, it would crash since we were missing a null check for fargate quotas count.

## How Has This Been Tested?
Tested manually

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
