### PR TITLE
KM451 Create direct Helm service client

### DIFF
--- a/pkg/client/core/api/direct/helm_direct_api.go
+++ b/pkg/client/core/api/direct/helm_direct_api.go
@@ -23,8 +23,9 @@ func (d *helmDirectClient) DeleteHelmRelease(opts api.DeleteHelmReleaseOpts) err
 	return d.service.DeleteHelmRelease(context.Background(), opts)
 }
 
+// NewHelmAPI initializes a helm API that uses the server side service directly
 func NewHelmAPI(service api.HelmService) client.HelmAPI {
 	return &helmDirectClient{
-		service:service,
+		service: service,
 	}
 }

--- a/pkg/client/core/api/direct/helm_direct_api.go
+++ b/pkg/client/core/api/direct/helm_direct_api.go
@@ -1,0 +1,30 @@
+package direct
+
+import (
+	"context"
+
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+)
+
+type helmDirectClient struct {
+	service api.HelmService
+}
+
+func (d *helmDirectClient) GetHelmRelease(opts api.GetHelmReleaseOpts) (*api.Helm, error) {
+	return d.service.GetHelmRelease(context.Background(), opts)
+}
+
+func (d *helmDirectClient) CreateHelmRelease(opts api.CreateHelmReleaseOpts) (*api.Helm, error) {
+	return d.service.CreateHelmRelease(context.Background(), opts)
+}
+
+func (d *helmDirectClient) DeleteHelmRelease(opts api.DeleteHelmReleaseOpts) error {
+	return d.service.DeleteHelmRelease(context.Background(), opts)
+}
+
+func NewHelmAPI(service api.HelmService) client.HelmAPI {
+	return &helmDirectClient{
+		service:service,
+	}
+}

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -190,8 +190,52 @@ func (o *Okctl) ClientServices(handlers *clientCore.StateHandlers) (*clientCore.
 		return nil, err
 	}
 
+	homeDir, err := o.GetHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	appDir, err := o.GetUserDataDir()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeConfigStore, err := o.KubeConfigStore()
+	if err != nil {
+		return nil, err
+	}
+
+	o.kubeConfigStore = kubeConfigStore
+
+	awsIamAuth, err := o.BinariesProvider.AwsIamAuthenticator(awsiamauthenticator.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	helmRun := run.NewHelmRun(
+		helm.New(&helm.Config{
+			HomeDir:              homeDir,
+			Path:                 fmt.Sprintf("/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:%s", path.Dir(awsIamAuth.BinaryPath)),
+			HelmPluginsDirectory: path.Join(appDir, constant.DefaultHelmBaseDir, constant.DefaultHelmPluginsDirectory),
+			HelmRegistryConfig:   path.Join(appDir, constant.DefaultHelmBaseDir, constant.DefaultHelmRegistryConfig),
+			HelmRepositoryConfig: path.Join(appDir, constant.DefaultHelmBaseDir, constant.DefaultHelmRepositoryConfig),
+			HelmRepositoryCache:  path.Join(appDir, constant.DefaultHelmBaseDir, constant.DefaultHelmRepositoryCache),
+			HelmBaseDir:          path.Join(appDir, constant.DefaultHelmBaseDir),
+			Debug:                o.Debug,
+			DebugOutput:          o.Err,
+		},
+			o.CredentialsProvider.Aws(),
+			o.FileSystem,
+		),
+		kubeConfigStore,
+	)
+
+	helmAPIService := core.NewHelmService(
+		helmRun,
+	)
+
 	helmService := clientCore.NewHelmService(
-		rest.NewHelmAPI(o.restClient),
+		clientDirectAPI.NewHelmAPI(helmAPIService),
 		handlers.Helm,
 	)
 


### PR DESCRIPTION
Create a client to use the Helm service directly instead of via REST call.

## Description

Created a direct client and wired it up in the ClientServices() function by replicating logic for initialising HelmRun and HelmService from the initialise() function.

## Motivation and Context

Step in removing the client-server split in okctl.

## How to prove the effect of this PR?

## Additional info

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
