### PR TITLE
[KM267] Non-blocking storage operations towards storm

### DIFF
--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -127,13 +127,6 @@ func venvRunE(o *okctl.Okctl, okctlEnvironment commands.OkctlEnvironment) error 
 		}
 	}()
 
-	// Close Storm so that okctl commands running in the venv subshell can access Storm state without hitting
-	// the exclusive lock limitation: https://github.com/etcd-io/bbolt#caveats--limitations
-	err = o.StormDB.Close()
-	if err != nil {
-		return fmt.Errorf("closing storm: %w", err)
-	}
-
 	err = printWelcomeMessage(o.Out, venv, okctlEnvironment)
 	if err != nil {
 		return fmt.Errorf("could not print welcome message: %w", err)

--- a/pkg/breeze/breeze.go
+++ b/pkg/breeze/breeze.go
@@ -1,0 +1,143 @@
+package breeze
+
+import (
+	"fmt"
+
+	"github.com/asdine/storm/v3/index"
+
+	"github.com/asdine/storm/v3"
+	"github.com/asdine/storm/v3/codec/json"
+)
+
+// Breeze contains the required state
+type Breeze struct {
+	path   string
+	addend []string
+}
+
+// Client extracts the interface we are currently using from storm
+// we can simply extend this interface in the future if we want to
+// use more of the available functionality
+type Client interface {
+	All(to interface{}, options ...func(*index.Options)) error
+	AllByIndex(fieldName string, to interface{}, options ...func(*index.Options)) error
+	DeleteStruct(data interface{}) error
+	From(addend ...string) Client
+	Init(data interface{}) error
+	One(fieldName string, value interface{}, to interface{}) error
+	Save(data interface{}) error
+}
+
+// New returns an initialised client
+func New(path string) Breeze {
+	return Breeze{
+		path: path,
+	}
+}
+
+// From returns the client with the added addend, we
+// use this later on when using the storm From
+func (b Breeze) From(addend ...string) Client {
+	from := b
+	from.addend = append(from.addend, addend...)
+
+	return from
+}
+
+// Init the data type
+func (b Breeze) Init(data interface{}) error {
+	db, node, err := b.open()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = db.Close()
+	}()
+
+	return node.Init(data)
+}
+
+// AllByIndex fetches all items by using the index
+func (b Breeze) AllByIndex(fieldName string, to interface{}, options ...func(*index.Options)) error {
+	db, node, err := b.open()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = db.Close()
+	}()
+
+	return node.AllByIndex(fieldName, to, options...)
+}
+
+// All returns all items
+func (b Breeze) All(to interface{}, options ...func(*index.Options)) error {
+	db, node, err := b.open()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = db.Close()
+	}()
+
+	return node.All(to, options...)
+}
+
+// One returns one item
+func (b Breeze) One(fieldName string, value interface{}, to interface{}) error {
+	db, node, err := b.open()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = db.Close()
+	}()
+
+	return node.One(fieldName, value, to)
+}
+
+// Save the provided data
+func (b Breeze) Save(data interface{}) error {
+	db, node, err := b.open()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = db.Close()
+	}()
+
+	return node.Save(data)
+}
+
+// DeleteStruct removes the data
+func (b Breeze) DeleteStruct(data interface{}) error {
+	db, node, err := b.open()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = db.Close()
+	}()
+
+	return node.DeleteStruct(data)
+}
+
+// open the storm database
+func (b Breeze) open() (*storm.DB, storm.Node, error) {
+	db, err := storm.Open(b.path, storm.Codec(json.Codec))
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading state database: %w", err)
+	}
+
+	if b.addend != nil {
+		return db, db.From(b.addend...), nil
+	}
+
+	return db, db, nil
+}

--- a/pkg/breeze/doc.go
+++ b/pkg/breeze/doc.go
@@ -1,0 +1,7 @@
+// Package breeze provides a wrapper around storm
+// for opening and closing the database as required
+// instead of keeping the connection open over
+// and unlimited timespan. This means storage
+// operations will take longer, but we won't
+// block other actions.
+package breeze

