### PR TITLE
KM434 🐛 Add control plane SecurityGroup to security group policy

### DIFF
--- a/docs/release_notes/0.0.73.md
+++ b/docs/release_notes/0.0.73.md
@@ -7,3 +7,5 @@
 ## Changes
 
 ## Other
+
+KM434 🐛 Add control plane SecurityGroup to security group policy

--- a/pkg/api/cluster_api.go
+++ b/pkg/api/cluster_api.go
@@ -72,7 +72,7 @@ func (o *ClusterSecurityGroupIDGetOpts) Validate() error {
 type ClusterService interface {
 	CreateCluster(context.Context, ClusterCreateOpts) (*Cluster, error)
 	DeleteCluster(context.Context, ClusterDeleteOpts) error
-	GetClusterSecurityGroupID(context.Context, ClusterSecurityGroupIDGetOpts) (*ClusterSecurityGroupID, error)
+	GetClusterSecurityGroupID(context.Context, *ClusterSecurityGroupIDGetOpts) (*ClusterSecurityGroupID, error)
 }
 
 // ClusterRun provides an interface for running CLIs

--- a/pkg/api/cluster_api.go
+++ b/pkg/api/cluster_api.go
@@ -50,10 +50,29 @@ func (o *ClusterDeleteOpts) Validate() error {
 	)
 }
 
+// ClusterSecurityGroupIDGetOpts specifies the required inputs for getting the cluster's security group
+type ClusterSecurityGroupIDGetOpts struct {
+	ID ID
+}
+
+// ClusterSecurityGroupID contains an EKS cluster's cluster security group ID
+// See https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+type ClusterSecurityGroupID struct {
+	Value string
+}
+
+// Validate the delete inputs
+func (o *ClusterSecurityGroupIDGetOpts) Validate() error {
+	return validation.ValidateStruct(o,
+		validation.Field(&o.ID, validation.Required),
+	)
+}
+
 // ClusterService provides an interface for the business logic when working with clusters
 type ClusterService interface {
 	CreateCluster(context.Context, ClusterCreateOpts) (*Cluster, error)
 	DeleteCluster(context.Context, ClusterDeleteOpts) error
+	GetClusterSecurityGroupID(context.Context, ClusterSecurityGroupIDGetOpts) (*ClusterSecurityGroupID, error)
 }
 
 // ClusterRun provides an interface for running CLIs

--- a/pkg/api/cluster_api.go
+++ b/pkg/api/cluster_api.go
@@ -70,8 +70,18 @@ func (o *ClusterSecurityGroupIDGetOpts) Validate() error {
 
 // ClusterService provides an interface for the business logic when working with clusters
 type ClusterService interface {
+	ClusterCruder
+	ClusterDetailer
+}
+
+// ClusterCruder knows how to create and delete clusters
+type ClusterCruder interface {
 	CreateCluster(context.Context, ClusterCreateOpts) (*Cluster, error)
 	DeleteCluster(context.Context, ClusterDeleteOpts) error
+}
+
+// ClusterDetailer knows how to get details about a cluster
+type ClusterDetailer interface {
 	GetClusterSecurityGroupID(context.Context, *ClusterSecurityGroupIDGetOpts) (*ClusterSecurityGroupID, error)
 }
 

--- a/pkg/api/core/endpoint_cluster.go
+++ b/pkg/api/core/endpoint_cluster.go
@@ -7,19 +7,19 @@ import (
 	"github.com/oslokommune/okctl/pkg/api"
 )
 
-func makeCreateClusterEndpoint(s api.ClusterService) endpoint.Endpoint {
+func makeCreateClusterEndpoint(s api.ClusterCruder) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 		return s.CreateCluster(ctx, request.(api.ClusterCreateOpts))
 	}
 }
 
-func makeDeleteClusterEndpoint(s api.ClusterService) endpoint.Endpoint {
+func makeDeleteClusterEndpoint(s api.ClusterCruder) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 		return Ok(), s.DeleteCluster(ctx, request.(api.ClusterDeleteOpts))
 	}
 }
 
-func makeGetClusterSecurityGroupIDEndpoint(s api.ClusterService) endpoint.Endpoint {
+func makeGetClusterSecurityGroupIDEndpoint(s api.ClusterDetailer) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 		return s.GetClusterSecurityGroupID(ctx, request.(*api.ClusterSecurityGroupIDGetOpts))
 	}

--- a/pkg/api/core/endpoint_cluster.go
+++ b/pkg/api/core/endpoint_cluster.go
@@ -18,3 +18,9 @@ func makeDeleteClusterEndpoint(s api.ClusterService) endpoint.Endpoint {
 		return Ok(), s.DeleteCluster(ctx, request.(api.ClusterDeleteOpts))
 	}
 }
+
+func makeGetClusterSecurityGroupID(s api.ClusterService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return s.GetClusterSecurityGroupID(ctx, request.(api.ClusterSecurityGroupIDGetOpts))
+	}
+}

--- a/pkg/api/core/endpoint_cluster.go
+++ b/pkg/api/core/endpoint_cluster.go
@@ -19,8 +19,8 @@ func makeDeleteClusterEndpoint(s api.ClusterService) endpoint.Endpoint {
 	}
 }
 
