### PR TITLE
[NOTASK] Break out of the loop, not switch when describing listeners

### DIFF
--- a/pkg/elbv2api/elbv2api.go
+++ b/pkg/elbv2api/elbv2api.go
@@ -30,6 +30,7 @@ func (a *ELBv2API) GetListenersForLoadBalancer(loadbalancerARN string) ([]*elbv2
 
 	var all []*elbv2.Listener
 
+DESCRIBE:
 	for {
 		listeners, err := a.provider.ELBV2().DescribeListeners(&elbv2.DescribeListenersInput{
 			LoadBalancerArn: aws.String(loadbalancerARN),
@@ -41,7 +42,7 @@ func (a *ELBv2API) GetListenersForLoadBalancer(loadbalancerARN string) ([]*elbv2
 				case elbv2.ErrCodeLoadBalancerNotFoundException:
 					// If the load balancer doesn't exist, not much
 					// point in continuing..
-					break
+					break DESCRIBE
 				}
 			}
 

--- a/pkg/elbv2api/elbv2api_test.go
+++ b/pkg/elbv2api/elbv2api_test.go
@@ -1,7 +1,10 @@
 package elbv2api_test
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
 
 	"github.com/oslokommune/okctl/pkg/elbv2api"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +26,6 @@ func TestELBv2API_GetListenersForLoadBalancer(t *testing.T) {
 		expect    interface{}
 		expectErr bool
 	}{
-		// What a stupid test
 		{
 			name:     "Should work",
 			provider: mock.NewGoodCloudProvider(),
@@ -38,6 +40,14 @@ func TestELBv2API_GetListenersForLoadBalancer(t *testing.T) {
 					ListenerArn: aws.String(mock.DefaultListenerARN),
 				},
 			},
+			expectErr: false,
+		},
+		{
+			name: "Should ignore lb not found",
+			provider: mock.NewGoodCloudProvider().
+				DescribeListenersResponse(nil, awserr.New(elbv2.ErrCodeLoadBalancerNotFoundException, "", errors.New("something"))),
+			arn:       mock.DefaultLoadBalancerARN,
+			expect:    []*elbv2.Listener(nil),
 			expectErr: false,
 		},
 		{

--- a/pkg/mock/aws.go
+++ b/pkg/mock/aws.go
@@ -614,6 +614,15 @@ func (p *CloudProvider) PrincipalARN() string {
 	return "arn:::::/someuser"
 }
 
+// DescribeListenersResponse returns the provided values
+func (p *CloudProvider) DescribeListenersResponse(output *elbv2.DescribeListenersOutput, err error) *CloudProvider {
+	p.ELBv2API.DescribeListenersFn = func(*elbv2.DescribeListenersInput) (*elbv2.DescribeListenersOutput, error) {
+		return output, err
+	}
+
+	return p
+}
+
 // NewCloudProvider returns a mocked cloud provider with no mocks sets
 func NewCloudProvider() *CloudProvider {
 	return &CloudProvider{


### PR DESCRIPTION
Break out of the loop, not switch when describing listeners

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
