### PR TITLE
KM412 🐛 Fix OOM issue for Prometheus by increasing memory

### DIFF
--- a/docs/release_notes/0.0.70.md
+++ b/docs/release_notes/0.0.70.md
@@ -6,6 +6,8 @@ KM437 ✅ Add terminationGracePeriodSeconds to apply application (#741)
 
 ## Bugfixes
 
+KM412 🐛 Fix OOM issue for Prometheus by increasing memory (#745)
+
 ## Changes
 
 ## Other

--- a/pkg/helm/charts/kubepromstack/kubepromstack.go
+++ b/pkg/helm/charts/kubepromstack/kubepromstack.go
@@ -2144,10 +2144,10 @@ prometheus:
     resources:
       limits:
         cpu: 300m
-        memory: 500Mi
+        memory: 1Gi
       requests:
         cpu: 150m
-        memory: 400Mi
+        memory: 800Mi
 
     ## Prometheus StorageSpec for persistent data
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/storage.md

--- a/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
+++ b/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
@@ -2076,10 +2076,10 @@ prometheus:
     resources:
       limits:
         cpu: 300m
-        memory: 500Mi
+        memory: 1Gi
       requests:
         cpu: 150m
-        memory: 400Mi
+        memory: 800Mi
 
     ## Prometheus StorageSpec for persistent data
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/storage.md


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Increases memory request to 800Mi and limit to 1Gi

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM412](https://trello.com/c/69QeOTIz)

## How to prove the effect of this PR?

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
In a new cluster, let the cluster run for a day and check `kubectl -n monitoring get pods` to see if prometheus has any restarts.

In an existing cluster, set `integrations.kubePromStack` to false and run `apply cluster`. After the reconciliation is complete, set it back to true and run `apply cluster` again. Wait a day and run `kubectl -n monitoring get pods` to see if prometheus has any restarts.

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
