### PR TITLE
KM-188: Add CI documentation

### DIFF
--- a/userdocs/mkdocs.yml
+++ b/userdocs/mkdocs.yml
@@ -17,7 +17,8 @@ nav:
       - 6. View bundled applications: getting-started/view-bundled-applications.md
       - 7. Monitoring your cluster and applications: getting-started/monitoring.md
       - 8. Application addons: getting-started/application-addons.md
-      - 9. Delete cluster: getting-started/clean-up.md
+      - 9. Continuous integration: getting-started/continuous-integration.md
+      - 10. Delete cluster: getting-started/clean-up.md
   - Building blocks:
     - buildingblocks/cloud.md
     - buildingblocks/github.md

--- a/userdocs/src/getting-started/continuous-integration.md
+++ b/userdocs/src/getting-started/continuous-integration.md
@@ -1,0 +1,61 @@
+#Continuous Integration
+
+The following guide is to help set up continuous integration for an application running on a cluster set up with okctl.
+For this example and in the reference app we will be using github actions
+
+## Prerequisites
+
+It is assumed that you already have set up a cluster, and that you have applied your application so that it runs there
+Now you are ready to set up continuous integration, so that every push to main will deploy your app
+to your dev cluster, and a tag to main will deploy your app to your production cluster.
+
+You need a IAM user with credentials that you can use for github actions. You need to create credentials for both your
+and prod environment: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey
+
+Github repositories used in this guide as a working example
+1. Application repository (https://github.com/oslokommune/okctl-kotlin-app-template)
+2. IAC repo (https://github.com/oslokommune/okctl-template-iac)
+
+
+Generate a secret key in your IAC repo
+```bash
+# We will generate a key inside a separate secret directory to ensure it will not get mixed up with anything else
+mkdir secret
+# Gitignore that directory, so tehre will be no accidental commits
+echo secret/* >> .gitignore
+
+cd secret
+# We use stronger encryption than a default key for added security
+ssh-keygen -t rsa -b 4096 -f cluster_deploy_key -C git@github.com:oslokommune/okctl-template-iac.git
+```
+
+**NOTE:** The -C parameter of the ssh-keygen command, which is the comment for the public-key, needs to be the git@github address for your IAC repo, this is because it will be needed by github actions later.
+
+1. Go to your settings/secrets under your application
+https://github.com/oslokommune/okctl-kotlin-app-template/settings/secrets/actions
+
+1. Add **Repository**secret (it will be the same for dev and produdction) named CLUSTER_DEPLOY_KEY, paste the contnetns of
+cluster_deploy_key (the private key) that you generated earlier
+
+1. Create a **dev** and a **prod** environment (only available in github enterprise):
+https://github.com/oslokommune/okctl-kotlin-app-template/settings/environments
+
+1. Create *Environment*secrets for
+   * AWS_ECR_ACCESS_KEY_ID
+   * AWS_ECR_ACCESS_KEY_SECRET
+
+    Here you will place values for AWS_ACCESS_KEY_ID and AWS_ACCESS_KEY_SECRET that you created earlier for each account
+1. Go to your IAC repo (https://github.com/oslokommune/okctl-template-iac/settings/keys)
+1. Add a new deploy key called cluster_deploy_key, using the value in `cluster_deploy_key.pub`, that you generated earlier NOTE: Make sure you check the `Allow write access` checkbox
+
+## Setup github actions workflow files
+
+Use templates found here: https://github.com/oslokommune/okctl-kotlin-app-template/tree/main/.github/workflows
+
+You need to edit the following:
+* jobs -> docker-build-push -> steps[0] -> with -> aws-region (if you run somewhere else than Ireland)
+* jobs -> docker-build-push -> steps[1] -> env -> ECR_REPOSITORY (name of your ecr_repositroy, i.e. kotlin-test-app)
+* jobs -> update-tag -> steps[0] -> with -> repository (your iac-repository, i.e oslokommune/okctl-template-iac)
+* jobs -> update-tag -> steps[0] -> env -> CONTAINER_NAME (name of the container, i.e kotlin-test-app)
+* jobs -> update-tag -> steps[0] -> env -> DEPLOYMENT_YAML_FILE (location of overlay deployment patch file: i.e infrastructure/applications/kotlin-test-app/overlays/okctl-template-dev/deployment-patch.json)
+

--- a/userdocs/src/getting-started/continuous-integration.md
+++ b/userdocs/src/getting-started/continuous-integration.md
@@ -53,9 +53,10 @@ https://github.com/oslokommune/okctl-kotlin-app-template/settings/environments
 Use templates found here: https://github.com/oslokommune/okctl-kotlin-app-template/tree/main/.github/workflows
 
 You need to edit the following:
-* jobs -> docker-build-push -> steps[0] -> with -> aws-region (if you run somewhere else than Ireland)
-* jobs -> docker-build-push -> steps[1] -> env -> ECR_REPOSITORY (name of your ecr_repositroy, i.e. kotlin-test-app)
-* jobs -> update-tag -> steps[0] -> with -> repository (your iac-repository, i.e oslokommune/okctl-template-iac)
-* jobs -> update-tag -> steps[0] -> env -> CONTAINER_NAME (name of the container, i.e kotlin-test-app)
-* jobs -> update-tag -> steps[0] -> env -> DEPLOYMENT_YAML_FILE (location of overlay deployment patch file: i.e infrastructure/applications/kotlin-test-app/overlays/okctl-template-dev/deployment-patch.json)
+
+* jobs -> docker-build-push -> steps[0] -> with -> aws-region `if you run somewhere else than Ireland`
+* jobs -> docker-build-push -> steps[1] -> env -> ECR_REPOSITORY `name of your ecr_repositroy, i.e. kotlin-test-app`
+* jobs -> update-tag -> steps[0] -> with -> repository `your iac-repository, i.e oslokommune/okctl-template-iac`
+* jobs -> update-tag -> steps[0] -> env -> CONTAINER_NAME `name of the container, i.e kotlin-test-app`
+* jobs -> update-tag -> steps[0] -> env -> DEPLOYMENT_YAML_FILE `location of overlay deployment patch file: i.e infrastructure/applications/kotlin-test-app/overlays/okctl-template-dev/deployment-patch.json`
 


### PR DESCRIPTION
Userdocs for CI

## Description
Add docs for setting up CI integration for an application in a okctl cluster, using github actions

## Motivation and Context
Setting up CI for an app in okctl is not trivial, therefore we have made an example in the kotlin refrence app. This documentation is meant to help people understand it and copy the parts they need to their own project.

## How Has This Been Tested?
Set up manually and ran

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).

