### PR TITLE
🐛 Switch GoReleaser to different origin and bump to v.17.2-2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: goreleaser
 
 on:
   push:
-    branches:
-      - GoRelease
     tags:
       - '*'
 
@@ -39,4 +37,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           RELEASE_NOTES: docs/release_notes/${{ steps.tagName.outputs.tag }}.md
-          ARGS:  --skip-validate --skip-publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
       -
         name: Run GoReleaser
         run: make release
+        with:
+          args:  --skip-validate --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           RELEASE_NOTES: docs/release_notes/${{ steps.tagName.outputs.tag }}.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,7 @@ jobs:
       -
         name: Run GoReleaser
         run: make release
-        with:
-          args:  --skip-validate --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           RELEASE_NOTES: docs/release_notes/${{ steps.tagName.outputs.tag }}.md
+          ARGS:  --skip-validate --skip-publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: goreleaser
 
 on:
   push:
+    branches:
+      - GoRelease
     tags:
       - '*'
 
@@ -33,7 +35,7 @@ jobs:
 
       -
         name: Run GoReleaser
-        run: make release
+        run: make release --skip-validate --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           RELEASE_NOTES: docs/release_notes/${{ steps.tagName.outputs.tag }}.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       -
         name: Run GoReleaser
-        run: make release --skip-validate --skip-publish
+        run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           RELEASE_NOTES: docs/release_notes/${{ steps.tagName.outputs.tag }}.md

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ release:
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -w /go/src/github.com/oslokommune/okctl \
 	  -e GITHUB_TOKEN \
-	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-2 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml $ARGS
+	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-2 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml $$ARGS
 
 ## Generate
 generate: $(STATIK)

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,6 @@ MAKEDOC        := $(GOBIN)/makedoc
 STATIK         := $(GOBIN)/statik
 GOFUMPT        := $(GOBIN)/gofumpt
 
-# Deprecated: Use release-local instead.
-GORELEASER     := bin/goreleaser/v.0.154.0/$(OS)/goreleaser
 
 $(GOLANGCILINT):
 	# To bump, simply change the version at the end to the desired version. The git sha here points to the newest commit

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ release-local:
 	  -v $$PWD:/go/src/github.com/oslokommune/okctl \
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -w /go/src/github.com/oslokommune/okctl \
-	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-2 release --config=/go/src/github.com/oslokommune/okctl/.goreleaser-local.yml --snapshot --skip-publish --rm-dist
+	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-0 release --config=/go/src/github.com/oslokommune/okctl/.goreleaser-local.yml --snapshot --skip-publish --rm-dist
 
 release:
 	 docker run --rm --privileged \

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,10 @@ GOCOV          := $(GOBIN)/gocov
 RICHGO         := $(GOBIN)/richgo
 MAKEDOC        := $(GOBIN)/makedoc
 STATIK         := $(GOBIN)/statik
-GORELEASER     := bin/goreleaser/v.0.154.0/$(OS)/goreleaser
 GOFUMPT        := $(GOBIN)/gofumpt
+
+# Deprecated: Use release-local instead.
+GORELEASER     := bin/goreleaser/v.0.154.0/$(OS)/goreleaser
 
 $(GOLANGCILINT):
 	# To bump, simply change the version at the end to the desired version. The git sha here points to the newest commit
@@ -117,7 +119,7 @@ release-local:
 	  -v $$PWD:/go/src/github.com/oslokommune/okctl \
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -w /go/src/github.com/oslokommune/okctl \
-	  troian/golang-cross:v1.16 release --config=/go/src/github.com/oslokommune/okctl/.goreleaser-local.yml --snapshot --skip-publish --rm-dist
+	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-2 release --config=/go/src/github.com/oslokommune/okctl/.goreleaser-local.yml --snapshot --skip-publish --rm-dist
 
 release:
 	 docker run --rm --privileged \
@@ -125,7 +127,7 @@ release:
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -w /go/src/github.com/oslokommune/okctl \
 	  -e GITHUB_TOKEN \
-	  troian/golang-cross:v1.16 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml
+	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-2 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml
 
 ## Generate
 generate: $(STATIK)

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ release:
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -w /go/src/github.com/oslokommune/okctl \
 	  -e GITHUB_TOKEN \
-	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-2 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml
+	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-2 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml $ARGS
 
 ## Generate
 generate: $(STATIK)

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ release:
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -w /go/src/github.com/oslokommune/okctl \
 	  -e GITHUB_TOKEN \
-	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-0 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml $$ARGS
+	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-0 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml
 
 ## Generate
 generate: $(STATIK)

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ release:
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -w /go/src/github.com/oslokommune/okctl \
 	  -e GITHUB_TOKEN \
-	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-2 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml $$ARGS
+	  ghcr.io/gythialy/golang-cross-builder:v1.17.2-0 release --rm-dist --release-notes=$(RELEASE_NOTES) --config=/go/src/github.com/oslokommune/okctl/.goreleaser.yml $$ARGS
 
 ## Generate
 generate: $(STATIK)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR switches the golang-cross-builder from the user "troian" to "gythialy" and bumps the version to v.1.17.2-2.

## Motivation and Context
After latest macOS update, Homebrew reports deprication errors for code the goreleaser version used in golang-cross. This has been fixed in the latest release of goreleaser, and subsequently my this version of golang-cross.

## How to prove the effect of this PR?
The code should build cleanly with no errors, even on the new Docker image provided by the new repository source.

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
