### PR TITLE
KM332 ✅ Add metrics usage

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -69,6 +69,7 @@ jobs:
         run: dist/linux_linux_amd64/okctl apply cluster --github-credentials-type token --aws-credentials-type access-key --no-spinner --file nightly-cfg.yaml
         env:
           OKCTL_DEBUG: true
+          OKCTL_METRICS_USERAGENT: okctldev
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.OKCTL_BOT_NIGHTLY_BUILD_PAT }}
@@ -77,6 +78,7 @@ jobs:
         run: dist/linux_linux_amd64/okctl delete cluster --github-credentials-type token --aws-credentials-type access-key --no-spinner --confirm --cluster-declaration nightly-cfg.yaml
         env:
           OKCTL_DEBUG: true
+          OKCTL_METRICS_USERAGENT: okctldev
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.OKCTL_BOT_NIGHTLY_BUILD_PAT }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,24 @@ make test
 make release-local
 ```
 
+After running the initialization process that will automatically start when running a command, please edit your
+`~/.okctl/conf.yml` and add the following:
+
+```yaml
+...
+metrics:
+  userAgent: okctldev
+...
+```
+
+This will allow us to differentiate between actual production usage and development usage. Thank you!
+
 #### 4. Write your feature
 
-- Find an [issue](https://github.com/oslokommune/okctl/issues) to work on or
-  create your own. If you are a new contributor take a look at issues marked
-  with [good first issue](https://github.com/oslokommune/okctl/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+- Find an [issue](https://github.com/oslokommune/okctl/issues) to work on or create your own. If you are a new
+  contributor take a look at issues marked
+  with [good first issue](https://github.com/oslokommune/okctl/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+  .
 
 - Then create a topic branch from where you want to base your work (usually branched from master):
 

--- a/cmd/okctl/apply_application.go
+++ b/cmd/okctl/apply_application.go
@@ -49,11 +49,7 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 			preruns.InitializeMetrics(o),
 			preruns.InitializeOkctl(o),
 			func(cmd *cobra.Command, args []string) (err error) {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionApplyApplication,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionApplyApplication))
 
 				opts.Application, err = commands.InferApplicationFromStdinOrFile(*o.Declaration, o.In, o.FileSystem, opts.File)
 				if err != nil {
@@ -107,11 +103,7 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 			})
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionApplyApplication,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionApplyApplication))
 
 			return nil
 		},

--- a/cmd/okctl/apply_application.go
+++ b/cmd/okctl/apply_application.go
@@ -49,6 +49,12 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 			preruns.InitializeMetrics(o),
 			preruns.InitializeOkctl(o),
 			func(cmd *cobra.Command, args []string) (err error) {
+				metrics.Publish(metrics.Event{
+					Category: metrics.CategoryCommandExecution,
+					Action:   metrics.ActionApplyApplication,
+					Label:    metrics.LabelStart,
+				})
+
 				opts.Application, err = commands.InferApplicationFromStdinOrFile(*o.Declaration, o.In, o.FileSystem, opts.File)
 				if err != nil {
 					return fmt.Errorf("inferring application from stdin or file: %w", err)
@@ -62,11 +68,6 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed validating options: %w", err)
 			}
-
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryApplication,
-				Action:   metrics.ActionApply,
-			})
 
 			state := o.StateHandlers(o.StateNodes())
 
@@ -104,6 +105,15 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 				Application: opts.Application,
 				Cluster:     *o.Declaration,
 			})
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			metrics.Publish(metrics.Event{
+				Category: metrics.CategoryCommandExecution,
+				Action:   metrics.ActionApplyApplication,
+				Label:    metrics.LabelEnd,
+			})
+
+			return nil
 		},
 	}
 

--- a/cmd/okctl/apply_cluster.go
+++ b/cmd/okctl/apply_cluster.go
@@ -84,11 +84,7 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),
 			func(cmd *cobra.Command, args []string) (err error) {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionApplyCluster,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionApplyCluster))
 
 				opts.Declaration, err = commands.InferClusterFromStdinOrFile(o.In, opts.File)
 				if err != nil {
@@ -231,11 +227,7 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 			return nil
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionApplyCluster,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionApplyCluster))
 
 			return nil
 		},

--- a/cmd/okctl/apply_cluster.go
+++ b/cmd/okctl/apply_cluster.go
@@ -9,6 +9,9 @@ import (
 	"path"
 	"syscall"
 
+	"github.com/oslokommune/okctl/cmd/okctl/preruns"
+	"github.com/oslokommune/okctl/pkg/metrics"
+
 	"github.com/oslokommune/okctl/pkg/upgrade/clusterversion"
 	"github.com/oslokommune/okctl/pkg/upgrade/originalclusterversion"
 
@@ -33,7 +36,6 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
-	"github.com/oslokommune/okctl/pkg/config/load"
 	common "github.com/oslokommune/okctl/pkg/controller/common/reconciliation"
 	"github.com/oslokommune/okctl/pkg/okctl"
 	"github.com/oslokommune/okctl/pkg/spinner"
@@ -78,90 +80,94 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 
 			return nil
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
-			opts.Declaration, err = commands.InferClusterFromStdinOrFile(o.In, opts.File)
-			if err != nil {
-				return fmt.Errorf("inferring cluster: %w", err)
-			}
-
-			err = opts.Declaration.Validate()
-			if err != nil {
-				return fmt.Errorf("validating cluster declaration: %w", err)
-			}
-
-			err = loadNoUserInputUserData(o, cmd)
-			if err != nil {
-				return fmt.Errorf("loading application data: %w", err)
-			}
-
-			o.Declaration = opts.Declaration
-
-			// Move into a function
-			{
-				baseDir, err := o.GetRepoDir()
+		PreRunE: preruns.PreRunECombinator(
+			preruns.LoadUserData(o),
+			preruns.InitializeMetrics(o),
+			func(cmd *cobra.Command, args []string) (err error) {
+				opts.Declaration, err = commands.InferClusterFromStdinOrFile(o.In, opts.File)
 				if err != nil {
-					return err
+					return fmt.Errorf("inferring cluster: %w", err)
 				}
 
-				stormDB := path.Join(baseDir, o.Declaration.Github.OutputPath, o.Declaration.Metadata.Name, constant.DefaultStormDBName)
-
-				exists, err := o.FileSystem.Exists(stormDB)
+				err = opts.Declaration.Validate()
 				if err != nil {
-					return err
+					return fmt.Errorf("validating cluster declaration: %w", err)
 				}
 
-				if !exists {
-					err := o.FileSystem.MkdirAll(path.Dir(stormDB), 0o744)
+				metrics.Publish(metrics.Event{
+					Category: metrics.CategoryCluster,
+					Action:   metrics.ActionApply,
+				})
+
+				o.Declaration = opts.Declaration
+
+				// Move into a function
+				{
+					baseDir, err := o.GetRepoDir()
 					if err != nil {
 						return err
 					}
 
-					db, err := storm.Open(stormDB, storm.Codec(json.Codec))
+					stormDB := path.Join(baseDir, o.Declaration.Github.OutputPath, o.Declaration.Metadata.Name, constant.DefaultStormDBName)
+
+					exists, err := o.FileSystem.Exists(stormDB)
 					if err != nil {
 						return err
 					}
 
-					err = db.Close()
-					if err != nil {
-						return err
+					if !exists {
+						err := o.FileSystem.MkdirAll(path.Dir(stormDB), 0o744)
+						if err != nil {
+							return err
+						}
+
+						db, err := storm.Open(stormDB, storm.Codec(json.Codec))
+						if err != nil {
+							return err
+						}
+
+						err = db.Close()
+						if err != nil {
+							return err
+						}
 					}
 				}
-			}
 
-			err = o.Initialise()
-			if err != nil {
-				return fmt.Errorf("initializing okctl: %w", err)
-			}
+				err = o.Initialise()
+				if err != nil {
+					return fmt.Errorf("initializing okctl: %w", err)
+				}
 
-			state := o.StateHandlers(o.StateNodes())
+				state := o.StateHandlers(o.StateNodes())
 
-			// Cluster version
-			clusterID := api.ID{
-				Region:       o.Declaration.Metadata.Region,
-				AWSAccountID: o.Declaration.Metadata.AccountID,
-				ClusterName:  o.Declaration.Metadata.Name,
-			}
+				// Cluster version
+				clusterID := api.ID{
+					Region:       o.Declaration.Metadata.Region,
+					AWSAccountID: o.Declaration.Metadata.AccountID,
+					ClusterName:  o.Declaration.Metadata.Name,
+				}
 
-			clusterVersioner = clusterversion.New(
-				o.Out,
-				clusterID,
-				state.Upgrade,
-			)
+				clusterVersioner = clusterversion.New(
+					o.Out,
+					clusterID,
+					state.Upgrade,
+				)
 
-			err = clusterVersioner.ValidateBinaryVsClusterVersion(version.GetVersionInfo().Version)
-			if err != nil {
-				return fmt.Errorf(commands.ValidateBinaryVsClusterVersionErr, err)
-			}
+				err = clusterVersioner.ValidateBinaryVsClusterVersion(version.GetVersionInfo().Version)
+				if err != nil {
+					return fmt.Errorf(commands.ValidateBinaryVsClusterVersionErr, err)
+				}
 
-			// Original version
-			originalClusterVersioner = originalclusterversion.New(
-				clusterID,
-				state.Upgrade,
-				state.Cluster,
-			)
+				// Original version
+				originalClusterVersioner = originalclusterversion.New(
+					clusterID,
+					state.Upgrade,
+					state.Cluster,
+				)
 
-			return nil
-		},
+				return nil
+			},
+		),
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			var spinnerWriter io.Writer
 			if opts.DisableSpinner {
@@ -323,12 +329,3 @@ func isVersionFromBeforeUpgradeWasReleased(versionString string) (bool, error) {
 }
 
 const usageApplyClusterFile = `specifies where to read the declaration from. Use "-" for stdin`
-
-// ~/.okctl.yaml
-func loadNoUserInputUserData(o *okctl.Okctl, cmd *cobra.Command) error {
-	userDataNotFound := load.CreateOnUserDataNotFoundWithNoInput()
-
-	o.UserDataLoader = load.UserDataFromFlagsEnvConfigDefaults(cmd, userDataNotFound)
-
-	return o.LoadUserData()
-}

--- a/cmd/okctl/attach_postgres.go
+++ b/cmd/okctl/attach_postgres.go
@@ -50,11 +50,7 @@ func buildAttachPostgres(o *okctl.Okctl) *cobra.Command {
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),
 			func(_ *cobra.Command, _ []string) error {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionAttachPostgres,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionAttachPostgres))
 
 				err := o.Initialise()
 				if err != nil {
@@ -170,11 +166,7 @@ func buildAttachPostgres(o *okctl.Okctl) *cobra.Command {
 			return err
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionAttachPostgres,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionAttachPostgres))
 
 			return nil
 		},

--- a/cmd/okctl/delete.go
+++ b/cmd/okctl/delete.go
@@ -58,11 +58,7 @@ func buildDeleteClusterCommand(o *okctl.Okctl) *cobra.Command {
 			preruns.InitializeMetrics(o),
 			preruns.InitializeOkctl(o),
 			func(cmd *cobra.Command, args []string) error {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionDeleteCluster,
-					Label:    metrics.LabelEnd,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionDeleteCluster))
 
 				return nil
 			},
@@ -130,11 +126,7 @@ func buildDeleteClusterCommand(o *okctl.Okctl) *cobra.Command {
 			return nil
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionDeleteCluster,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionDeleteCluster))
 
 			return nil
 		},

--- a/cmd/okctl/forward_postgres.go
+++ b/cmd/okctl/forward_postgres.go
@@ -61,11 +61,7 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),
 			func(_ *cobra.Command, _ []string) error {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionForwardPostgres,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionForwardPostgres))
 
 				if len(opts.ApplicationName) == 0 {
 					return fmt.Errorf("missing database instance name")
@@ -190,11 +186,7 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 			return err
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionForwardPostgres,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionForwardPostgres))
 
 			return nil
 		},

--- a/cmd/okctl/metrics.go
+++ b/cmd/okctl/metrics.go
@@ -2,18 +2,12 @@ package main
 
 import "github.com/oslokommune/okctl/pkg/metrics"
 
-const (
-	labelKeyPhase   = "phase"
-	labelValueStart = "start"
-	labelValueEnd   = "end"
-)
-
 func generateStartEvent(action metrics.Action) metrics.Event {
 	return metrics.Event{
 		Category: metrics.CategoryCommandExecution,
 		Action:   action,
 		Labels: map[string]string{
-			labelKeyPhase: labelValueStart,
+			metrics.LabelPhaseKey: metrics.LabelPhaseStart,
 		},
 	}
 }
@@ -23,7 +17,7 @@ func generateEndEvent(action metrics.Action) metrics.Event {
 		Category: metrics.CategoryCommandExecution,
 		Action:   action,
 		Labels: map[string]string{
-			labelKeyPhase: labelValueEnd,
+			metrics.LabelPhaseKey: metrics.LabelPhaseEnd,
 		},
 	}
 }

--- a/cmd/okctl/metrics.go
+++ b/cmd/okctl/metrics.go
@@ -1,0 +1,29 @@
+package main
+
+import "github.com/oslokommune/okctl/pkg/metrics"
+
+const (
+	labelKeyPhase   = "phase"
+	labelValueStart = "start"
+	labelValueEnd   = "end"
+)
+
+func generateStartEvent(action metrics.Action) metrics.Event {
+	return metrics.Event{
+		Category: metrics.CategoryCommandExecution,
+		Action:   action,
+		Labels: map[string]string{
+			labelKeyPhase: labelValueStart,
+		},
+	}
+}
+
+func generateEndEvent(action metrics.Action) metrics.Event {
+	return metrics.Event{
+		Category: metrics.CategoryCommandExecution,
+		Action:   action,
+		Labels: map[string]string{
+			labelKeyPhase: labelValueEnd,
+		},
+	}
+}

--- a/cmd/okctl/preruns/api.go
+++ b/cmd/okctl/preruns/api.go
@@ -48,3 +48,15 @@ func InitializeMetrics(o *okctl.Okctl) PreRunEer {
 		return nil
 	}
 }
+
+// InitializeOkctl initializes the okctl instance
+func InitializeOkctl(o *okctl.Okctl) PreRunEer {
+	return func(cmd *cobra.Command, args []string) error {
+		err := o.Initialise()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/cmd/okctl/scaffold_application.go
+++ b/cmd/okctl/scaffold_application.go
@@ -30,11 +30,7 @@ func buildScaffoldApplicationCommand(o *okctl.Okctl) *cobra.Command {
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),
 			func(cmd *cobra.Command, args []string) error {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionScaffoldApplication,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionScaffoldApplication))
 
 				if declarationPath != "" {
 					clusterDeclaration, err := commands.InferClusterFromStdinOrFile(o.In, declarationPath)
@@ -54,11 +50,7 @@ func buildScaffoldApplicationCommand(o *okctl.Okctl) *cobra.Command {
 			return commands.ScaffoldApplicationDeclaration(o.Out, opts)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionScaffoldApplication,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionScaffoldApplication))
 
 			return nil
 		},

--- a/cmd/okctl/scaffold_cluster.go
+++ b/cmd/okctl/scaffold_cluster.go
@@ -28,11 +28,7 @@ func buildScaffoldClusterCommand(o *okctl.Okctl) *cobra.Command {
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),
 			func(cmd *cobra.Command, args []string) error {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionScaffoldCluster,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionScaffoldCluster))
 
 				return nil
 			},
@@ -41,11 +37,7 @@ func buildScaffoldClusterCommand(o *okctl.Okctl) *cobra.Command {
 			return commands.ScaffoldClusterDeclaration(o.Out, opts)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionScaffoldCluster,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionScaffoldCluster))
 
 			return nil
 		},

--- a/cmd/okctl/scaffold_cluster.go
+++ b/cmd/okctl/scaffold_cluster.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"github.com/oslokommune/okctl/cmd/okctl/preruns"
 	"github.com/oslokommune/okctl/pkg/commands"
 	"github.com/oslokommune/okctl/pkg/config/constant"
+	"github.com/oslokommune/okctl/pkg/metrics"
 
 	"github.com/oslokommune/okctl/pkg/okctl"
 	"github.com/spf13/cobra"
@@ -22,7 +24,16 @@ func buildScaffoldClusterCommand(o *okctl.Okctl) *cobra.Command {
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			return nil
 		},
+		PreRunE: preruns.PreRunECombinator(
+			preruns.LoadUserData(o),
+			preruns.InitializeMetrics(o),
+		),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			metrics.Publish(metrics.Event{
+				Category: metrics.CategoryCluster,
+				Action:   metrics.ActionScaffold,
+			})
+
 			return commands.ScaffoldClusterDeclaration(o.Out, opts)
 		},
 	}

--- a/cmd/okctl/scaffold_cluster.go
+++ b/cmd/okctl/scaffold_cluster.go
@@ -27,14 +27,27 @@ func buildScaffoldClusterCommand(o *okctl.Okctl) *cobra.Command {
 		PreRunE: preruns.PreRunECombinator(
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),
+			func(cmd *cobra.Command, args []string) error {
+				metrics.Publish(metrics.Event{
+					Category: metrics.CategoryCommandExecution,
+					Action:   metrics.ActionScaffoldCluster,
+					Label:    metrics.LabelStart,
+				})
+
+				return nil
+			},
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			return commands.ScaffoldClusterDeclaration(o.Out, opts)
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
 			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCluster,
-				Action:   metrics.ActionScaffold,
+				Category: metrics.CategoryCommandExecution,
+				Action:   metrics.ActionScaffoldCluster,
+				Label:    metrics.LabelEnd,
 			})
 
-			return commands.ScaffoldClusterDeclaration(o.Out, opts)
+			return nil
 		},
 	}
 

--- a/cmd/okctl/show.go
+++ b/cmd/okctl/show.go
@@ -37,7 +37,10 @@ func buildShowCommand(o *okctl.Okctl) *cobra.Command {
 
 //nolint:funlen,gocognit
 func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
-	okctlEnvironment := commands.OkctlEnvironment{}
+	var (
+		okctlEnvironment = commands.OkctlEnvironment{}
+		err              error
+	)
 
 	cmd := &cobra.Command{
 		Use:   "credentials",
@@ -46,6 +49,7 @@ func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
 		Args:  cobra.ExactArgs(showCredentialsArgs),
 		PreRunE: preruns.PreRunECombinator(
 			preruns.LoadUserData(o),
+			preruns.InitializeMetrics(o),
 			preruns.InitializeOkctl(o),
 			func(_ *cobra.Command, args []string) error {
 				metrics.Publish(metrics.Event{
@@ -53,11 +57,6 @@ func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
 					Action:   metrics.ActionShowCredentials,
 					Label:    metrics.LabelStart,
 				})
-
-				err := o.Initialise()
-				if err != nil {
-					return err
-				}
 
 				okctlEnvironment, err = commands.GetOkctlEnvironment(o, declarationPath)
 				if err != nil {

--- a/cmd/okctl/show.go
+++ b/cmd/okctl/show.go
@@ -52,11 +52,7 @@ func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
 			preruns.InitializeMetrics(o),
 			preruns.InitializeOkctl(o),
 			func(_ *cobra.Command, args []string) error {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionShowCredentials,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionShowCredentials))
 
 				okctlEnvironment, err = commands.GetOkctlEnvironment(o, declarationPath)
 				if err != nil {
@@ -143,11 +139,7 @@ func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
 			return err
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionShowCredentials,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionShowCredentials))
 
 			return nil
 		},

--- a/cmd/okctl/upgrade.go
+++ b/cmd/okctl/upgrade.go
@@ -45,11 +45,7 @@ binaries used by okctl (kubectl, etc), and internal state.`,
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),
 			func(cmd *cobra.Command, args []string) error {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionUpgrade,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionUpgrade))
 
 				err := o.Initialise()
 				if err != nil {
@@ -130,11 +126,7 @@ binaries used by okctl (kubectl, etc), and internal state.`,
 			return nil
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionUpgrade,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionUpgrade))
 
 			return nil
 		},

--- a/cmd/okctl/upgrade.go
+++ b/cmd/okctl/upgrade.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 
+	"github.com/oslokommune/okctl/cmd/okctl/preruns"
+	"github.com/oslokommune/okctl/pkg/metrics"
+
 	"github.com/oslokommune/okctl/pkg/upgrade/clusterversion"
 	"github.com/oslokommune/okctl/pkg/upgrade/originalclusterversion"
 
@@ -38,82 +41,101 @@ func buildUpgradeCommand(o *okctl.Okctl) *cobra.Command {
 to the current version of okctl. Example of such resources are helm charts, okctl cluster and application declarations,
 binaries used by okctl (kubectl, etc), and internal state.`,
 		Hidden: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Initialise()
-			if err != nil {
-				return err
-			}
+		PreRunE: preruns.PreRunECombinator(
+			preruns.LoadUserData(o),
+			preruns.InitializeMetrics(o),
+			func(cmd *cobra.Command, args []string) error {
+				metrics.Publish(metrics.Event{
+					Category: metrics.CategoryCommandExecution,
+					Action:   metrics.ActionUpgrade,
+					Label:    metrics.LabelStart,
+				})
 
-			stateHandlers := o.StateHandlers(o.StateNodes())
+				err := o.Initialise()
+				if err != nil {
+					return err
+				}
 
-			services, err := o.ClientServices(stateHandlers)
-			if err != nil {
-				return err
-			}
+				stateHandlers := o.StateHandlers(o.StateNodes())
 
-			out := o.Out
-			if o.Debug {
-				out = o.Err
-			}
+				services, err := o.ClientServices(stateHandlers)
+				if err != nil {
+					return err
+				}
 
-			userDataDir, err := o.GetUserDataDir()
-			if err != nil {
-				return err
-			}
+				out := o.Out
+				if o.Debug {
+					out = o.Err
+				}
 
-			repoDir, err := o.GetHomeDir()
-			if err != nil {
-				return err
-			}
+				userDataDir, err := o.GetUserDataDir()
+				if err != nil {
+					return err
+				}
 
-			fetcherOpts := upgrade.FetcherOpts{
-				Host:  o.Host(),
-				Store: storage.NewFileSystemStorage(userDataDir),
-			}
+				repoDir, err := o.GetHomeDir()
+				if err != nil {
+					return err
+				}
 
-			clusterID := api.ID{
-				Region:       o.Declaration.Metadata.Region,
-				AWSAccountID: o.Declaration.Metadata.AccountID,
-				ClusterName:  o.Declaration.Metadata.Name,
-			}
+				fetcherOpts := upgrade.FetcherOpts{
+					Host:  o.Host(),
+					Store: storage.NewFileSystemStorage(userDataDir),
+				}
 
-			clusterVersioner = clusterversion.New(
-				out,
-				clusterID,
-				stateHandlers.Upgrade,
-			)
+				clusterID := api.ID{
+					Region:       o.Declaration.Metadata.Region,
+					AWSAccountID: o.Declaration.Metadata.AccountID,
+					ClusterName:  o.Declaration.Metadata.Name,
+				}
 
-			surveyor := survey.NewTerminalSurveyor(out, flags.confirm)
+				clusterVersioner = clusterversion.New(
+					out,
+					clusterID,
+					stateHandlers.Upgrade,
+				)
 
-			originalClusterVersioner = originalclusterversion.New(clusterID, stateHandlers.Upgrade, stateHandlers.Cluster)
+				surveyor := survey.NewTerminalSurveyor(out, flags.confirm)
 
-			upgrader, err = upgrade.New(upgrade.Opts{
-				Debug:                    o.Debug,
-				AutoConfirm:              flags.confirm,
-				Logger:                   o.Logger,
-				Out:                      out,
-				RepositoryDirectory:      repoDir,
-				GithubService:            services.Github,
-				ChecksumDownloader:       upgrade.NewChecksumDownloader(),
-				ClusterVersioner:         clusterVersioner,
-				OriginalClusterVersioner: originalClusterVersioner,
-				Surveyor:                 surveyor,
-				FetcherOpts:              fetcherOpts,
-				OkctlVersion:             version.GetVersionInfo().Version,
-				State:                    stateHandlers.Upgrade,
-				ClusterID:                clusterID,
-			})
-			if err != nil {
-				return fmt.Errorf("creating upgrader: %w", err)
-			}
+				originalClusterVersioner = originalclusterversion.New(clusterID, stateHandlers.Upgrade, stateHandlers.Cluster)
 
-			return nil
-		},
+				upgrader, err = upgrade.New(upgrade.Opts{
+					Debug:                    o.Debug,
+					AutoConfirm:              flags.confirm,
+					Logger:                   o.Logger,
+					Out:                      out,
+					RepositoryDirectory:      repoDir,
+					GithubService:            services.Github,
+					ChecksumDownloader:       upgrade.NewChecksumDownloader(),
+					ClusterVersioner:         clusterVersioner,
+					OriginalClusterVersioner: originalClusterVersioner,
+					Surveyor:                 surveyor,
+					FetcherOpts:              fetcherOpts,
+					OkctlVersion:             version.GetVersionInfo().Version,
+					State:                    stateHandlers.Upgrade,
+					ClusterID:                clusterID,
+				})
+				if err != nil {
+					return fmt.Errorf("creating upgrader: %w", err)
+				}
+
+				return nil
+			},
+		),
 		RunE: func(_ *cobra.Command, args []string) error {
 			err := upgrader.Run()
 			if err != nil {
 				return fmt.Errorf("upgrading: %w", err)
 			}
+			return nil
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			metrics.Publish(metrics.Event{
+				Category: metrics.CategoryCommandExecution,
+				Action:   metrics.ActionUpgrade,
+				Label:    metrics.LabelEnd,
+			})
+
 			return nil
 		},
 	}

