### PR TITLE
KM256 🐛 Replace Ingress v1 with v1beta1

### DIFF
--- a/docs/release_notes/0.0.57.md
+++ b/docs/release_notes/0.0.57.md
@@ -5,6 +5,18 @@
 ## Bugfixes
 KM255: Fix certificate created in any case during apply application
 
+KM256: Fixed that it was not possible to deploy more than once to ArgoCD (#507). If you encounter problems with this,
+that is, if you have used `okctl apply application` between 0.0.54 and 0.0.56, you can do the following steps to fix
+the problem:
+
+```shell
+cd my-okctl-iac-repo
+okctl apply application -f my-application.yaml
+git add . && git commit -m "Fix application" && git push
+```
+
+When pushed, ArgoCD should automatically deploy your application.
+
 ## Changes
 
 ## Other

--- a/pkg/client/core/testdata/ingress.yaml.golden
+++ b/pkg/client/core/testdata/ingress.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/pkg/client/core/testdata/ingress.yaml.golden
+++ b/pkg/client/core/testdata/ingress.yaml.golden
@@ -14,19 +14,13 @@ spec:
   - http:
       paths:
       - backend:
-          service:
-            name: ssl-redirect
-            port:
-              name: use-annotation
+          serviceName: ssl-redirect
+          servicePort: use-annotation
         path: /*
-        pathType: Prefix
       - backend:
-          service:
-            name: my-app
-            port:
-              number: 80
+          serviceName: my-app
+          servicePort: 80
         path: /*
-        pathType: Prefix
 
 ---
 

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/oslokommune/okctl/pkg/scaffold/resources"
 	v1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -81,7 +81,7 @@ func GenerateApplicationBase(app v1alpha1.Application, iacRepoURL, relativeAppli
 	}
 
 	if app.HasIngress() && app.HasService() {
-		var ingress networkingv1.Ingress
+		var ingress networkingv1beta1.Ingress
 
 		ingress, err = resources.CreateOkctlIngress(app)
 		if err != nil {

--- a/pkg/scaffold/resources/ingress.go
+++ b/pkg/scaffold/resources/ingress.go
@@ -44,7 +44,7 @@ func generateDefaultIngress() networkingv1beta1.Ingress {
 	return networkingv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
-			APIVersion: "networking.k8s.io/v1",
+			APIVersion: "networking.k8s.io/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      map[string]string{},

--- a/pkg/scaffold/resources/ingress.go
+++ b/pkg/scaffold/resources/ingress.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
-	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // CreateOkctlIngress creates an ingress customized for okctl
-func CreateOkctlIngress(app v1alpha1.Application) (networkingv1.Ingress, error) {
+func CreateOkctlIngress(app v1alpha1.Application) (networkingv1beta1.Ingress, error) {
 	ingress, err := createGenericIngress(app)
 	if err != nil {
-		return networkingv1.Ingress{}, err
+		return networkingv1beta1.Ingress{}, err
 	}
 
 	ingress.Spec.Rules[0].HTTP.Paths[0].Path = "/*"
@@ -23,30 +24,24 @@ func CreateOkctlIngress(app v1alpha1.Application) (networkingv1.Ingress, error) 
 	ingress.Annotations["alb.ingress.kubernetes.io/actions.ssl-redirect"] =
 		`{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}`
 
-	redirectPath := networkingv1.HTTPIngressPath{
-		PathType: pathTypePointer(networkingv1.PathTypePrefix),
-		Path:     "/*",
-		Backend: networkingv1.IngressBackend{
-			Service: &networkingv1.IngressServiceBackend{
-				Name: "ssl-redirect",
-				Port: networkingv1.ServiceBackendPort{
-					Name: "use-annotation",
-				},
+	redirectPath := networkingv1beta1.HTTPIngressPath{
+		Path: "/*",
+		Backend: networkingv1beta1.IngressBackend{
+			ServiceName: "ssl-redirect",
+			ServicePort: intstr.IntOrString{
+				Type:   intstr.String,
+				StrVal: "use-annotation",
 			},
 		},
 	}
 
-	ingress.Spec.Rules[0].HTTP.Paths = append([]networkingv1.HTTPIngressPath{redirectPath}, ingress.Spec.Rules[0].HTTP.Paths...)
+	ingress.Spec.Rules[0].HTTP.Paths = append([]networkingv1beta1.HTTPIngressPath{redirectPath}, ingress.Spec.Rules[0].HTTP.Paths...)
 
 	return ingress, nil
 }
 
-func pathTypePointer(p networkingv1.PathType) *networkingv1.PathType {
-	return &p
-}
-
-func generateDefaultIngress() networkingv1.Ingress {
-	return networkingv1.Ingress{
+func generateDefaultIngress() networkingv1beta1.Ingress {
+	return networkingv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
 			APIVersion: "networking.k8s.io/v1",
@@ -55,16 +50,16 @@ func generateDefaultIngress() networkingv1.Ingress {
 			Labels:      map[string]string{},
 			Annotations: map[string]string{},
 		},
-		Spec: networkingv1.IngressSpec{
-			Rules: make([]networkingv1.IngressRule, 1),
+		Spec: networkingv1beta1.IngressSpec{
+			Rules: make([]networkingv1beta1.IngressRule, 1),
 		},
 	}
 }
 
-func createGenericIngress(app v1alpha1.Application) (networkingv1.Ingress, error) {
+func createGenericIngress(app v1alpha1.Application) (networkingv1beta1.Ingress, error) {
 	hostURL, err := app.URL()
 	if err != nil {
-		return networkingv1.Ingress{}, fmt.Errorf("getting application URL: %w", err)
+		return networkingv1beta1.Ingress{}, fmt.Errorf("getting application URL: %w", err)
 	}
 
 	ingress := generateDefaultIngress()
@@ -72,20 +67,17 @@ func createGenericIngress(app v1alpha1.Application) (networkingv1.Ingress, error
 
 	ingress.ObjectMeta.Name = app.Metadata.Name
 
-	ingress.Spec.Rules = []networkingv1.IngressRule{
+	ingress.Spec.Rules = []networkingv1beta1.IngressRule{
 		{
 			Host: hostURL.Host,
-			IngressRuleValue: networkingv1.IngressRuleValue{
-				HTTP: &networkingv1.HTTPIngressRuleValue{
-					Paths: []networkingv1.HTTPIngressPath{{
-						PathType: pathTypePointer(networkingv1.PathTypePrefix),
-						Path:     "/",
-						Backend: networkingv1.IngressBackend{
-							Service: &networkingv1.IngressServiceBackend{
-								Name: app.Metadata.Name,
-								Port: networkingv1.ServiceBackendPort{
-									Number: defaultServiceListeningPort,
-								},
+			IngressRuleValue: networkingv1beta1.IngressRuleValue{
+				HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+					Paths: []networkingv1beta1.HTTPIngressPath{{
+						Path: "/",
+						Backend: networkingv1beta1.IngressBackend{
+							ServiceName: app.Metadata.Name,
+							ServicePort: intstr.IntOrString{
+								IntVal: defaultServiceListeningPort,
 							},
 						},
 					}},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

ArgoCD 1.17.x can't handle Ingress v1. Reverting to Ingress v1beta1.


## Description
<!--- Describe your changes in detail -->

#488 replaced Ingress 

```
networkingv1beta1 "k8s.io/api/networking/v1beta1"
```

with

```
networkingv1 "k8s.io/api/networking/v1"
```

But v1 ingress doesn't work with ArgoCD. After deploying for the second time, ArgoCD log and GUI outputs an error:

![image](https://user-images.githubusercontent.com/562343/116863402-8c62d280-ac06-11eb-82db-1546bf9ef80f.png)

This is a known bug in ArgoCD fixed in 1.18: https://github.com/argoproj/argo-cd/issues/4358

Because of this, ArgoCD is currently broken.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is the quickest fix for making ArgoCD work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
