### PR TITLE
Move *-credentials-type flags to top level

### DIFF
--- a/cmd/okctl/apply_cluster.go
+++ b/cmd/okctl/apply_cluster.go
@@ -20,7 +20,6 @@ import (
 	"github.com/oslokommune/okctl/pkg/config/constant"
 
 	"github.com/oslokommune/okctl/pkg/commands"
-	"github.com/oslokommune/okctl/pkg/context"
 
 	"github.com/logrusorgru/aurora"
 
@@ -35,11 +34,9 @@ import (
 )
 
 type applyClusterOpts struct {
-	AWSCredentialsType    string
-	GithubCredentialsType string
-	DisableSpinner        bool
-	File                  string
-	Declaration           *v1alpha1.Cluster
+	DisableSpinner bool
+	File           string
+	Declaration    *v1alpha1.Cluster
 }
 
 // Validate ensures the applyClusterOpts contains the right information
@@ -72,9 +69,6 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 			return nil
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
-			o.AWSCredentialsType = opts.AWSCredentialsType
-			o.GithubCredentialsType = opts.GithubCredentialsType
-
 			opts.Declaration, err = commands.InferClusterFromStdinOrFile(o.In, opts.File)
 			if err != nil {
 				return fmt.Errorf("inferring cluster: %w", err)
@@ -218,31 +212,11 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 
 	flags := cmd.Flags()
 
-	flags.StringVarP(&opts.AWSCredentialsType,
-		"aws-credentials-type",
-		"a",
-		context.AWSCredentialsTypeSAML,
-		fmt.Sprintf(
-			"The form of authentication to use for AWS. Possible values: [%s,%s]",
-			context.AWSCredentialsTypeSAML,
-			context.AWSCredentialsTypeAccessKey,
-		),
-	)
 	flags.StringVarP(&opts.File,
 		"file",
 		"f",
 		"",
 		usageApplyClusterFile,
-	)
-	flags.StringVarP(&opts.GithubCredentialsType,
-		"github-credentials-type",
-		"g",
-		context.GithubCredentialsTypeDeviceAuthentication,
-		fmt.Sprintf(
-			"The form of authentication to use for Github. Possible values: [%s,%s]",
-			context.GithubCredentialsTypeDeviceAuthentication,
-			context.GithubCredentialsTypeToken,
-		),
 	)
 	flags.BoolVar(&opts.DisableSpinner,
 		"no-spinner",

--- a/cmd/okctl/main.go
+++ b/cmd/okctl/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/oslokommune/okctl/pkg/api/core"
 	"github.com/oslokommune/okctl/pkg/config/load"
+	"github.com/oslokommune/okctl/pkg/context"
 	"github.com/oslokommune/okctl/pkg/okctl"
 	"github.com/spf13/cobra"
 )
@@ -41,7 +42,7 @@ func loadUserData(o *okctl.Okctl, cmd *cobra.Command) error {
 
 //nolint:funlen,govet
 func buildRootCommand() *cobra.Command {
-	var outputFormat, declarationPath string
+	var outputFormat, declarationPath, awsCredentialsType, githubCredentialsType string
 
 	o := okctl.New()
 
@@ -60,6 +61,9 @@ being captured. Together with slack and slick.`,
 			if cmd.Name() == cobra.ShellCompRequestCmd {
 				return nil
 			}
+
+			o.AWSCredentialsType = awsCredentialsType
+			o.GithubCredentialsType = githubCredentialsType
 
 			var err error
 
@@ -123,6 +127,26 @@ being captured. Together with slack and slick.`,
 		"c",
 		os.Getenv(fmt.Sprintf("%s_%s", constant.EnvPrefix, constant.EnvClusterDeclaration)),
 		"The cluster declaration you want to use",
+	)
+	cmd.PersistentFlags().StringVarP(&awsCredentialsType,
+		"aws-credentials-type",
+		"a",
+		context.AWSCredentialsTypeSAML,
+		fmt.Sprintf(
+			"The form of authentication to use for AWS. Possible values: [%s,%s]",
+			context.AWSCredentialsTypeSAML,
+			context.AWSCredentialsTypeAccessKey,
+		),
+	)
+	cmd.PersistentFlags().StringVarP(&githubCredentialsType,
+		"github-credentials-type",
+		"g",
+		context.GithubCredentialsTypeDeviceAuthentication,
+		fmt.Sprintf(
+			"The form of authentication to use for Github. Possible values: [%s,%s]",
+			context.GithubCredentialsTypeDeviceAuthentication,
+			context.GithubCredentialsTypeToken,
+		),
 	)
 
 	return cmd

--- a/docs/release_notes/0.0.63.md
+++ b/docs/release_notes/0.0.63.md
@@ -10,6 +10,8 @@ KM302 🐛 Fix broken validation for vpc.highAvailability setting (#580)
 
 ## Changes
 
+👌 Move aws-credentials-type and github-credentials-type flags from `apply cluster` command to top level (#587)
+
 ## Other
 
 KM279 👌 Make integration tests toggleable


### PR DESCRIPTION
aws-credentials-type and github-credentials-type flags were located on
the `apply cluster` command. This patch moves them to the top level, so
they work with other commands that also talks to AWS/Github.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