--- a/pkg/client/core/handler_client.go
+++ b/pkg/client/core/handler_client.go
@@ -1,28 +1,28 @@
 package core
 
 import (
-	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 // StateNodes contains all state storage nodes
 type StateNodes struct {
-	ArgoCD              stormpkg.Node
-	Certificate         stormpkg.Node
-	Cluster             stormpkg.Node
-	Domain              stormpkg.Node
-	ExternalDNS         stormpkg.Node
-	Github              stormpkg.Node
-	Manifest            stormpkg.Node
-	Parameter           stormpkg.Node
-	Vpc                 stormpkg.Node
-	IdentityManager     stormpkg.Node
-	Monitoring          stormpkg.Node
-	Component           stormpkg.Node
-	Helm                stormpkg.Node
-	ManagedPolicy       stormpkg.Node
-	ServiceAccount      stormpkg.Node
-	ContainerRepository stormpkg.Node
+	ArgoCD              breeze.Client
+	Certificate         breeze.Client
+	Cluster             breeze.Client
+	Domain              breeze.Client
+	ExternalDNS         breeze.Client
+	Github              breeze.Client
+	Manifest            breeze.Client
+	Parameter           breeze.Client
+	Vpc                 breeze.Client
+	IdentityManager     breeze.Client
+	Monitoring          breeze.Client
+	Component           breeze.Client
+	Helm                breeze.Client
+	ManagedPolicy       breeze.Client
+	ServiceAccount      breeze.Client
+	ContainerRepository breeze.Client
 }
 
 // StateHandlers contains the state handlers

--- a/pkg/client/core/state/storm/argocd_state.go
+++ b/pkg/client/core/state/storm/argocd_state.go
@@ -4,12 +4,14 @@ import (
 	"errors"
 	"time"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
+
 	stormpkg "github.com/asdine/storm/v3"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type argoCDState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // ArgoCD contains state about an argo cd deployment
@@ -96,7 +98,7 @@ func (a *argoCDState) RemoveArgoCD() error {
 }
 
 // NewArgoCDState returns an initialised state client
-func NewArgoCDState(node stormpkg.Node) client.ArgoCDState {
+func NewArgoCDState(node breeze.Client) client.ArgoCDState {
 	return &argoCDState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/argocd_state_test.go
+++ b/pkg/client/core/state/storm/argocd_state_test.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
+
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +23,7 @@ func TestArgoCDStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.ArgoCD{})
 	assert.NoError(t, err)
@@ -57,8 +56,5 @@ func TestArgoCDStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveArgoCD()
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/certificate_state.go
+++ b/pkg/client/core/state/storm/certificate_state.go
@@ -4,12 +4,14 @@ import (
 	"errors"
 	"time"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
+
 	stormpkg "github.com/asdine/storm/v3"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type certificateState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // Certificate contains storm compatible state
@@ -103,7 +105,7 @@ func (c *certificateState) RemoveCertificate(domain string) error {
 }
 
 // NewCertificateState returns an initialised state store
-func NewCertificateState(node stormpkg.Node) client.CertificateState {
+func NewCertificateState(node breeze.Client) client.CertificateState {
 	return &certificateState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/certificate_state_test.go
+++ b/pkg/client/core/state/storm/certificate_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestCertificateStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.Certificate{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestCertificateStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveCertificate(mock.DefaultDomain)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/cluster_state.go
+++ b/pkg/client/core/state/storm/cluster_state.go
@@ -6,11 +6,12 @@ import (
 
 	stormpkg "github.com/asdine/storm/v3"
 	"github.com/oslokommune/okctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type clusterState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // Cluster contains storm compatible state
@@ -92,7 +93,7 @@ func (c *clusterState) RemoveCluster(name string) error {
 }
 
 // NewClusterState returns an initialised state client
-func NewClusterState(node stormpkg.Node) client.ClusterState {
+func NewClusterState(node breeze.Client) client.ClusterState {
 	return &clusterState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/cluster_state_test.go
+++ b/pkg/client/core/state/storm/cluster_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestClusterStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.Cluster{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestClusterStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveCluster(mock.DefaultClusterName)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/component_state.go
+++ b/pkg/client/core/state/storm/component_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type componentState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // PostgresDatabase contains storm compatible state
@@ -178,7 +179,7 @@ func (c *componentState) GetPostgresDatabases() ([]*client.PostgresDatabase, err
 }
 
 // NewComponentState returns an initialised state client
-func NewComponentState(node stormpkg.Node) client.ComponentState {
+func NewComponentState(node breeze.Client) client.ComponentState {
 	return &componentState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/component_state_test.go
+++ b/pkg/client/core/state/storm/component_state_test.go
@@ -6,12 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,8 +24,7 @@ func TestPostgresStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.PostgresDatabase{})
 	assert.NoError(t, err)
@@ -52,8 +50,5 @@ func TestPostgresStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemovePostgresDatabase(mock.StackNamePostgresDatabase)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/container_repository_state.go
+++ b/pkg/client/core/state/storm/container_repository_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type containerRepositoryState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // ContainerRepository contains storm compatible state
@@ -94,7 +95,7 @@ func (c *containerRepositoryState) getContainerRepository(imageName string) (*Co
 }
 
 // NewContainerRepositoryState returns an initialised state client
-func NewContainerRepositoryState(node stormpkg.Node) client.ContainerRepositoryState {
+func NewContainerRepositoryState(node breeze.Client) client.ContainerRepositoryState {
 	return &containerRepositoryState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/container_repository_state_test.go
+++ b/pkg/client/core/state/storm/container_repository_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestContainerRepositoryStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.ContainerRepository{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestContainerRepositoryStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveContainerRepository(mock.DefaultImage)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/domain_state.go
+++ b/pkg/client/core/state/storm/domain_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type domainState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // HostedZone contains storm compatible state
@@ -150,7 +151,7 @@ func (d *domainState) GetPrimaryHostedZone() (*client.HostedZone, error) {
 }
 
 // NewDomainState returns an initialised state store
-func NewDomainState(db stormpkg.Node) client.DomainState {
+func NewDomainState(db breeze.Client) client.DomainState {
 	return &domainState{
 		node: db,
 	}

--- a/pkg/client/core/state/storm/domain_state_test.go
+++ b/pkg/client/core/state/storm/domain_state_test.go
@@ -6,12 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,8 +24,7 @@ func TestDomainStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.HostedZone{})
 	assert.NoError(t, err)
@@ -56,8 +54,5 @@ func TestDomainStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveHostedZone(mock.DefaultDomain)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/externaldns_state.go
+++ b/pkg/client/core/state/storm/externaldns_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type externalDNSState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // ExternalDNS contains storm compatible state
@@ -127,7 +128,7 @@ func (e *externalDNSState) RemoveExternalDNS() error {
 }
 
 // NewExternalDNSState returns an initialised state
-func NewExternalDNSState(node stormpkg.Node) client.ExternalDNSState {
+func NewExternalDNSState(node breeze.Client) client.ExternalDNSState {
 	return &externalDNSState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/externaldns_state_test.go
+++ b/pkg/client/core/state/storm/externaldns_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestExternalDNSStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.ExternalDNS{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestExternalDNSStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveExternalDNS()
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/github_state.go
+++ b/pkg/client/core/state/storm/github_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type githubState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // GithubRepository contains storm compatible state
@@ -159,7 +160,7 @@ func (g *githubState) getGithubRepository(fullName string) (*GithubRepository, e
 }
 
 // NewGithubState returns an initialised state client
-func NewGithubState(node stormpkg.Node) client.GithubState {
+func NewGithubState(node breeze.Client) client.GithubState {
 	return &githubState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/github_state_test.go
+++ b/pkg/client/core/state/storm/github_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestGithubRepositoryStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.GithubRepository{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestGithubRepositoryStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveGithubRepository(mock.DefaultGithubFullName)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/helm_state.go
+++ b/pkg/client/core/state/storm/helm_state.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
+
 	stormpkg "github.com/asdine/storm/v3"
 	"github.com/oslokommune/okctl/pkg/client"
 	"github.com/oslokommune/okctl/pkg/helm"
@@ -11,7 +13,7 @@ import (
 )
 
 type helmState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // Helm contains storm compatible state
@@ -95,7 +97,7 @@ func (h *helmState) getHelmRelease(releaseName string) (*Helm, error) {
 }
 
 // NewHelmState returns an initialised helm state
-func NewHelmState(node stormpkg.Node) client.HelmState {
+func NewHelmState(node breeze.Client) client.HelmState {
 	return &helmState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/helm_state_test.go
+++ b/pkg/client/core/state/storm/helm_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestHelmStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.Helm{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestHelmStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveHelmRelease(mock.DefaultHelmReleaseName)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/identitymanager_state.go
+++ b/pkg/client/core/state/storm/identitymanager_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type identityManagerState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // IdentityPool contains storm compatible state
@@ -312,7 +313,7 @@ func (s *identityManagerState) SaveIdentityPoolUser(user *client.IdentityPoolUse
 }
 
 // NewIdentityManager returns an initialised state
-func NewIdentityManager(node stormpkg.Node) client.IdentityManagerState {
+func NewIdentityManager(node breeze.Client) client.IdentityManagerState {
 	return &identityManagerState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/identitymanager_state_test.go
+++ b/pkg/client/core/state/storm/identitymanager_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestIdentityPoolStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.IdentityPool{})
 	assert.NoError(t, err)
@@ -47,9 +45,6 @@ func TestIdentityPoolStateScenario(t *testing.T) {
 
 	err = state.RemoveIdentityPool(mock.StackNameIdentityPool)
 	assert.NoError(t, err)
-
-	err = db.Close()
-	assert.NoError(t, err)
 }
 
 func TestIdentityPoolClientStateScenario(t *testing.T) {
@@ -61,8 +56,7 @@ func TestIdentityPoolClientStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.IdentityPoolClient{})
 	assert.NoError(t, err)
@@ -84,9 +78,6 @@ func TestIdentityPoolClientStateScenario(t *testing.T) {
 
 	err = state.RemoveIdentityPoolClient(mock.StackNameIdentityPoolClient)
 	assert.NoError(t, err)
-
-	err = db.Close()
-	assert.NoError(t, err)
 }
 
 func TestIdentityPoolUserStateScenario(t *testing.T) {
@@ -98,8 +89,7 @@ func TestIdentityPoolUserStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.IdentityPoolUser{})
 	assert.NoError(t, err)
@@ -121,8 +111,5 @@ func TestIdentityPoolUserStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveIdentityPoolUser(mock.StackNameIdentityPoolUser)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/managedpolicy_state.go
+++ b/pkg/client/core/state/storm/managedpolicy_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type managedPolicyState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // ManagedPolicy contains storm compatible state
@@ -94,7 +95,7 @@ func (m *managedPolicyState) RemovePolicy(stackName string) error {
 }
 
 // NewManagedPolicyState returns an initialised managed policy state
-func NewManagedPolicyState(node stormpkg.Node) client.ManagedPolicyState {
+func NewManagedPolicyState(node breeze.Client) client.ManagedPolicyState {
 	return &managedPolicyState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/managedpolicy_state_test.go
+++ b/pkg/client/core/state/storm/managedpolicy_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestManagedPolicyStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.ManagedPolicy{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestManagedPolicyStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemovePolicy(mock.StackNameManagedPolicy)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/manifest_state.go
+++ b/pkg/client/core/state/storm/manifest_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type manifestState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // KubernetesManifest contains storm compatible state
@@ -97,7 +98,7 @@ func (s *manifestState) RemoveKubernetesManifests(name string) error {
 }
 
 // NewManifestState returns an initialised manifest state
-func NewManifestState(node stormpkg.Node) client.ManifestState {
+func NewManifestState(node breeze.Client) client.ManifestState {
 	return &manifestState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/manifest_state_test.go
+++ b/pkg/client/core/state/storm/manifest_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestManifestStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.KubernetesManifest{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestManifestStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveKubernetesManifests(mock.DefaultManifestName)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/monitoring_state.go
+++ b/pkg/client/core/state/storm/monitoring_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type monitoringState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // KubePromStack contains storm compatible state
@@ -120,7 +121,7 @@ func (m *monitoringState) getKubePromStack() (*KubePromStack, error) {
 }
 
 // NewMonitoringState returns an initialised state client
-func NewMonitoringState(node stormpkg.Node) client.MonitoringState {
+func NewMonitoringState(node breeze.Client) client.MonitoringState {
 	return &monitoringState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/monitoring_state_test.go
+++ b/pkg/client/core/state/storm/monitoring_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestKubePromStackStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.KubePromStack{})
 	assert.NoError(t, err)
@@ -54,8 +52,5 @@ func TestKubePromStackStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveKubePromStack()
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/parameter_state.go
+++ b/pkg/client/core/state/storm/parameter_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type parameterState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // SecretParameter contains storm compatible state
@@ -95,7 +96,7 @@ func (p *parameterState) RemoveSecret(name string) error {
 }
 
 // NewParameterState returns an initialised state
-func NewParameterState(node stormpkg.Node) client.ParameterState {
+func NewParameterState(node breeze.Client) client.ParameterState {
 	return &parameterState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/parameter_state_test.go
+++ b/pkg/client/core/state/storm/parameter_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestParameterStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.SecretParameter{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestParameterStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveSecret(mock.DefaultSecretParameterName)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/serviceaccount_state.go
+++ b/pkg/client/core/state/storm/serviceaccount_state.go
@@ -6,6 +6,7 @@ import (
 
 	stormpkg "github.com/asdine/storm/v3"
 	"github.com/oslokommune/okctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
@@ -41,7 +42,7 @@ func (sa *ServiceAccount) Convert() *client.ServiceAccount {
 }
 
 type serviceAccountState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 func (s *serviceAccountState) SaveServiceAccount(account *client.ServiceAccount) error {
@@ -99,7 +100,7 @@ func (s *serviceAccountState) UpdateServiceAccount(account *client.ServiceAccoun
 }
 
 // NewServiceAccountState returns an initialised state store
-func NewServiceAccountState(node stormpkg.Node) client.ServiceAccountState {
+func NewServiceAccountState(node breeze.Client) client.ServiceAccountState {
 	return &serviceAccountState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/serviceaccount_state_test.go
+++ b/pkg/client/core/state/storm/serviceaccount_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestServiceAccountStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.ServiceAccount{})
 	assert.NoError(t, err)
@@ -50,8 +48,5 @@ func TestServiceAccountStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveServiceAccount(mock.DefaultServiceAccountName)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/client/core/state/storm/vpc_state.go
+++ b/pkg/client/core/state/storm/vpc_state.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client"
 )
 
 type vpcState struct {
-	node stormpkg.Node
+	node breeze.Client
 }
 
 // Vpc contains storm compatible state
@@ -170,7 +171,7 @@ func (v *vpcState) RemoveVpc(stackName string) error {
 }
 
 // NewVpcState returns an initialised state client
-func NewVpcState(node stormpkg.Node) client.VPCState {
+func NewVpcState(node breeze.Client) client.VPCState {
 	return &vpcState{
 		node: node,
 	}

--- a/pkg/client/core/state/storm/vpc_state_test.go
+++ b/pkg/client/core/state/storm/vpc_state_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/breeze"
 	"github.com/oslokommune/okctl/pkg/client/mock"
 
-	stormpkg "github.com/asdine/storm/v3"
-	"github.com/asdine/storm/v3/codec/json"
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +22,7 @@ func TestVpcStateScenario(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	db, err := stormpkg.Open(filepath.Join(dir, "storm.db"), stormpkg.Codec(json.Codec))
-	assert.NoError(t, err)
+	db := breeze.New(filepath.Join(dir, "storm.db"))
 
 	err = db.Init(&storm.Vpc{})
 	assert.NoError(t, err)
@@ -46,8 +44,5 @@ func TestVpcStateScenario(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = state.RemoveVpc(mock.StackNameVpc)
-	assert.NoError(t, err)
-
-	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -12,9 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/asdine/storm/v3/codec/json"
-
-	stormpkg "github.com/asdine/storm/v3"
+	"github.com/oslokommune/okctl/pkg/breeze"
 
 	"github.com/oslokommune/okctl/pkg/client/core/state/storm"
 
@@ -64,7 +62,7 @@ type Okctl struct {
 	BinariesProvider    binaries.Provider
 	CredentialsProvider credentials.Provider
 
-	StormDB *stormpkg.DB
+	DB breeze.Client
 
 	restClient      *rest.HTTPClient
 	kubeConfigStore api.KubeConfigStore
@@ -121,22 +119,22 @@ $ cat %s
 // StateNodes returns the initialised state nodes
 func (o *Okctl) StateNodes() *clientCore.StateNodes {
 	return &clientCore.StateNodes{
-		ArgoCD:              o.StormDB.From(constant.DefaultStormNodeArgoCD),
-		Certificate:         o.StormDB.From(constant.DefaultStormNodeCertificates),
-		Cluster:             o.StormDB.From(constant.DefaultStormNodeCluster),
-		Domain:              o.StormDB.From(constant.DefaultStormNodeDomains),
-		ExternalDNS:         o.StormDB.From(constant.DefaultStormNodeExternalDNS),
-		Github:              o.StormDB.From(constant.DefaultStormNodeGithub),
-		Manifest:            o.StormDB.From(constant.DefaultStormNodeKubernetesManifest),
-		Parameter:           o.StormDB.From(constant.DefaultStormNodeParameter),
-		Vpc:                 o.StormDB.From(constant.DefaultStormNodeVpc),
-		IdentityManager:     o.StormDB.From(constant.DefaultStormNodeIdentityManager),
-		Monitoring:          o.StormDB.From(constant.DefaultStormNodeMonitoring),
-		Component:           o.StormDB.From(constant.DefaultStormNodeComponent),
-		Helm:                o.StormDB.From(constant.DefaultStormNodeHelm),
-		ManagedPolicy:       o.StormDB.From(constant.DefaultStormNodeManagedPolicy),
-		ServiceAccount:      o.StormDB.From(constant.DefaultStormNodeServiceAccount),
-		ContainerRepository: o.StormDB.From(constant.DefaultStormNodeContainerRepository),
+		ArgoCD:              o.DB.From(constant.DefaultStormNodeArgoCD),
+		Certificate:         o.DB.From(constant.DefaultStormNodeCertificates),
+		Cluster:             o.DB.From(constant.DefaultStormNodeCluster),
+		Domain:              o.DB.From(constant.DefaultStormNodeDomains),
+		ExternalDNS:         o.DB.From(constant.DefaultStormNodeExternalDNS),
+		Github:              o.DB.From(constant.DefaultStormNodeGithub),
+		Manifest:            o.DB.From(constant.DefaultStormNodeKubernetesManifest),
+		Parameter:           o.DB.From(constant.DefaultStormNodeParameter),
+		Vpc:                 o.DB.From(constant.DefaultStormNodeVpc),
+		IdentityManager:     o.DB.From(constant.DefaultStormNodeIdentityManager),
+		Monitoring:          o.DB.From(constant.DefaultStormNodeMonitoring),
+		Component:           o.DB.From(constant.DefaultStormNodeComponent),
+		Helm:                o.DB.From(constant.DefaultStormNodeHelm),
+		ManagedPolicy:       o.DB.From(constant.DefaultStormNodeManagedPolicy),
+		ServiceAccount:      o.DB.From(constant.DefaultStormNodeServiceAccount),
+		ContainerRepository: o.DB.From(constant.DefaultStormNodeContainerRepository),
 	}
 }
 
@@ -371,7 +369,7 @@ func (o *Okctl) initialise() error {
 		return err
 	}
 
-	err = o.initialiseStorm()
+	err = o.initialiseBreeze()
 	if err != nil {
 		return err
 	}
@@ -563,18 +561,15 @@ func (o *Okctl) waitForServer() error {
 	}
 }
 
-func (o *Okctl) initialiseStorm() error {
+func (o *Okctl) initialiseBreeze() error {
 	outputDir, err := o.GetRepoOutputDir()
 	if err != nil {
 		return err
 	}
 
-	s, err := stormpkg.Open(path.Join(outputDir, constant.DefaultStormDBName), stormpkg.Codec(json.Codec))
-	if err != nil {
-		return fmt.Errorf("loading state database: %w", err)
-	}
+	db := breeze.New(path.Join(outputDir, constant.DefaultStormDBName))
 
-	o.StormDB = s
+	o.DB = db
 
 	return nil
 }


### PR DESCRIPTION
Non-blocking storage operations towards storm

## Description
Create a small wrapper around the storm operations we are currently using, where the storage operations now open and close the database for each action. This will increase the time it takes to perform a storage operation, but it means we only block multiple access for short intervals of time

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
