### PR TITLE
KM263: Add 80 listener port in kubepromstack-alb, to enable https red…

### DIFF
--- a/docs/release_notes/0.0.63.md
+++ b/docs/release_notes/0.0.63.md
@@ -19,3 +19,5 @@ KM309 🐛 Fix broken access key authentication type for apply cluster (#593)
 KM279 👌 Make integration tests toggleable
 
 KM256 👌 Soften password constrains for cognito users
+
+KM263 👌 Fix grafana https redirect

--- a/pkg/helm/charts/kubepromstack/kubepromstack.go
+++ b/pkg/helm/charts/kubepromstack/kubepromstack.go
@@ -684,6 +684,7 @@ grafana:
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/target-type: instance
       alb.ingress.kubernetes.io/healthcheck-path: /api/health
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
       alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
       alb.ingress.kubernetes.io/certificate-arn: {{ .GrafanaCertificateARN }}
 

--- a/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
+++ b/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
@@ -616,6 +616,7 @@ grafana:
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/target-type: instance
       alb.ingress.kubernetes.io/healthcheck-path: /api/health
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
       alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
       alb.ingress.kubernetes.io/certificate-arn: arn::1234567890/certificate/fake
 


### PR DESCRIPTION
Enable https redirect for grafana

## Motivation and Context
Did not work without putting https:// in front of url before

## How Has This Been Tested?
Manually edited with 
`kubectl -n monitoring edit ing kube-prometheus-stack-grafana`
And added the same line as in diff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