-func makeGetClusterSecurityGroupID(s api.ClusterService) endpoint.Endpoint {
+func makeGetClusterSecurityGroupIDEndpoint(s api.ClusterService) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
-		return s.GetClusterSecurityGroupID(ctx, request.(api.ClusterSecurityGroupIDGetOpts))
+		return s.GetClusterSecurityGroupID(ctx, request.(*api.ClusterSecurityGroupIDGetOpts))
 	}
 }

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -391,6 +391,7 @@ type EndpointOption func(Endpoints) Endpoints
 
 const (
 	clusterTag             = "clusterService"
+	securityGroupIDTag     = "securityGroupID"
 	vpcTag                 = "vpc"
 	managedPoliciesTag     = "managedPolicies"
 	externalSecretsTag     = "externalSecrets"
@@ -429,7 +430,7 @@ func InstrumentEndpoints(logger *logrus.Logger) EndpointOption {
 		return Endpoints{
 			CreateCluster:                   logmd.Logging(logger, "create", clusterTag)(endpoints.CreateCluster),
 			DeleteCluster:                   logmd.Logging(logger, "delete", clusterTag)(endpoints.DeleteCluster),
-			GetClusterSecurityGroupID:       logmd.Logging(logger, "get", clusterTag, "securityGroupID")(endpoints.GetClusterSecurityGroupID),
+			GetClusterSecurityGroupID:       logmd.Logging(logger, "get", clusterTag, securityGroupIDTag)(endpoints.GetClusterSecurityGroupID),
 			CreateVpc:                       logmd.Logging(logger, "create", vpcTag)(endpoints.CreateVpc),
 			DeleteVpc:                       logmd.Logging(logger, "delete", vpcTag)(endpoints.DeleteVpc),
 			CreateExternalDNSKubeDeployment: logmd.Logging(logger, "create", kubeTag, externalDNSTag)(endpoints.CreateExternalDNSKubeDeployment),

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -256,10 +256,10 @@ func AttachRoutes(handlers *Handlers) http.Handler {
 		r.Route("/clusters", func(r chi.Router) {
 			r.Method(http.MethodPost, "/", handlers.CreateCluster)
 			r.Method(http.MethodDelete, "/", handlers.DeleteCluster)
-		})
 
-		r.Route("/clustersecuritygroupid", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", handlers.GetClusterSecurityGroupID)
+			r.Route("/clustersecuritygroupid", func(r chi.Router) {
+				r.Method(http.MethodGet, "/", handlers.GetClusterSecurityGroupID)
+			})
 		})
 
 		r.Route("/vpcs", func(r chi.Router) {

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -429,7 +429,7 @@ func InstrumentEndpoints(logger *logrus.Logger) EndpointOption {
 		return Endpoints{
 			CreateCluster:                   logmd.Logging(logger, "create", clusterTag)(endpoints.CreateCluster),
 			DeleteCluster:                   logmd.Logging(logger, "delete", clusterTag)(endpoints.DeleteCluster),
-			GetClusterSecurityGroupID:       logmd.Logging(logger, "getClusterSecurityGroupID", clusterTag)(endpoints.GetClusterSecurityGroupID),
+			GetClusterSecurityGroupID:       logmd.Logging(logger, "get", clusterTag, "securityGroupID")(endpoints.GetClusterSecurityGroupID),
 			CreateVpc:                       logmd.Logging(logger, "create", vpcTag)(endpoints.CreateVpc),
 			DeleteVpc:                       logmd.Logging(logger, "delete", vpcTag)(endpoints.DeleteVpc),
 			CreateExternalDNSKubeDeployment: logmd.Logging(logger, "create", kubeTag, externalDNSTag)(endpoints.CreateExternalDNSKubeDeployment),

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -200,7 +200,7 @@ func MakeHandlers(responseType EncodeResponseType, endpoints Endpoints) *Handler
 	return &Handlers{
 		CreateCluster:                   newServer(endpoints.CreateCluster, decodeClusterCreateRequest),
 		DeleteCluster:                   newServer(endpoints.DeleteCluster, decodeClusterDeleteRequest),
-		GetClusterSecurityGroupID:       newServer(endpoints.GetClusterSecurityGroupID, decodeGetClusterSecurityGroupIDRequest),
+		GetClusterSecurityGroupID:       newServer(endpoints.GetClusterSecurityGroupID, decodeStructRequest(&api.ClusterSecurityGroupIDGetOpts{})),
 		CreateVpc:                       newServer(endpoints.CreateVpc, decodeVpcCreateRequest),
 		DeleteVpc:                       newServer(endpoints.DeleteVpc, decodeVpcDeleteRequest),
 		CreateExternalDNSKubeDeployment: newServer(endpoints.CreateExternalDNSKubeDeployment, decodeCreateExternalDNSKubeDeployment),

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -17,6 +17,7 @@ import (
 type Endpoints struct {
 	CreateCluster                   endpoint.Endpoint
 	DeleteCluster                   endpoint.Endpoint
+	GetClusterSecurityGroupID       endpoint.Endpoint
 	CreateVpc                       endpoint.Endpoint
 	DeleteVpc                       endpoint.Endpoint
 	CreateExternalDNSKubeDeployment endpoint.Endpoint
@@ -69,6 +70,7 @@ func MakeEndpoints(s Services) Endpoints {
 	return Endpoints{
 		CreateCluster:                   makeCreateClusterEndpoint(s.Cluster),
 		DeleteCluster:                   makeDeleteClusterEndpoint(s.Cluster),
+		GetClusterSecurityGroupID:       makeGetClusterSecurityGroupID(s.Cluster),
 		CreateVpc:                       makeCreateVpcEndpoint(s.Vpc),
 		DeleteVpc:                       makeDeleteVpcEndpoint(s.Vpc),
 		CreateExternalDNSKubeDeployment: makeCreateExternalDNSKubeDeploymentEndpoint(s.Kube),
@@ -119,6 +121,7 @@ func MakeEndpoints(s Services) Endpoints {
 type Handlers struct {
 	CreateCluster                   http.Handler
 	DeleteCluster                   http.Handler
+	GetClusterSecurityGroupID       http.Handler
 	CreateVpc                       http.Handler
 	DeleteVpc                       http.Handler
 	CreateExternalDNSKubeDeployment http.Handler
@@ -197,6 +200,7 @@ func MakeHandlers(responseType EncodeResponseType, endpoints Endpoints) *Handler
 	return &Handlers{
 		CreateCluster:                   newServer(endpoints.CreateCluster, decodeClusterCreateRequest),
 		DeleteCluster:                   newServer(endpoints.DeleteCluster, decodeClusterDeleteRequest),
+		GetClusterSecurityGroupID:       newServer(endpoints.GetClusterSecurityGroupID, decodeGetClusterSecurityGroupIDRequest),
 		CreateVpc:                       newServer(endpoints.CreateVpc, decodeVpcCreateRequest),
 		DeleteVpc:                       newServer(endpoints.DeleteVpc, decodeVpcDeleteRequest),
 		CreateExternalDNSKubeDeployment: newServer(endpoints.CreateExternalDNSKubeDeployment, decodeCreateExternalDNSKubeDeployment),
@@ -253,6 +257,11 @@ func AttachRoutes(handlers *Handlers) http.Handler {
 			r.Method(http.MethodPost, "/", handlers.CreateCluster)
 			r.Method(http.MethodDelete, "/", handlers.DeleteCluster)
 		})
+
+		r.Route("/clustersecuritygroupid", func(r chi.Router) {
+			r.Method(http.MethodGet, "/", handlers.GetClusterSecurityGroupID)
+		})
+
 		r.Route("/vpcs", func(r chi.Router) {
 			r.Method(http.MethodPost, "/", handlers.CreateVpc)
 			r.Method(http.MethodDelete, "/", handlers.DeleteVpc)
@@ -420,6 +429,7 @@ func InstrumentEndpoints(logger *logrus.Logger) EndpointOption {
 		return Endpoints{
 			CreateCluster:                   logmd.Logging(logger, "create", clusterTag)(endpoints.CreateCluster),
 			DeleteCluster:                   logmd.Logging(logger, "delete", clusterTag)(endpoints.DeleteCluster),
+			GetClusterSecurityGroupID:       logmd.Logging(logger, "getClusterSecurityGroupID", clusterTag)(endpoints.GetClusterSecurityGroupID),
 			CreateVpc:                       logmd.Logging(logger, "create", vpcTag)(endpoints.CreateVpc),
 			DeleteVpc:                       logmd.Logging(logger, "delete", vpcTag)(endpoints.DeleteVpc),
 			CreateExternalDNSKubeDeployment: logmd.Logging(logger, "create", kubeTag, externalDNSTag)(endpoints.CreateExternalDNSKubeDeployment),

--- a/pkg/api/core/handler_api.go
+++ b/pkg/api/core/handler_api.go
@@ -70,7 +70,7 @@ func MakeEndpoints(s Services) Endpoints {
 	return Endpoints{
 		CreateCluster:                   makeCreateClusterEndpoint(s.Cluster),
 		DeleteCluster:                   makeDeleteClusterEndpoint(s.Cluster),
-		GetClusterSecurityGroupID:       makeGetClusterSecurityGroupID(s.Cluster),
+		GetClusterSecurityGroupID:       makeGetClusterSecurityGroupIDEndpoint(s.Cluster),
 		CreateVpc:                       makeCreateVpcEndpoint(s.Vpc),
 		DeleteVpc:                       makeDeleteVpcEndpoint(s.Vpc),
 		CreateExternalDNSKubeDeployment: makeCreateExternalDNSKubeDeploymentEndpoint(s.Kube),

--- a/pkg/api/core/service_cluster_api.go
+++ b/pkg/api/core/service_cluster_api.go
@@ -3,8 +3,6 @@ package core
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/mishudark/errors"
 	"github.com/oslokommune/okctl/pkg/api"
@@ -53,7 +51,7 @@ func (s *clusterService) GetClusterSecurityGroupID(
 		Name: &opts.ID.ClusterName,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("describing cluster: %w", err)
+		return nil, errors.E(err, "describing cluster", errors.Internal)
 	}
 
 	return &api.ClusterSecurityGroupID{

--- a/pkg/api/core/service_cluster_api.go
+++ b/pkg/api/core/service_cluster_api.go
@@ -3,6 +3,7 @@ package core
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/mishudark/errors"
 	"github.com/oslokommune/okctl/pkg/api"
@@ -45,7 +46,7 @@ func (s *clusterService) DeleteCluster(_ context.Context, opts api.ClusterDelete
 // GetClusterSecurityGroupID returns the EKS cluster's security group ID.
 // See https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
 func (s *clusterService) GetClusterSecurityGroupID(
-	ctx context.Context, opts api.ClusterSecurityGroupIDGetOpts,
+	ctx context.Context, opts *api.ClusterSecurityGroupIDGetOpts,
 ) (*api.ClusterSecurityGroupID, error) {
 	cluster, err := s.cloudProvider.EKS().DescribeClusterWithContext(ctx, &eks.DescribeClusterInput{
 		Name: &opts.ID.ClusterName,

--- a/pkg/api/core/service_cluster_api_test.go
+++ b/pkg/api/core/service_cluster_api_test.go
@@ -80,7 +80,7 @@ func TestGetClusterSecurityGroupId(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			clusterSecurityGroupID, err := tc.service.GetClusterSecurityGroupID(context.Background(), tc.opts)
+			clusterSecurityGroupID, err := tc.service.GetClusterSecurityGroupID(context.Background(), &tc.opts)
 
 			if tc.expectError {
 				assert.Error(t, err)

--- a/pkg/api/core/service_cluster_api_test.go
+++ b/pkg/api/core/service_cluster_api_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	awsmock "github.com/oslokommune/okctl/pkg/mock"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/oslokommune/okctl/pkg/api"
 	"github.com/oslokommune/okctl/pkg/api/core"
@@ -23,6 +25,7 @@ func TestClusterCreateCluster(t *testing.T) {
 			name: "Validate request",
 			service: core.NewClusterService(
 				mock.NewGoodClusterExe(),
+				awsmock.NewGoodCloudProvider(),
 			),
 			opts:   mock.DefaultClusterCreateOpts(),
 			expect: mock.DefaultCluster(),
@@ -31,6 +34,7 @@ func TestClusterCreateCluster(t *testing.T) {
 			name: "Invalid opts",
 			service: core.NewClusterService(
 				mock.NewGoodClusterExe(),
+				awsmock.NewGoodCloudProvider(),
 			),
 			opts: api.ClusterCreateOpts{},
 			//nolint: lll
@@ -50,6 +54,40 @@ func TestClusterCreateCluster(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Empty(t, cmp.Diff(tc.expect, got))
+			}
+		})
+	}
+}
+
+func TestGetClusterSecurityGroupId(t *testing.T) {
+	testCases := []struct {
+		name        string
+		service     api.ClusterService
+		opts        api.ClusterSecurityGroupIDGetOpts
+		expect      interface{}
+		expectError bool
+	}{
+		{
+			name: "Should work",
+			service: core.NewClusterService(
+				mock.NewGoodClusterExe(),
+				awsmock.NewGoodCloudProvider(),
+			),
+			opts:   mock.DefaultClusterSecurityGroupIDGetOpts(),
+			expect: mock.DefaultClusterSecurityGroupID(),
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			clusterSecurityGroupID, err := tc.service.GetClusterSecurityGroupID(context.Background(), tc.opts)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expect, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Empty(t, cmp.Diff(tc.expect, clusterSecurityGroupID))
 			}
 		})
 	}

--- a/pkg/api/core/transport_cluster.go
+++ b/pkg/api/core/transport_cluster.go
@@ -29,3 +29,14 @@ func decodeClusterDeleteRequest(_ context.Context, r *http.Request) (interface{}
 
 	return cluster, nil
 }
+
+func decodeGetClusterSecurityGroupIDRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	var opts api.ClusterSecurityGroupIDGetOpts
+
+	err := json.NewDecoder(r.Body).Decode(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}

--- a/pkg/api/core/transport_cluster.go
+++ b/pkg/api/core/transport_cluster.go
@@ -29,14 +29,3 @@ func decodeClusterDeleteRequest(_ context.Context, r *http.Request) (interface{}
 
 	return cluster, nil
 }
-
-func decodeGetClusterSecurityGroupIDRequest(_ context.Context, r *http.Request) (interface{}, error) {
-	var opts api.ClusterSecurityGroupIDGetOpts
-
-	err := json.NewDecoder(r.Body).Decode(&opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return opts, nil
-}

--- a/pkg/api/mock/cluster_mock.go
+++ b/pkg/api/mock/cluster_mock.go
@@ -53,6 +53,8 @@ const (
 	DefaultPolicyARN = "arn:aws:iam::123456789012:policy/somePolicy"
 	// DefaultDomainName is the default domain name
 	DefaultDomainName = "test.oslo.systems"
+	// DefaultClusterSecurityGroupIDValue is the default domain name
+	DefaultClusterSecurityGroupIDValue = "sg-2430fjm0fgCLUSTER"
 )
 
 // ErrBad just defines a mocked error
@@ -106,6 +108,13 @@ func DefaultClusterCreateOpts() api.ClusterCreateOpts {
 		VpcID:             DefaultVpcID,
 		VpcPrivateSubnets: DefaultVpcPrivateSubnets(),
 		VpcPublicSubnets:  DefaultVpcPublicSubnets(),
+	}
+}
+
+// DefaultClusterSecurityGroupIDGetOpts returns options for getting a cluster security group ID with defaults set
+func DefaultClusterSecurityGroupIDGetOpts() api.ClusterSecurityGroupIDGetOpts {
+	return api.ClusterSecurityGroupIDGetOpts{
+		ID: DefaultID(),
 	}
 }
 
@@ -183,6 +192,13 @@ func DefaultCluster() *api.Cluster {
 	return &api.Cluster{
 		ID:     DefaultID(),
 		Config: DefaultClusterConfig(),
+	}
+}
+
+// DefaultClusterSecurityGroupID returns a default cluster security group ID
+func DefaultClusterSecurityGroupID() *api.ClusterSecurityGroupID {
+	return &api.ClusterSecurityGroupID{
+		Value: DefaultClusterSecurityGroupIDValue,
 	}
 }
 

--- a/pkg/client/cluster_client.go
+++ b/pkg/client/cluster_client.go
@@ -31,16 +31,23 @@ type ClusterDeleteOpts struct {
 	FargateProfileName string
 }
 
-// ClusterService orchestrates the creation of a cluster
+// GetClusterSecurityGroupIDOpts specifies the required inputs for getting a cluster
+type GetClusterSecurityGroupIDOpts struct {
+	ID api.ID
+}
+
+// ClusterService manages a cluster
 type ClusterService interface {
 	CreateCluster(context.Context, ClusterCreateOpts) (*Cluster, error)
 	DeleteCluster(context.Context, ClusterDeleteOpts) error
+	GetClusterSecurityGroupID(ctx context.Context, opts GetClusterSecurityGroupIDOpts) (*api.ClusterSecurityGroupID, error)
 }
 
 // ClusterAPI invokes the API calls for creating a cluster
 type ClusterAPI interface {
 	CreateCluster(opts api.ClusterCreateOpts) (*api.Cluster, error)
 	DeleteCluster(opts api.ClusterDeleteOpts) error
+	GetClusterSecurityGroupID(opts api.ClusterSecurityGroupIDGetOpts) (*api.ClusterSecurityGroupID, error)
 }
 
 // ClusterState implements the state layer

--- a/pkg/client/core/api/rest/cluster_rest.go
+++ b/pkg/client/core/api/rest/cluster_rest.go
@@ -9,7 +9,7 @@ import (
 const ClusterTarget = "clusters/"
 
 // ClusterSecurityGroupIDTarget is the API route for HTTP requests
-const ClusterSecurityGroupIDTarget = "clustersecuritygroupid/"
+const ClusterSecurityGroupIDTarget = ClusterTarget + "clustersecuritygroupid/"
 
 type clusterAPI struct {
 	client *HTTPClient

--- a/pkg/client/core/api/rest/cluster_rest.go
+++ b/pkg/client/core/api/rest/cluster_rest.go
@@ -25,8 +25,8 @@ func (a *clusterAPI) DeleteCluster(opts api.ClusterDeleteOpts) error {
 }
 
 func (a *clusterAPI) GetClusterSecurityGroupID(opts api.ClusterSecurityGroupIDGetOpts) (*api.ClusterSecurityGroupID, error) {
-	id := &api.ClusterSecurityGroupID{}
-	return id, a.client.DoGet(ClusterSecurityGroupIDTarget, &opts, id)
+	into := &api.ClusterSecurityGroupID{}
+	return into, a.client.DoGet(ClusterSecurityGroupIDTarget, opts, into)
 }
 
 // NewClusterAPI returns an initialised cluster API

--- a/pkg/client/core/api/rest/cluster_rest.go
+++ b/pkg/client/core/api/rest/cluster_rest.go
@@ -26,7 +26,7 @@ func (a *clusterAPI) DeleteCluster(opts api.ClusterDeleteOpts) error {
 
 func (a *clusterAPI) GetClusterSecurityGroupID(opts api.ClusterSecurityGroupIDGetOpts) (*api.ClusterSecurityGroupID, error) {
 	id := &api.ClusterSecurityGroupID{}
-	return id, a.client.DoGet(ClusterSecurityGroupIDTarget, &opts, &id)
+	return id, a.client.DoGet(ClusterSecurityGroupIDTarget, &opts, id)
 }
 
 // NewClusterAPI returns an initialised cluster API

--- a/pkg/client/core/api/rest/cluster_rest.go
+++ b/pkg/client/core/api/rest/cluster_rest.go
@@ -8,6 +8,9 @@ import (
 // ClusterTarget is the API route for HTTP requests
 const ClusterTarget = "clusters/"
 
+// ClusterSecurityGroupIDTarget is the API route for HTTP requests
+const ClusterSecurityGroupIDTarget = "clustersecuritygroupid/"
+
 type clusterAPI struct {
 	client *HTTPClient
 }
@@ -19,6 +22,11 @@ func (a *clusterAPI) CreateCluster(opts api.ClusterCreateOpts) (*api.Cluster, er
 
 func (a *clusterAPI) DeleteCluster(opts api.ClusterDeleteOpts) error {
 	return a.client.DoDelete(ClusterTarget, &opts)
+}
+
+func (a *clusterAPI) GetClusterSecurityGroupID(opts api.ClusterSecurityGroupIDGetOpts) (*api.ClusterSecurityGroupID, error) {
+	id := &api.ClusterSecurityGroupID{}
+	return id, a.client.DoGet(ClusterSecurityGroupIDTarget, &opts, &id)
 }
 
 // NewClusterAPI returns an initialised cluster API

--- a/pkg/client/core/service_application_postgres_client.go
+++ b/pkg/client/core/service_application_postgres_client.go
@@ -33,6 +33,7 @@ type applicationPostgresService struct {
 	securityGroupAPI       client.SecurityGroupAPI
 	vpcService             client.VPCService
 	applicationPostgresAPI client.ApplicationPostgresAPI
+	clusterService         client.ClusterService
 }
 
 // AddPostgresToApplication does the required steps for allowing EKS pod to RDS traffic
@@ -52,7 +53,7 @@ func (a *applicationPostgresService) AddPostgresToApplication(ctx context.Contex
 		return fmt.Errorf("fetching database: %w", err)
 	}
 
-	securityGroup, err := a.securityGroupAPI.CreateSecurityGroup(ctx, api.CreateSecurityGroupOpts{
+	appSecurityGroup, err := a.securityGroupAPI.CreateSecurityGroup(ctx, api.CreateSecurityGroupOpts{
 		ClusterID:     clusterID,
 		VPCID:         vpc.VpcID,
 		Name:          opts.Application.Metadata.Name,
@@ -64,33 +65,14 @@ func (a *applicationPostgresService) AddPostgresToApplication(ctx context.Contex
 		return fmt.Errorf("creating security group: %w", err)
 	}
 
-	err = a.generateSecurityGroupPolicy(ctx, opts.Cluster, opts.Application, appSecurityGroup)
+	err = a.allowTrafficFromAppToRDS(ctx, opts, appSecurityGroup)
 	if err != nil {
-		return fmt.Errorf("generating security group policy: %w", err)
+		return fmt.Errorf("allowing traffic to RDS: %w", err)
 	}
 
-	stackName := cfn.NewStackNamer().RDSPostgres(opts.DatabaseName, opts.Cluster.Metadata.Name)
-
-	resourceName := components.NewRDSPostgresComposer(components.RDSPostgresComposerOpts{
-		ApplicationDBName: opts.DatabaseName,
-		ClusterName:       opts.Cluster.Metadata.Name,
-	}).CloudFormationResourceName("RDSPostgresIncoming")
-
-	_, err = a.securityGroupAPI.AddRule(ctx, api.AddRuleOpts{
-		ClusterName:               opts.Cluster.Metadata.Name,
-		SecurityGroupStackName:    stackName,
-		SecurityGroupResourceName: resourceName,
-		RuleType:                  api.RuleTypeIngress,
-		Rule: api.Rule{
-			Description:           fmt.Sprintf("Allow postgres traffic from %s", opts.Application.Metadata.Name),
-			FromPort:              postgresPort,
-			ToPort:                postgresPort,
-			Protocol:              api.RuleProtocolTCP,
-			SourceSecurityGroupID: appSecurityGroup.ID,
-		},
-	})
+	err = a.createSecurityGroupPolicy(ctx, opts, appSecurityGroup)
 	if err != nil {
-		return fmt.Errorf("adding incoming rule for database security group: %w", err)
+		return fmt.Errorf("creating security group policy: %w", err)
 	}
 
 	err = a.disableEarlyTCPDemux(ctx, clusterID)
@@ -184,7 +166,64 @@ func (a *applicationPostgresService) HasPostgresIntegration(ctx context.Context,
 	}), nil
 }
 
-func (a *applicationPostgresService) generateSecurityGroupPolicy(ctx context.Context, cluster v1alpha1.Cluster, app v1alpha1.Application, sg api.SecurityGroup) error {
+func (a *applicationPostgresService) allowTrafficFromAppToRDS(ctx context.Context, opts client.AddPostgresToApplicationOpts, appSecurityGroup api.SecurityGroup) error {
+	stackName := cfn.NewStackNamer().RDSPostgres(opts.DatabaseName, opts.Cluster.Metadata.Name)
+
+	resourceName := components.NewRDSPostgresComposer(components.RDSPostgresComposerOpts{
+		ApplicationDBName: opts.DatabaseName,
+		ClusterName:       opts.Cluster.Metadata.Name,
+	}).CloudFormationResourceName("RDSPostgresIncoming")
+
+	_, err := a.securityGroupAPI.AddRule(ctx, api.AddRuleOpts{
+		ClusterName:               opts.Cluster.Metadata.Name,
+		SecurityGroupStackName:    stackName,
+		SecurityGroupResourceName: resourceName,
+		RuleType:                  api.RuleTypeIngress,
+		Rule: api.Rule{
+			Description:           fmt.Sprintf("Allow postgres traffic from %s", opts.Application.Metadata.Name),
+			FromPort:              postgresPort,
+			ToPort:                postgresPort,
+			Protocol:              api.RuleProtocolTCP,
+			SourceSecurityGroupID: appSecurityGroup.ID,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("adding incoming rule for database security group: %w", err)
+	}
+
+	return nil
+}
+
+func (a *applicationPostgresService) createSecurityGroupPolicy(
+	ctx context.Context,
+	opts client.AddPostgresToApplicationOpts,
+	appSecurityGroup api.SecurityGroup,
+) error {
+	clusterID := clusterMetaAsID(opts.Cluster.Metadata)
+
+	clusterSecurityGroupID, err := a.clusterService.GetClusterSecurityGroupID(ctx, client.GetClusterSecurityGroupIDOpts{
+		ID: clusterID,
+	})
+	if err != nil {
+		return fmt.Errorf("getting cluster security group ID: %w", err)
+	}
+
+	err = a.generateSecurityGroupPolicyManifest(
+		ctx, opts.Cluster, opts.Application, appSecurityGroup, clusterSecurityGroupID.Value)
+	if err != nil {
+		return fmt.Errorf("generating security group policy: %w", err)
+	}
+
+	return nil
+}
+
+func (a *applicationPostgresService) generateSecurityGroupPolicyManifest(
+	ctx context.Context,
+	cluster v1alpha1.Cluster,
+	app v1alpha1.Application,
+	appSecurityGroup api.SecurityGroup,
+	clusterSecurityGroupID string,
+) error {
 	baseManifest, err := scaffold.ResourceAsBytes(resources.CreateSecurityGroupPolicy(app))
 	if err != nil {
 		return fmt.Errorf("converting security group policy to bytes: %w", err)
@@ -208,7 +247,12 @@ func (a *applicationPostgresService) generateSecurityGroupPolicy(ctx context.Con
 				{
 					Type:  jsonpatch.OperationTypeAdd,
 					Path:  "/spec/securityGroups/groupIds/0",
-					Value: sg.ID,
+					Value: clusterSecurityGroupID,
+				},
+				{
+					Type:  jsonpatch.OperationTypeAdd,
+					Path:  "/spec/securityGroups/groupIds/1",
+					Value: appSecurityGroup.ID,
 				},
 			},
 		},
@@ -347,6 +391,7 @@ func NewApplicationPostgresService(
 	securityGroupAPI client.SecurityGroupAPI,
 	vpcService client.VPCService,
 	applicationPostgresAPI client.ApplicationPostgresAPI,
+	clusterService client.ClusterService,
 ) client.ApplicationPostgresService {
 	return &applicationPostgresService{
 		manifestService:        manifestService,
@@ -354,5 +399,6 @@ func NewApplicationPostgresService(
 		securityGroupAPI:       securityGroupAPI,
 		vpcService:             vpcService,
 		applicationPostgresAPI: applicationPostgresAPI,
+		clusterService:         clusterService,
 	}
 }

--- a/pkg/client/core/service_cluster_client.go
+++ b/pkg/client/core/service_cluster_client.go
@@ -94,6 +94,12 @@ func (s *clusterService) DeleteCluster(_ context.Context, opts client.ClusterDel
 	return nil
 }
 
+func (s *clusterService) GetClusterSecurityGroupID(_ context.Context, opts client.GetClusterSecurityGroupIDOpts) (*api.ClusterSecurityGroupID, error) {
+	return s.api.GetClusterSecurityGroupID(api.ClusterSecurityGroupIDGetOpts{
+		ID: opts.ID,
+	})
+}
+
 // NewClusterService returns an initialised cluster service
 func NewClusterService(
 	api client.ClusterAPI,

--- a/pkg/controller/cluster/reconciliation/cluster_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/cluster_reconciler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/api"
+
 	"github.com/oslokommune/okctl/pkg/config/constant"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -125,6 +127,10 @@ func (m mockClusterService) DeleteCluster(_ context.Context, _ client.ClusterDel
 	m.deletionBump()
 
 	return nil
+}
+
+func (m mockClusterService) GetClusterSecurityGroupID(_ context.Context, _ client.GetClusterSecurityGroupIDOpts) (*api.ClusterSecurityGroupID, error) {
+	panic("implement me")
 }
 
 func createCloudProvider(serviceQuotaOK bool) v1alpha1.CloudProvider {

--- a/pkg/jsonpatch/jsonpatch.go
+++ b/pkg/jsonpatch/jsonpatch.go
@@ -109,6 +109,17 @@ func (p *Patch) HasOperation(operation Operation) bool {
 	return false
 }
 
+// HasOperations determines if a patch contains all the given operations
+func (p *Patch) HasOperations(operations []Operation) bool {
+	for _, op := range operations {
+		if !p.HasOperation(op) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // MarshalJSON knows how to turn a Patch into a kustomize patch.json
 func (p Patch) MarshalJSON() ([]byte, error) {
 	type serializedOperation struct {

--- a/pkg/jsonpatch/jsonpatch_test.go
+++ b/pkg/jsonpatch/jsonpatch_test.go
@@ -55,3 +55,42 @@ func TestMarshallPatch(t *testing.T) {
 		})
 	}
 }
+
+func TestHasOperations(t *testing.T) {
+	testCases := []struct {
+		name           string
+		withPatch      Patch
+		expectContains []Operation
+	}{
+		{
+			name: "Should work",
+			withPatch: Patch{
+				Operations: []Operation{
+					{
+						Type:  OperationTypeAdd,
+						Path:  "/hello",
+						Value: "howdy",
+					},
+					{
+						Type:  OperationTypeAdd,
+						Path:  "/bye",
+						Value: "bye",
+					},
+				},
+			},
+			expectContains: []Operation{
+				{
+					Type:  OperationTypeAdd,
+					Path:  "/bye",
+					Value: "bye",
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, tc.withPatch.HasOperations(tc.expectContains))
+		})
+	}
+}

--- a/pkg/mock/aws.go
+++ b/pkg/mock/aws.go
@@ -193,6 +193,11 @@ func (a *EKSAPI) DescribeCluster(input *eks.DescribeClusterInput) (*eks.Describe
 	return a.DescribeClusterFn(input)
 }
 
+// DescribeClusterWithContext mocks describe cluster with context invocation
+func (a *EKSAPI) DescribeClusterWithContext(_ aws.Context, input *eks.DescribeClusterInput, _ ...request.Option) (*eks.DescribeClusterOutput, error) {
+	return a.DescribeClusterFn(input)
+}
+
 // DescribeFargateProfile mocks the API invocation
 func (a *EKSAPI) DescribeFargateProfile(input *eks.DescribeFargateProfileInput) (*eks.DescribeFargateProfileOutput, error) {
 	return a.DescribeFargateProfileFn(input)
@@ -239,6 +244,15 @@ func (a *EC2API) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOu
 
 // DescribeSecurityGroups invokes the mocked response
 func (a *EC2API) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return a.DescribeSecurityGroupsFn(input)
+}
+
+// DescribeSecurityGroupsWithContext invokes the mocked response
+func (a *EC2API) DescribeSecurityGroupsWithContext(_ aws.Context, input *ec2.DescribeSecurityGroupsInput, _ ...request.Option) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return a.DescribeSecurityGroupsFn(input)
+}
+
+func (a *EC2API) DescribeSecurityGroupsWithContext2(_ aws.Context, input *ec2.DescribeSecurityGroupsInput, _ ...request.Option) (*ec2.DescribeSecurityGroupsOutput, error) {
 	return a.DescribeSecurityGroupsFn(input)
 }
 
@@ -1357,6 +1371,9 @@ func NewGoodCloudProvider() *CloudProvider {
 						Endpoint: aws.String("https://something"),
 						Name:     aws.String(mock.DefaultClusterName),
 						Status:   aws.String(eks.ClusterStatusActive),
+						ResourcesVpcConfig: &eks.VpcConfigResponse{
+							ClusterSecurityGroupId: aws.String(mock.DefaultClusterSecurityGroupIDValue),
+						},
 					},
 				}, nil
 			},

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -300,6 +300,7 @@ func (o *Okctl) ClientServices(handlers *clientCore.StateHandlers) (*clientCore.
 		rest.NewSecurityGroupAPI(o.restClient),
 		vpcService,
 		rest.NewApplicationPostgresIntegrationAPI(o.restClient),
+		clusterService,
 	)
 
 	monitoringService := clientCore.NewMonitoringService(
@@ -436,6 +437,7 @@ func (o *Okctl) initialise() error {
 			o.BinariesProvider,
 			o.CloudProvider,
 		),
+		o.CloudProvider,
 	)
 
 	managedPolicyService := core.NewManagedPolicyService(awsProvider.NewManagedPolicyCloudProvider(o.CloudProvider))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds the control plane security group to `infrastructure/application/some-app/overlays/securitygrouppolicy-patch.json`.

## Description

<!--- Describe your changes in detail -->

This PR provides a step to fixing cluster communication between services, which currently doesn't work, while using security groups.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[KM434](https://trello.com/c/N6PTVzf4/434-fix-communication-for-pods-with-security-group)

## How to prove the effect of this PR?

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

Run `okctl -c my-cluster.yaml apply application -f my-app.yaml`. The output file `securitygrouppolicy-patch.json` should include two security groups. One of them should be the same as running

```
aws eks describe-cluster --name <cluster_name> --query cluster.resourcesVpcConfig.clusterSecurityGroupId
```

This is the same as the security group with the description

> EKS created security group applied to ENI that is attached to EKS Control Plane master nodes, as well as any managed workloads.

in EC2->Security groups.

Source: https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (See: https://github.com/oslokommune/okctl/commit/446e412a110c05f841e526045625cb794ebf044e)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