--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -44,11 +44,7 @@ func buildVenvCommand(o *okctl.Okctl) *cobra.Command { //nolint: funlen
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),
 			func(_ *cobra.Command, args []string) error {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionVenv,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionVenv))
 
 				e, err := venvPreRunE(o)
 				if err != nil {
@@ -98,11 +94,7 @@ func buildVenvCommand(o *okctl.Okctl) *cobra.Command { //nolint: funlen
 			return venvRunE(o, okctlEnvironment)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionVenv,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionVenv))
 
 			return nil
 		},

--- a/cmd/okctl/version.go
+++ b/cmd/okctl/version.go
@@ -24,11 +24,7 @@ func buildVersionCommand(o *okctl.Okctl) *cobra.Command {
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),
 			func(cmd *cobra.Command, args []string) error {
-				metrics.Publish(metrics.Event{
-					Category: metrics.CategoryCommandExecution,
-					Action:   metrics.ActionVersion,
-					Label:    metrics.LabelStart,
-				})
+				metrics.Publish(generateStartEvent(metrics.ActionVersion))
 
 				return nil
 			},
@@ -38,11 +34,7 @@ func buildVersionCommand(o *okctl.Okctl) *cobra.Command {
 			return err
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			metrics.Publish(metrics.Event{
-				Category: metrics.CategoryCommandExecution,
-				Action:   metrics.ActionVersion,
-				Label:    metrics.LabelEnd,
-			})
+			metrics.Publish(generateEndEvent(metrics.ActionVersion))
 
 			return nil
 		},

