### PR TITLE
KM-379: Change scaffold of volumes to use ReadWriteOnce instead of Many

### DIFF
--- a/pkg/client/core/testdata/volumes.yaml.golden
+++ b/pkg/client/core/testdata/volumes.yaml.golden
@@ -5,7 +5,7 @@ metadata:
   namespace: okctl
 spec:
   accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
   resources:
     requests:
       storage: 24Gi

--- a/pkg/scaffold/resources/persistentvolumeclaim.go
+++ b/pkg/scaffold/resources/persistentvolumeclaim.go
@@ -67,7 +67,7 @@ func generateDefaultPVC() corev1.PersistentVolumeClaim {
 					},
 				},
 			},
-			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		},
 	}
 }


### PR DESCRIPTION
ReadWriteMany is for multiple nodes to be connected to the same PVC
It will not work in this case
https://kubernetes.io/docs/concepts/storage/persistent-volumes/