### PR TITLE
KM315 🐛 Cast to PostgresReconcilerState pointer

### DIFF
--- a/docs/release_notes/0.0.63.md
+++ b/docs/release_notes/0.0.63.md
@@ -10,6 +10,8 @@ KM302 🐛 Fix broken validation for vpc.highAvailability setting (#580)
 
 KM309 🐛 Fix broken access key authentication type for apply cluster (#593)
 
+KM315 🐛 Fix reconciliation of Postgres breaking (#606)
+
 ## Changes
 
 👌 Move aws-credentials-type and github-credentials-type flags from `apply cluster` command to top level (#587)
@@ -21,3 +23,4 @@ KM279 👌 Make integration tests toggleable
 KM256 👌 Soften password constrains for cognito users
 
 KM263 👌 Fix grafana https redirect
+

--- a/pkg/controller/cluster/synchronization.go
+++ b/pkg/controller/cluster/synchronization.go
@@ -181,10 +181,7 @@ func applyExistingState(existingResources ExistingResources) dependencytree.Appl
 		NextDb:
 			for _, existingDB := range existingResources.hasPostgres {
 				for _, declaredDB := range receiver.Children {
-					data, ok := declaredDB.Data.(clusterrec.PostgresReconcilerState)
-					if !ok {
-						panic("could not cast to database state")
-					}
+					data := declaredDB.Data.(*clusterrec.PostgresReconcilerState)
 
 					if data.DB.Name == existingDB.Name {
 						declaredDB.State = dependencytree.NodeStatePresent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Cast to `*clusterrec.PostgresReconcilerState` instead of `clusterrec.PostgresReconcilerState`
* I also removed the cast check because:
Today I learned that the actual error message when a cast fails is useful for debugging for the developer. With the check, the output is:

```
could not cast to database state
```

but without the check, we get the actual error

```
panic: interface conversion: interface {} is *reconciliation.PostgresReconcilerState, not reconciliation.PostgresReconcilerState
```

It was quite hard to spot the missing `*` in the IntelliJ debugger, so this error helped. UX is another thing, if we want a nice error to the user, then we should probably print something nicer.

Not adding tests because [KM305](https://trello.com/c/ws2w0db9/305-clean-up-tree-structure) will rewrite the whole reconciliation soon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

* Ran okctl apply cluster on my own cluster, this change fixed the issue
* Ran existing unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