--- a/cmd/okctl/version.go
+++ b/cmd/okctl/version.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 
+	"github.com/oslokommune/okctl/cmd/okctl/preruns"
+	"github.com/oslokommune/okctl/pkg/metrics"
+
 	"github.com/oslokommune/okctl/pkg/version"
 
 	"github.com/oslokommune/okctl/pkg/okctl"
@@ -17,9 +20,31 @@ func buildVersionCommand(o *okctl.Okctl) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},
+		PreRunE: preruns.PreRunECombinator(
+			preruns.LoadUserData(o),
+			preruns.InitializeMetrics(o),
+			func(cmd *cobra.Command, args []string) error {
+				metrics.Publish(metrics.Event{
+					Category: metrics.CategoryCommandExecution,
+					Action:   metrics.ActionVersion,
+					Label:    metrics.LabelStart,
+				})
+
+				return nil
+			},
+		),
 		RunE: func(_ *cobra.Command, args []string) error {
 			_, err := fmt.Fprint(o.Out, version.String()+"\n")
 			return err
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			metrics.Publish(metrics.Event{
+				Category: metrics.CategoryCommandExecution,
+				Action:   metrics.ActionVersion,
+				Label:    metrics.LabelEnd,
+			})
+
+			return nil
 		},
 	}
 

