### PR TITLE
argocd application controller: increase K8s resources

### DIFF
--- a/docs/release_notes/0.0.66.md
+++ b/docs/release_notes/0.0.66.md
@@ -4,7 +4,8 @@
 
 ✅ KM334 Add application resource quota and probes (#678)
 ✅ KM271 Add ability to connect to postgres through application.yaml (#683)
-👌 Add support for loading Grafana notification channels through configmap (#969)
+👌 Add support for loading Grafana notification channels through configmap (#696)
+👌 Increase CPU and memory for ArgoCD (#697)
 
 ## Bugfixes
 

--- a/pkg/client/core/service_monitoring_client.go
+++ b/pkg/client/core/service_monitoring_client.go
@@ -63,7 +63,7 @@ const (
 	lokiDatasourceConfigMapName        = "loki-datasource"
 	tempoDatasourceConfigMapName       = "tempo-datasource"
 	cloudwatchDatasourceConfigMapName  = "cloudwatch-datasource"
-	notifiersProvisioningConfigMapName  = "kube-prometheus-stack-grafana-notifiers"
+	notifiersProvisioningConfigMapName = "kube-prometheus-stack-grafana-notifiers"
 
 	kubepromChartTimeout = 15 * time.Minute
 )

--- a/pkg/helm/charts/argocd/argocd.go
+++ b/pkg/helm/charts/argocd/argocd.go
@@ -94,12 +94,12 @@ func NewDefaultValues(opts ValuesOpts) *Values {
 			},
 			Resources: resources{
 				Limits: resourceEntry{
-					CPU:    "500m",
-					Memory: "512Mi",
+					CPU:    "800m",
+					Memory: "1Gi",
 				},
 				Requests: resourceEntry{
-					CPU:    "250m",
-					Memory: "256Mi",
+					CPU:    "500m",
+					Memory: "512Mi",
 				},
 			},
 			ServiceAccount: serviceAccount{

--- a/pkg/helm/charts/argocd/testdata/argocd-values.yaml.golden
+++ b/pkg/helm/charts/argocd/testdata/argocd-values.yaml.golden
@@ -34,11 +34,11 @@ controller:
         portName: https-controller
     resources:
         limits:
+            cpu: 800m
+            memory: 1Gi
+        requests:
             cpu: 500m
             memory: 512Mi
-        requests:
-            cpu: 250m
-            memory: 256Mi
     serviceAccount:
         create: true
         name: argocd-application-controller


### PR DESCRIPTION
## Description
Extends the resource request and limitations for argocd application controller

## Motivation and Context
We experiences that the argocd application controller used more resources than the allocated out-of-the-box defined values which caused several restarts from OOM challenges for the container. We solved this problem, in our test cluster, by doubling the resources requested. In this PR we also double the limit for memory and increase CPU from 500 to 800.

## How Has This Been Tested?
By doubling the requested resources in our test environment we were able to avoid the problem, and our application controller container has been running without any resource challenges for the last three days (from 01.10).

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
