### PR TITLE
Modified grafana dashboard config and added support for loading notification channels through configmap

### DIFF
--- a/pkg/helm/charts/kubepromstack/kubepromstack.go
+++ b/pkg/helm/charts/kubepromstack/kubepromstack.go
@@ -734,6 +734,11 @@ grafana:
       ##
       annotations: {}
       multicluster: false
+
+      ## Allow Grafana to replicate dashboard structure from filesystem
+      provider:
+        foldersFromFilesStructure: true
+
     datasources:
       enabled: true
       defaultDatasourceEnabled: true
@@ -749,7 +754,12 @@ grafana:
       createPrometheusReplicasDatasources: false
       label: grafana_datasource
 
-  extraConfigmapMounts: []
+  extraConfigmapMounts:
+    - name: notification-provisioning
+      mountPath: /etc/grafana/provisioning/notifiers/grafana-notifiers.yaml
+      configMap: kube-prometheus-stack-grafana-notifiers
+      readOnly: true
+      subPath: notifiers.yaml
   # - name: certs-configmap
   #   mountPath: /etc/grafana/ssl/
   #   configMap: certs-configmap

--- a/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
+++ b/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
@@ -666,6 +666,11 @@ grafana:
       ##
       annotations: {}
       multicluster: false
+
+      ## Allow Grafana to replicate dashboard structure from filesystem
+      provider:
+        foldersFromFilesStructure: true
+
     datasources:
       enabled: true
       defaultDatasourceEnabled: true
@@ -681,7 +686,12 @@ grafana:
       createPrometheusReplicasDatasources: false
       label: grafana_datasource
 
-  extraConfigmapMounts: []
+  extraConfigmapMounts:
+    - name: notification-provisioning
+      mountPath: /etc/grafana/provisioning/notifiers/grafana-notifiers.yaml
+      configMap: kube-prometheus-stack-grafana-notifiers
+      readOnly: true
+      subPath: notifiers.yaml
   # - name: certs-configmap
   #   mountPath: /etc/grafana/ssl/
   #   configMap: certs-configmap


### PR DESCRIPTION
## Description
Replaces the current dashboard provisioning config
Adds a config map for provisioning notification channels to Grafana

## Motivation and Context
Up until now it has not been possible to provide notification channels to Grafana other than manually adding them through the UI. By adding another config map where they are described, we can now store the configuration in a git repository and add the config to Grafana through, for instance, a Helm chart.

The modified dashboard config makes it possible to store the various dashboards in Grafana in the same folder structure as they are stored on the file system. For an example of how this can be done, have a look at this repo: [skjema-suctl](https://github.com/oslokommune/skjema-suctl/tree/master/src/main/resources/templates/iac/grafana-config)

## How Has This Been Tested?
Unit tests and created one cluster

## Screenshots (if appropriate):
<img width="1412" alt="Skjermbilde 2021-09-29 kl  20 58 14" src="https://user-images.githubusercontent.com/32042006/135331679-c3d6346c-8d38-4979-b66b-d933582e85f9.png">


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
