### PR TITLE
[NOTASK] Make helm timeouts easier to configure

### DIFF
--- a/pkg/client/core/service_argocd_client.go
+++ b/pkg/client/core/service_argocd_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/asdine/storm/v3"
 
@@ -33,6 +34,7 @@ const (
 	argoPurpose          = "argocd"
 	argoPrivateKeyName   = "argocd-privatekey"
 	argoSecretName       = "argocd-secret"
+	argoChartTimeout     = 15 * time.Minute
 )
 
 // nolint: funlen
@@ -46,12 +48,10 @@ func (s *argoCDService) DeleteArgoCD(ctx context.Context, opts client.DeleteArgo
 		return err
 	}
 
-	chart := argocd.New(nil)
-
 	err = s.helm.DeleteHelmRelease(ctx, client.DeleteHelmReleaseOpts{
 		ID:          opts.ID,
-		ReleaseName: chart.ReleaseName,
-		Namespace:   chart.Namespace,
+		ReleaseName: argocd.ReleaseName,
+		Namespace:   argocd.Namespace,
 	})
 	if err != nil {
 		return err
@@ -233,7 +233,7 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 		RepoName:             opts.Repository.Repository,
 		PrivateKeySecretName: argoPrivateKeyName,
 		PrivateKeySecretKey:  privateKeyDataName,
-	}))
+	}), argoChartTimeout)
 
 	values, err := chart.ValuesYAML()
 	if err != nil {

--- a/pkg/client/core/service_autoscaler.go
+++ b/pkg/client/core/service_autoscaler.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 
+	"github.com/oslokommune/okctl/pkg/config/constant"
+
 	"github.com/oslokommune/okctl/pkg/cfn"
 	"github.com/oslokommune/okctl/pkg/cfn/components"
 
@@ -53,12 +55,10 @@ func (s *autoscalerService) DeleteAutoscaler(ctx context.Context, id api.ID) err
 		return err
 	}
 
