### PR TITLE
KM287 🐛 Don't adjust download URL in processor.go

### DIFF
--- a/pkg/binaries/fetch/processor.go
+++ b/pkg/binaries/fetch/processor.go
@@ -76,7 +76,7 @@ func (s *Processor) Stager(baseDir string, bufferSize int64, binary state.Binary
 		NewEphemeralStorage(),
 		NewHTTPFetcher(
 			replaceVars(binary.URLPattern, map[string]string{
-				"#{os}":   ExpectedReleaseAssetNamingConvention(s.Host.Os),
+				"#{os}":   s.Host.Os,
 				"#{arch}": s.Host.Arch,
 				"#{ver}":  binary.Version,
 			}),
@@ -86,20 +86,6 @@ func (s *Processor) Stager(baseDir string, bufferSize int64, binary state.Binary
 	)
 
 	return stager, nil
-}
-
-// ExpectedReleaseAssetNamingConvention returns the given string with first character
-// upper case, the rest lower case. Example:
-//
-// ExpectedReleaseAssetNamingConvention("darwin") // Returns "Darwin".
-//
-// We expect downloadable github release assets to be on the form "Darwin", not "darwin".
-func ExpectedReleaseAssetNamingConvention(os string) string {
-	if len(os) > 0 {
-		return strings.ToUpper(os[0:1]) + strings.ToLower(os[1:])
-	}
-
-	return os
 }
 
 // prepareAndLoad a set of stagers

--- a/pkg/binaries/fetch/processor_test.go
+++ b/pkg/binaries/fetch/processor_test.go
@@ -151,9 +151,3 @@ func TestProcessor(t *testing.T) {
 		})
 	}
 }
-
-func TestProcessorURLNaming(t *testing.T) {
-	assert.Equal(t, "Darwin", fetch.ExpectedReleaseAssetNamingConvention("darwin"))
-	assert.Equal(t, "Darwin", fetch.ExpectedReleaseAssetNamingConvention("dARWIN"))
-	assert.Equal(t, "", fetch.ExpectedReleaseAssetNamingConvention(""))
-}

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/oslokommune/okctl/pkg/upgrade/clusterversion"
@@ -30,8 +29,8 @@ import (
 const (
 	folderWorking  = "working"
 	folderCrashing = "upgrade_crashes"
-	linux          = "linux"
-	darwin         = "darwin"
+	linux          = "Linux"
+	darwin         = "Darwin"
 	amd64          = "amd64"
 )
 
@@ -413,10 +412,10 @@ func TestRunUpgrades(t *testing.T) {
 				err = upgrader.Run()
 
 				assert.Error(t, err)
-				assert.Contains(t, err.Error(),
+				assert.Contains(t, err.Error(), fmt.Sprintf(
 					"parsing upgrade binaries: validating release: could not find checksum asset for "+
-						"release 0.0.61 (assets: okctl_upgrade-linux_amd64_0.0.61.tar.gz,"+
-						"okctl_upgrade-darwin_amd64_0.0.61.tar.gz)",
+						"release 0.0.61 (assets: okctl_upgrade-%s_%s_0.0.61.tar.gz,"+
+						"okctl_upgrade-%s_%s_0.0.61.tar.gz)", linux, amd64, darwin, amd64),
 				)
 			},
 		},
@@ -674,7 +673,7 @@ func getExpectedUpgradesRun(expectBinaryVersionsRunOnce []string, withHost state
 		expectedUpgradesRun = append(expectedUpgradesRun,
 			fmt.Sprintf("okctl-upgrade_%s_%s_%s",
 				binaryVersion,
-				capitalizeFirst(withHost.Os),
+				withHost.Os,
 				withHost.Arch,
 			),
 		)
@@ -714,8 +713,6 @@ func createGithubReleases(oses []string, arch string, versions []string) []*gith
 		assets := make([]*github.ReleaseAsset, 0, len(oses)+1)
 
 		for _, os := range oses {
-			os = capitalizeFirst(os)
-
 			asset := createGihubReleaseAssetBinary(os, arch, version)
 			assets = append(assets, asset)
 		}
@@ -747,10 +744,4 @@ func createGihubReleaseAssetBinary(os, arch, version string) *github.ReleaseAsse
 		BrowserDownloadURL: github.StringPtr(fmt.Sprintf(
 			"https://github.com/oslokommune/okctl-upgrade/releases/download/%s/okctl-upgrade_%s_%s_%s.tar.gz", version, version, os, arch)),
 	}
-}
-
-// capitalizeFirst converts for instance "linux" to "Linux". We use this because we expect github release assets for
-// upgrades to be named this way.
-func capitalizeFirst(os string) string {
-	return strings.ToUpper(os[0:1]) + strings.ToLower(os[1:])
 }


### PR DESCRIPTION
Fixed downloading binaries (regular binaries, not upgrades), which was broken in 6f6cbd6c87a20de133a20423add1dc08f3c77631.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed a bug which caused okctl to rewrite "linux" to "Linux", which made for instance
URL to the kubectl binary to be wrong.

In upgrade, though, we need to make sure os is capitalized. We will
handle this case inside upgrade's domain instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Updated unit tests. Tested manually (old bug could be reproduced by deleting ~/.okctl/kubectl folder) and running the okctl venv, which would trigger downloading.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release). (Not needed, this fixes something that hasn't been released)