--- a/docs/release_notes/0.0.68.md
+++ b/docs/release_notes/0.0.68.md
@@ -9,6 +9,7 @@ KM416 🐛 Fix filepermissions for kubeconfig (#709)
 🐛 Fix hidden error in apply application (#732)
 
 ## Changes
+KM332 ✅ Add metrics
 
 ## Other
 

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/opencontainers/selinux v1.8.0 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/oslokommune/okctl-metrics-service v0.1.0
+	github.com/oslokommune/okctl-metrics-service v0.1.3
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.49.0

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/opencontainers/selinux v1.8.0 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/oslokommune/okctl-metrics-service v0.1.3
+	github.com/oslokommune/okctl-metrics-service v0.1.4
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.49.0

--- a/go.sum
+++ b/go.sum
@@ -1020,8 +1020,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
-github.com/oslokommune/okctl-metrics-service v0.1.0 h1:O4RtagyXu/5XCUwftN/qkAeJjaG3XfT7fm33n8b4r+8=
-github.com/oslokommune/okctl-metrics-service v0.1.0/go.mod h1:GbgfDeYW36uJCHvvYR2nbqEJODKI4rV83zI7Kde+Oh8=
+github.com/oslokommune/okctl-metrics-service v0.1.3 h1:7SeoYgLP9MUX2amiThy/8ofxVCkxtNE/N1BJnW01ckY=
+github.com/oslokommune/okctl-metrics-service v0.1.3/go.mod h1:yDjdZUm2AzQw/dQDhzcdCbm9KSoOq6NSdUXbOabFUmQ=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/go.sum
+++ b/go.sum
@@ -1020,8 +1020,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
-github.com/oslokommune/okctl-metrics-service v0.1.3 h1:7SeoYgLP9MUX2amiThy/8ofxVCkxtNE/N1BJnW01ckY=
-github.com/oslokommune/okctl-metrics-service v0.1.3/go.mod h1:yDjdZUm2AzQw/dQDhzcdCbm9KSoOq6NSdUXbOabFUmQ=
+github.com/oslokommune/okctl-metrics-service v0.1.4 h1:2rkP4iQsAKfhBRbrGB29bauwVJyGvpZy155A+Wjoexw=
+github.com/oslokommune/okctl-metrics-service v0.1.4/go.mod h1:yDjdZUm2AzQw/dQDhzcdCbm9KSoOq6NSdUXbOabFUmQ=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/metrics/command_execution_types.go
+++ b/pkg/metrics/command_execution_types.go
@@ -1,0 +1,34 @@
+package metrics
+
+import metricsapi "github.com/oslokommune/okctl-metrics-service/pkg/endpoints/metrics"
+
+const (
+	// CategoryCommandExecution represents the context of running commands
+	CategoryCommandExecution = metricsapi.CategoryCommandExecution
+
+	// ActionScaffoldCluster represents running the command `okctl scaffold cluster`
+	ActionScaffoldCluster = metricsapi.ActionScaffoldCluster
+	// ActionApplyCluster represents running the command `okctl apply cluster`
+	ActionApplyCluster = metricsapi.ActionApplyCluster
+	// ActionDeleteCluster represents running the command `okctl delete cluster`
+	ActionDeleteCluster = metricsapi.ActionDeleteCluster
+
+	// ActionScaffoldApplication represents running the command `okctl scaffold application`
+	ActionScaffoldApplication = metricsapi.ActionScaffoldApplication
+	// ActionApplyApplication represents running the command `okctl apply application`
+	ActionApplyApplication = metricsapi.ActionApplyApplication
+
+	// ActionForwardPostgres represents running the command `okctl forward postgres`
+	ActionForwardPostgres = metricsapi.ActionForwardPostgres
+	// ActionAttachPostgres represents running the command `okctl attach postgres`
+	ActionAttachPostgres = metricsapi.ActionAttachPostgres
+
+	// ActionShowCredentials represents running the command `okctl show credentials`
+	ActionShowCredentials = metricsapi.ActionShowCredentials
+	// ActionUpgrade represents running the command `okctl upgrade`
+	ActionUpgrade = metricsapi.ActionUpgrade
+	// ActionVenv represents running the command `okctl venv`
+	ActionVenv = metricsapi.ActionVenv
+	// ActionVersion represents running the command `okctl version`
+	ActionVersion = metricsapi.ActionVersion
+)

--- a/pkg/metrics/command_execution_types.go
+++ b/pkg/metrics/command_execution_types.go
@@ -2,9 +2,10 @@ package metrics
 
 import metricsapi "github.com/oslokommune/okctl-metrics-service/pkg/endpoints/metrics"
 
+// CategoryCommandExecution represents the context of running commands
+const CategoryCommandExecution = metricsapi.CategoryCommandExecution
+
 const (
-	// CategoryCommandExecution represents the context of running commands
-	CategoryCommandExecution = metricsapi.CategoryCommandExecution
 
 	// ActionScaffoldCluster represents running the command `okctl scaffold cluster`
 	ActionScaffoldCluster = metricsapi.ActionScaffoldCluster
@@ -31,4 +32,12 @@ const (
 	ActionVenv = metricsapi.ActionVenv
 	// ActionVersion represents running the command `okctl version`
 	ActionVersion = metricsapi.ActionVersion
+)
+
+const (
+	LabelPhaseKey = metricsapi.LabelPhaseKey
+	// LabelPhaseStart represents the start of a command
+	LabelPhaseStart = metricsapi.LabelPhaseStart
+	// LabelPhaseEnd represents the end of the command
+	LabelPhaseEnd = metricsapi.LabelPhaseEnd
 )

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -12,27 +12,9 @@ type Event = metricsapi.Event
 
 type (
 	// Category defines the category of an event
-	Category metricsapi.Category
+	Category = metricsapi.Category
 	// Action defines the action of an event
-	Action metricsapi.Action
-)
-
-// Categories
-const (
-	// CategoryCluster represents metrics associated with cluster manipulation
-	CategoryCluster = metricsapi.CategoryCluster
-	// CategoryApplication represents metrics associated with application manipulation
-	CategoryApplication = metricsapi.CategoryApplication
-)
-
-// Actions
-const (
-	// ActionScaffold represents scaffolding a resource
-	ActionScaffold = metricsapi.ActionScaffold
-	// ActionApply represents applying a resource
-	ActionApply = metricsapi.ActionApply
-	// ActionDelete represents deleting a resource
-	ActionDelete = metricsapi.ActionDelete
+	Action = metricsapi.Action
 )
 
 type context struct {
@@ -40,3 +22,10 @@ type context struct {
 	UserAgent  string
 	APIURL     url.URL
 }
+
+const (
+	// LabelStart indicates the start of something
+	LabelStart = "start"
+	// LabelEnd indicates the end of something
+	LabelEnd = "end"
+)

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -22,10 +22,3 @@ type context struct {
 	UserAgent  string
 	APIURL     url.URL
 }
-
-const (
-	// LabelStart indicates the start of something
-	LabelStart = "start"
-	// LabelEnd indicates the end of something
-	LabelEnd = "end"
-)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds metrics for the beginning and end of each command

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM332](https://trello.com/c/rkCQDIPG)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
1. Run a command
2. Verify in https://grafana.kjoremiljo.oslo.systems that the command was registered. The event will be registered prefixed by the user agent. For us developers, that will be okctldev_*

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->
Please add `metrics.userAgent: okctldev` to your `~/.okctl.conf.yml` if you haven't already done that. If not, our dev metrics will soil the production metrics

This PR is now dependent on [this](https://github.com/oslokommune/okctl-metrics-service/pull/7) PR. Remember to commit a version bump of the new metrics release before merging

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