-	chart := autoscaler.New(nil)
-
 	err = s.helm.DeleteHelmRelease(ctx, client.DeleteHelmReleaseOpts{
 		ID:          id,
-		ReleaseName: chart.ReleaseName,
-		Namespace:   chart.Namespace,
+		ReleaseName: autoscaler.ReleaseName,
+		Namespace:   autoscaler.Namespace,
 	})
 	if err != nil {
 		return err
@@ -111,7 +111,10 @@ func (s *autoscalerService) CreateAutoscaler(ctx context.Context, opts client.Cr
 		return nil, err
 	}
 
-	ch := autoscaler.New(autoscaler.NewDefaultValues(opts.ID.Region, opts.ID.ClusterName, "autoscaler"))
+	ch := autoscaler.New(
+		autoscaler.NewDefaultValues(opts.ID.Region, opts.ID.ClusterName, "autoscaler"),
+		constant.DefaultChartApplyTimeout,
+	)
 
 	values, err := ch.ValuesYAML()
 	if err != nil {

--- a/pkg/client/core/service_awsloadbalancercontroller_client.go
+++ b/pkg/client/core/service_awsloadbalancercontroller_client.go
@@ -3,6 +3,8 @@ package core // nolint: dupl
 import (
 	"context"
 
+	"github.com/oslokommune/okctl/pkg/config/constant"
+
 	"github.com/oslokommune/okctl/pkg/helm/charts/awslbc"
 
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
@@ -52,12 +54,10 @@ func (s *awsLoadBalancerControllerService) DeleteAWSLoadBalancerController(ctx c
 		return err
 	}
 
-	ch := awslbc.New(nil)
-
 	err = s.helm.DeleteHelmRelease(ctx, client.DeleteHelmReleaseOpts{
 		ID:          id,
-		ReleaseName: ch.ReleaseName,
-		Namespace:   ch.Namespace,
+		ReleaseName: awslbc.ReleaseName,
+		Namespace:   awslbc.Namespace,
 	})
 	if err != nil {
 		return err
@@ -112,7 +112,10 @@ func (s *awsLoadBalancerControllerService) CreateAWSLoadBalancerController(ctx c
 		return nil, err
 	}
 
-	ch := awslbc.New(awslbc.NewDefaultValues(opts.ID.ClusterName, opts.VPCID, opts.ID.Region))
+	ch := awslbc.New(
+		awslbc.NewDefaultValues(opts.ID.ClusterName, opts.VPCID, opts.ID.Region),
+		constant.DefaultChartApplyTimeout,
+	)
 
 	values, err := ch.ValuesYAML()
 	if err != nil {

--- a/pkg/client/core/service_blockstorage.go
+++ b/pkg/client/core/service_blockstorage.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 
+	"github.com/oslokommune/okctl/pkg/config/constant"
+
 	"github.com/oslokommune/okctl/pkg/cfn"
 	"github.com/oslokommune/okctl/pkg/cfn/components"
 
@@ -24,12 +26,10 @@ type blockstorageService struct {
 }
 
 func (s *blockstorageService) DeleteBlockstorage(ctx context.Context, id api.ID) error {
-	chart := blockstorage.New(nil)
-
 	err := s.helm.DeleteHelmRelease(ctx, client.DeleteHelmReleaseOpts{
 		ID:          id,
-		ReleaseName: chart.ReleaseName,
-		Namespace:   chart.Namespace,
+		ReleaseName: blockstorage.ReleaseName,
+		Namespace:   blockstorage.Namespace,
 	})
 	if err != nil {
 		return err
@@ -112,7 +112,10 @@ func (s *blockstorageService) CreateBlockstorage(ctx context.Context, opts clien
 		return nil, err
 	}
 
-	ch := blockstorage.New(blockstorage.NewDefaultValues(opts.ID.Region, opts.ID.ClusterName, "blockstorage"))
+	ch := blockstorage.New(
+		blockstorage.NewDefaultValues(opts.ID.Region, opts.ID.ClusterName, "blockstorage"),
+		constant.DefaultChartApplyTimeout,
+	)
 
 	values, err := ch.ValuesYAML()
 	if err != nil {

--- a/pkg/client/core/service_externalsecrets.go
+++ b/pkg/client/core/service_externalsecrets.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 
+	"github.com/oslokommune/okctl/pkg/config/constant"
+
 	"github.com/oslokommune/okctl/pkg/helm/charts/externalsecrets"
 
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
@@ -53,12 +55,10 @@ func (s *externalSecretsService) DeleteExternalSecrets(ctx context.Context, id a
 		return err
 	}
 
-	ch := externalsecrets.ExternalSecrets(nil)
-
 	err = s.helm.DeleteHelmRelease(ctx, client.DeleteHelmReleaseOpts{
 		ID:          id,
-		ReleaseName: ch.ReleaseName,
-		Namespace:   ch.Namespace,
+		ReleaseName: externalsecrets.ReleaseName,
+		Namespace:   externalsecrets.Namespace,
 	})
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func (s *externalSecretsService) CreateExternalSecrets(ctx context.Context, opts
 		return nil, err
 	}
 
-	ch := externalsecrets.ExternalSecrets(externalsecrets.DefaultExternalSecretsValues())
+	ch := externalsecrets.New(externalsecrets.DefaultExternalSecretsValues(), constant.DefaultChartApplyTimeout)
 
 	values, err := ch.ValuesYAML()
 	if err != nil {

--- a/pkg/controller/convert.go
+++ b/pkg/controller/convert.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"time"
-
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 
 	"github.com/oslokommune/okctl/pkg/helm/charts/externalsecrets"
@@ -76,16 +74,16 @@ func IdentifyResourcePresence(id api.ID, handlers *clientCore.StateHandlers) (Ex
 
 	return ExistingResources{
 		hasServiceQuotaCheck:                  false,
-		hasAWSLoadBalancerController:          !isNotFound(handlers.Helm.GetHelmRelease(awslbc.New(nil).ReleaseName)),
+		hasAWSLoadBalancerController:          !isNotFound(handlers.Helm.GetHelmRelease(awslbc.ReleaseName)),
 		hasCluster:                            !isNotFound(handlers.Cluster.GetCluster(id.ClusterName)),
 		hasExternalDNS:                        !isNotFound(handlers.ExternalDNS.GetExternalDNS()),
-		hasExternalSecrets:                    !isNotFound(handlers.Helm.GetHelmRelease(externalsecrets.ExternalSecrets(nil).ReleaseName)),
-		hasAutoscaler:                         !isNotFound(handlers.Helm.GetHelmRelease(autoscaler.New(nil).ReleaseName)),
-		hasBlockstorage:                       !isNotFound(handlers.Helm.GetHelmRelease(blockstorage.New(nil).ReleaseName)),
-		hasKubePromStack:                      !isNotFound(handlers.Helm.GetHelmRelease(kubepromstack.New(0*time.Second, nil).ReleaseName)),
-		hasLoki:                               !isNotFound(handlers.Helm.GetHelmRelease(lokipkg.New(nil).ReleaseName)),
-		hasPromtail:                           !isNotFound(handlers.Helm.GetHelmRelease(promtail.New(nil).ReleaseName)),
-		hasTempo:                              !isNotFound(handlers.Helm.GetHelmRelease(tempo.New(nil).ReleaseName)),
+		hasExternalSecrets:                    !isNotFound(handlers.Helm.GetHelmRelease(externalsecrets.ReleaseName)),
+		hasAutoscaler:                         !isNotFound(handlers.Helm.GetHelmRelease(autoscaler.ReleaseName)),
+		hasBlockstorage:                       !isNotFound(handlers.Helm.GetHelmRelease(blockstorage.ReleaseName)),
+		hasKubePromStack:                      !isNotFound(handlers.Helm.GetHelmRelease(kubepromstack.ReleaseName)),
+		hasLoki:                               !isNotFound(handlers.Helm.GetHelmRelease(lokipkg.ReleaseName)),
+		hasPromtail:                           !isNotFound(handlers.Helm.GetHelmRelease(promtail.ReleaseName)),
+		hasTempo:                              !isNotFound(handlers.Helm.GetHelmRelease(tempo.ReleaseName)),
 		hasIdentityManager:                    !isNotFound(handlers.IdentityManager.GetIdentityPool(cfn.NewStackNamer().IdentityPool(id.ClusterName))),
 		hasArgoCD:                             !isNotFound(handlers.ArgoCD.GetArgoCD()),
 		hasPrimaryHostedZone:                  !isNotFound(handlers.Domain.GetPrimaryHostedZone()),

--- a/pkg/helm/charts/argocd/argocd.go
+++ b/pkg/helm/charts/argocd/argocd.go
@@ -10,16 +10,23 @@ import (
 	"github.com/oslokommune/okctl/pkg/helm"
 )
 
+const (
+	// ReleaseName is the name of the release
+	ReleaseName = "argocd"
+	// Namespace is the default namespace
+	Namespace = "argocd"
+)
+
 // New returns an initialised Helm chart
-func New(values *Values) *helm.Chart {
+func New(values *Values, timeout time.Duration) *helm.Chart {
 	return &helm.Chart{
 		RepositoryName: "argo",
 		RepositoryURL:  "https://argoproj.github.io/argo-helm",
-		ReleaseName:    "argocd",
+		ReleaseName:    ReleaseName,
 		Version:        "2.6.2",
 		Chart:          "argo-cd",
-		Namespace:      "argocd",
-		Timeout:        5 * time.Minute, // nolint: gomnd
+		Namespace:      Namespace,
+		Timeout:        timeout,
 		Values:         values,
 	}
 }

--- a/pkg/helm/charts/autoscaler/autoscaler.go
+++ b/pkg/helm/charts/autoscaler/autoscaler.go
@@ -10,16 +10,23 @@ import (
 	"github.com/oslokommune/okctl/pkg/helm"
 )
 
+const (
+	// ReleaseName is the name of the release
+	ReleaseName = "cluster-autoscaler"
+	// Namespace is the default namespace
+	Namespace = "kube-system"
+)
+
 // New returns an initialised Helm chart for installing cluster-autoscaler
-func New(values *Values) *helm.Chart {
+func New(values *Values, timeout time.Duration) *helm.Chart {
 	return &helm.Chart{
 		RepositoryName: "autoscaler",
 		RepositoryURL:  "https://kubernetes.github.io/autoscaler",
-		ReleaseName:    "cluster-autoscaler",
+		ReleaseName:    ReleaseName,
 		Version:        "9.4.0",
 		Chart:          "cluster-autoscaler",
-		Namespace:      "kube-system",
-		Timeout:        5 * time.Minute, // nolint: gomnd
+		Namespace:      Namespace,
+		Timeout:        timeout,
 		Values:         values,
 	}
 }

--- a/pkg/helm/charts/awslbc/awslbc.go
+++ b/pkg/helm/charts/awslbc/awslbc.go
@@ -10,16 +10,23 @@ import (
 	"github.com/oslokommune/okctl/pkg/helm"
 )
 
+const (
+	// ReleaseName is the name of the release
+	ReleaseName = "aws-load-balancer-controller"
+	// Namespace is the default namespace
+	Namespace = "kube-system"
+)
+
 // New returns an initialised Helm chart for installing aws-alb-ingress-controller
-func New(values *Values) *helm.Chart {
+func New(values *Values, timeout time.Duration) *helm.Chart {
 	return &helm.Chart{
 		RepositoryName: "eks",
 		RepositoryURL:  "https://aws.github.io/eks-charts",
-		ReleaseName:    "aws-load-balancer-controller",
+		ReleaseName:    ReleaseName,
 		Version:        "1.1.3",
 		Chart:          "aws-load-balancer-controller",
-		Namespace:      "kube-system",
-		Timeout:        5 * time.Minute, // nolint: gomnd
+		Namespace:      Namespace,
+		Timeout:        timeout,
 		Values:         values,
 	}
 }

--- a/pkg/helm/charts/blockstorage/blockstorage.go
+++ b/pkg/helm/charts/blockstorage/blockstorage.go
@@ -10,16 +10,23 @@ import (
 	"github.com/oslokommune/okctl/pkg/helm"
 )
 
+const (
+	// ReleaseName is the name of the release
+	ReleaseName = "aws-ebs-csi-driver"
+	// Namespace is the default namespace
+	Namespace = "kube-system"
+)
+
 // New returns an initialised Helm chart for installing aws-ebs-csi-driver
-func New(values *Values) *helm.Chart {
+func New(values *Values, timeout time.Duration) *helm.Chart {
 	return &helm.Chart{
 		RepositoryName: "aws-ebs-csi-driver",
 		RepositoryURL:  "https://kubernetes-sigs.github.io/aws-ebs-csi-driver",
-		ReleaseName:    "aws-ebs-csi-driver",
+		ReleaseName:    ReleaseName,
 		Version:        "0.9.6",
 		Chart:          "aws-ebs-csi-driver",
-		Namespace:      "kube-system",
-		Timeout:        5 * time.Minute, // nolint: gomnd
+		Namespace:      Namespace,
+		Timeout:        timeout,
 		Values:         values,
 	}
 }

--- a/pkg/helm/charts/externalsecrets/externalsecrets.go
+++ b/pkg/helm/charts/externalsecrets/externalsecrets.go
@@ -8,6 +8,13 @@ import (
 	"github.com/oslokommune/okctl/pkg/helm"
 )
 
+const (
+	// ReleaseName is the name of the release
+	ReleaseName = "external-secrets"
+	// Namespace is the default namespace
+	Namespace = "kube-system"
+)
+
 // Values maps up the values.yaml file
 // nolint: maligned
 type Values struct {
@@ -86,17 +93,17 @@ type ServiceMonitor struct {
 	Namespace string `yaml:"namespace"`
 }
 
-// ExternalSecrets returns an initialised external secrets chart
+// New returns an initialised external secrets chart
 // - https://github.com/external-secrets/kubernetes-external-secrets/blob/master/charts/kubernetes-external-secrets/README.md
-func ExternalSecrets(values interface{}) *helm.Chart {
+func New(values interface{}, timeout time.Duration) *helm.Chart {
 	return &helm.Chart{
 		RepositoryName: "external-secrets",
 		RepositoryURL:  "https://external-secrets.github.io/kubernetes-external-secrets/",
-		ReleaseName:    "external-secrets",
+		ReleaseName:    ReleaseName,
 		Version:        "6.4.0",
 		Chart:          "kubernetes-external-secrets",
-		Namespace:      "kube-system",
-		Timeout:        5 * time.Minute, // nolint: gomnd
+		Namespace:      Namespace,
+		Timeout:        timeout,
 		Values:         values,
 	}
 }

--- a/pkg/helm/charts/kubepromstack/kubepromstack.go
+++ b/pkg/helm/charts/kubepromstack/kubepromstack.go
@@ -10,16 +10,23 @@ import (
 	"github.com/oslokommune/okctl/pkg/helm"
 )
 
+const (
+	// ReleaseName is the name of the release
+	ReleaseName = "kube-prometheus-stack"
+	// Namespace is the default namespace
+	Namespace = "monitoring"
+)
+
 // New returns an initialised helm chart:
 // - https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
-func New(timeout time.Duration, values *Values) *helm.Chart {
+func New(values *Values, timeout time.Duration) *helm.Chart {
 	return &helm.Chart{
 		RepositoryName: "prometheus-community",
 		RepositoryURL:  "https://prometheus-community.github.io/helm-charts",
-		ReleaseName:    "kube-prometheus-stack",
+		ReleaseName:    ReleaseName,
 		Version:        "13.9.1",
 		Chart:          "kube-prometheus-stack",
-		Namespace:      "monitoring",
+		Namespace:      Namespace,
 		Timeout:        timeout,
 		Values:         values,
 	}

--- a/pkg/helm/charts/loki/loki.go
+++ b/pkg/helm/charts/loki/loki.go
@@ -6,22 +6,28 @@ package loki
 import (
 	"bytes"
 	"text/template"
-
-	"github.com/oslokommune/okctl/pkg/config/constant"
+	"time"
 
 	"github.com/oslokommune/okctl/pkg/helm"
 )
 
+const (
+	// ReleaseName is the name of the release
+	ReleaseName = "loki"
+	// Namespace is the default namespace
+	Namespace = "monitoring"
+)
+
 // New returns an initialised Helm chart for installing cluster-Loki
-func New(values *Values) *helm.Chart {
+func New(values *Values, timeout time.Duration) *helm.Chart {
 	return &helm.Chart{
 		RepositoryName: "grafana",
 		RepositoryURL:  "https://grafana.github.io/helm-charts",
-		ReleaseName:    "loki",
+		ReleaseName:    ReleaseName,
 		Version:        "2.3.0",
 		Chart:          "loki",
-		Namespace:      "monitoring",
-		Timeout:        constant.DefaultChartApplyTimeout,
+		Namespace:      Namespace,
+		Timeout:        timeout,
 		Values:         values,
 	}
 }

--- a/pkg/helm/charts/promtail/promtail.go
+++ b/pkg/helm/charts/promtail/promtail.go
@@ -5,22 +5,28 @@ package promtail
 import (
 	"bytes"
 	"text/template"
-
-	"github.com/oslokommune/okctl/pkg/config/constant"
+	"time"
 
 	"github.com/oslokommune/okctl/pkg/helm"
 )
 
+const (
+	// ReleaseName is the name of the release
+	ReleaseName = "promtail"
+	// Namespace is the default namespace
+	Namespace = "monitoring"
+)
+
 // New returns an initialised Helm chart for installing cluster-promtail
-func New(values *Values) *helm.Chart {
+func New(values *Values, timeout time.Duration) *helm.Chart {
 	return &helm.Chart{
 		RepositoryName: "grafana",
 		RepositoryURL:  "https://grafana.github.io/helm-charts",
-		ReleaseName:    "promtail",
+		ReleaseName:    ReleaseName,
 		Version:        "3.1.0",
 		Chart:          "promtail",
-		Namespace:      "monitoring",
-		Timeout:        constant.DefaultChartApplyTimeout,
+		Namespace:      Namespace,
+		Timeout:        timeout,
 		Values:         values,
 	}
 }

--- a/pkg/helm/charts/tempo/tempo.go
+++ b/pkg/helm/charts/tempo/tempo.go
@@ -6,22 +6,28 @@ package tempo
 import (
 	"bytes"
 	"text/template"
-
-	"github.com/oslokommune/okctl/pkg/config/constant"
+	"time"
 
 	"github.com/oslokommune/okctl/pkg/helm"
 )
 
+const (
+	// ReleaseName is the name of the release
+	ReleaseName = "tempo"
+	// Namespace is the default namespace
+	Namespace = "monitoring"
+)
+
 // New returns an initialised Helm chart for installing cluster-tempo
-func New(values *Values) *helm.Chart {
+func New(values *Values, timeout time.Duration) *helm.Chart {
 	return &helm.Chart{
 		RepositoryName: "grafana",
 		RepositoryURL:  "https://grafana.github.io/helm-charts",
-		ReleaseName:    "tempo",
+		ReleaseName:    ReleaseName,
 		Version:        "0.6.3",
 		Chart:          "tempo",
-		Namespace:      "monitoring",
-		Timeout:        constant.DefaultChartApplyTimeout,
+		Namespace:      Namespace,
+		Timeout:        timeout,
 		Values:         values,
 	}
 }

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -160,7 +160,7 @@ func TestHelm(t *testing.T) {
 				RepoName:             "test",
 				PrivateKeySecretName: "argocd-test-oslokommune-private-key",
 				PrivateKeySecretKey:  "ssh-private-key",
-			})),
+			}), constant.DefaultChartApplyTimeout),
 			expect:    nil,
 			expectErr: false,
 		},


### PR DESCRIPTION
Make helm timeouts easier to configure.

## Description
This also increases the timeout for ArgoCD and Kubernetes Prometheus Stack to 15 minutes (from 10 and 5 minutes, respectively).

The primary purpose is to find a balance between waiting forever and not aborting too soon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
