### PR TITLE
KM275 🐛 Allow max 5 connections for pgbouncer

### DIFF
--- a/docs/release_notes/0.0.60.md
+++ b/docs/release_notes/0.0.60.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Bugfixes
+* KM275: Allow max 5 database connections for pgbouncer (used by okctl forward postgres) (#541)
 
 ## Changes
 

--- a/pkg/kube/manifests/pgbouncer/pgbouncer.go
+++ b/pkg/kube/manifests/pgbouncer/pgbouncer.go
@@ -402,6 +402,13 @@ func Pod(
 							Value: fmt.Sprintf("%d", listenPort),
 						},
 						{
+							// Default is 100, which is way more than needed.
+							// Also, for some reason, pgbouncer has been observed to create a lot of connections,
+							// which starves the actual application for connections.
+							Name:  "MAX_CLIENT_CONN",
+							Value: fmt.Sprintf("%d", 5),
+						},
+						{
 							Name: "DB_USER",
 							ValueFrom: &v1.EnvVarSource{
 								SecretKeyRef: &v1.SecretKeySelector{

--- a/pkg/kube/manifests/pgbouncer/testdata/default-pod.golden
+++ b/pkg/kube/manifests/pgbouncer/testdata/default-pod.golden
@@ -11,6 +11,8 @@ spec:
   - env:
     - name: LISTEN_PORT
       value: "5432"
+    - name: MAX_CLIENT_CONN
+      value: "5"
     - name: DB_USER
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Sometimes, pgbouncer sets up a lot of connections (up to 100) to the database (because it is in fact a connection pooler). It could potentially starve the application, depending on maximum number of connections allowed by RDS. We saw this happen for a team when using okctl forward postgres a lot.

Not sure exactly why pgbouncer establishes so many connections, but regardless, pgbbouncer should never need this anyway.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I ran okctl forward postgres in my own cluster. It works fine. Also, the pgbouncer pod's /etc/pgbouncer/pcbouncer.ini contains `max_client_conn = 5`, so it should work.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
