### PR TITLE
KM445 👌 Add validations for okctl vs cluster version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,24 +62,3 @@ archives:
 
 checksum:
   name_template: 'okctl_checksums.txt'
-
-brews:
-  -
-    tap:
-      owner: oslokommune
-      name: homebrew-tap
-
-    commit_author:
-      name: okctl
-      email: okctl@oslo.kommune.no
-
-    folder: Formula
-
-    homepage: "https://github.com/oslokommune/okctl"
-
-    description: "Opinionated and effortless infrastructure and application management"
-
-    skip_upload: false
-
-    custom_block: |
-      head "https://github.com/oslokommune/okctl/releases/download/latest_release/okctl_Darwin_amd64.tar.gz"

--- a/cmd/okctl/apply_application.go
+++ b/cmd/okctl/apply_application.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/oslokommune/okctl/cmd/okctl/preruns"
 	"github.com/oslokommune/okctl/pkg/metrics"
 
@@ -50,6 +49,11 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 			preruns.InitializeOkctl(o),
 			func(cmd *cobra.Command, args []string) (err error) {
 				metrics.Publish(generateStartEvent(metrics.ActionApplyApplication))
+
+				err = commands.ValidateBinaryEqualsClusterVersion(o)
+				if err != nil {
+					return err
+				}
 
 				opts.Application, err = commands.InferApplicationFromStdinOrFile(*o.Declaration, o.In, o.FileSystem, opts.File)
 				if err != nil {

--- a/cmd/okctl/apply_application.go
+++ b/cmd/okctl/apply_application.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/oslokommune/okctl/cmd/okctl/preruns"
 	"github.com/oslokommune/okctl/pkg/metrics"
 

--- a/cmd/okctl/apply_cluster.go
+++ b/cmd/okctl/apply_cluster.go
@@ -150,7 +150,7 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 					state.Upgrade,
 				)
 
-				err = clusterVersioner.ValidateBinaryVsClusterVersion(version.GetVersionInfo().Version)
+				err = clusterVersioner.ValidateBinaryEqualsClusterVersion(version.GetVersionInfo().Version)
 				if err != nil {
 					return fmt.Errorf(commands.ValidateBinaryVsClusterVersionErr, err)
 				}

--- a/cmd/okctl/attach_postgres.go
+++ b/cmd/okctl/attach_postgres.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/oslokommune/okctl/cmd/okctl/preruns"
+	"github.com/oslokommune/okctl/pkg/commands"
 	"github.com/oslokommune/okctl/pkg/metrics"
 
 	"github.com/oslokommune/okctl/pkg/cfn"
@@ -53,6 +53,11 @@ func buildAttachPostgres(o *okctl.Okctl) *cobra.Command {
 				metrics.Publish(generateStartEvent(metrics.ActionAttachPostgres))
 
 				err := o.Initialise()
+				if err != nil {
+					return err
+				}
+
+				err = commands.ValidateBinaryEqualsClusterVersion(o)
 				if err != nil {
 					return err
 				}

--- a/cmd/okctl/attach_postgres.go
+++ b/cmd/okctl/attach_postgres.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/oslokommune/okctl/cmd/okctl/preruns"
 	"github.com/oslokommune/okctl/pkg/commands"
 	"github.com/oslokommune/okctl/pkg/metrics"

--- a/cmd/okctl/forward_postgres.go
+++ b/cmd/okctl/forward_postgres.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/oslokommune/okctl/pkg/commands"
 	"os"
 	"strings"
+
+	"github.com/oslokommune/okctl/pkg/commands"
 
 	"github.com/oslokommune/okctl/cmd/okctl/preruns"
 	"github.com/oslokommune/okctl/pkg/metrics"

--- a/cmd/okctl/forward_postgres.go
+++ b/cmd/okctl/forward_postgres.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/oslokommune/okctl/pkg/commands"
 	"os"
 	"strings"
 
@@ -68,6 +69,11 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 				}
 
 				err := o.Initialise()
+				if err != nil {
+					return err
+				}
+
+				err = commands.ValidateBinaryEqualsClusterVersion(o)
 				if err != nil {
 					return err
 				}

--- a/cmd/okctl/scaffold_application.go
+++ b/cmd/okctl/scaffold_application.go
@@ -38,6 +38,13 @@ func buildScaffoldApplicationCommand(o *okctl.Okctl) *cobra.Command {
 						return fmt.Errorf("inferring cluster declaration: %w", err)
 					}
 
+					o.Declaration = clusterDeclaration
+
+					err = commands.ValidateBinaryVersionNotLessThanClusterVersion(o)
+					if err != nil {
+						return err
+					}
+
 					opts.PrimaryHostedZone = clusterDeclaration.ClusterRootDomain
 				} else {
 					opts.PrimaryHostedZone = "okctl.io"

--- a/cmd/okctl/show.go
+++ b/cmd/okctl/show.go
@@ -59,6 +59,11 @@ func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
 					return err
 				}
 
+				err := commands.ValidateBinaryVersionNotLessThanClusterVersion(o)
+				if err != nil {
+					return err
+				}
+
 				return nil
 			},
 		),

--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -53,6 +53,11 @@ func buildVenvCommand(o *okctl.Okctl) *cobra.Command { //nolint: funlen
 
 				okctlEnvironment = e
 
+				err = commands.ValidateBinaryVersionNotLessThanClusterVersion(o)
+				if err != nil {
+					return err
+				}
+
 				return nil
 			},
 		),

--- a/docs/release_notes/0.0.75.md
+++ b/docs/release_notes/0.0.75.md
@@ -14,4 +14,3 @@ KM445 👌 Add validations for okctl vs cluster version (#786).
 * **NOTE to OS X / `brew` users:** To support a proper UX for upgrades, we have removed `brew` support from okctl. To get future versions of `okctl`, see https://okctl.io/getting-started/install/. See more details in #786.
 
 ## Other
-

--- a/docs/release_notes/0.0.75.md
+++ b/docs/release_notes/0.0.75.md
@@ -10,5 +10,8 @@ KM449 🐛 Make it possible to import okctl as a library
 
 KM406 👌 Use latest okctl github release as okctl development version (#765)
 
+KM445 👌 Add validations for okctl vs cluster version (#786).
+* **NOTE to OS X / `brew` users:** To support a proper UX for upgrades, we have removed `brew` support from okctl. To get future versions of `okctl`, see https://okctl.io/getting-started/install/. See more details in #786.
+
 ## Other
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -84,7 +84,7 @@ function publish_stop() {
   publish_start_stop $PHASE_KEY
 }
 
-publish_start
+# publish_start
 
 if [[ -z $1 ]]; then
   VERSION=latest
@@ -96,7 +96,7 @@ fi
 if command -v brew &> /dev/null; then
   # Check if okctl exists
   if brew list okctl &> /dev/null; then
-    publish_event brew_uninstall
+    # publish_event brew_uninstall
 
     echo Uninstalling okctl from brew
     brew uninstall okctl
@@ -112,4 +112,4 @@ else
   install_usr $VERSION
 fi
 
-publish_stop
+# publish_stop

--- a/install/install.sh
+++ b/install/install.sh
@@ -48,9 +48,9 @@ function install_usr() {
   echo "You can then test it by running:"
   echo -e "${C}okctl version${CX}"
   echo
-  echo -e "💡 Tip: To avoid having to run the ${C}sudo mv${CX} command above for future installations, you can ignore the"\
-    "${C}sudo mv${CX} command above, and instead do the following:"
-  echo -e "- Create the directory ${BOLD}~/.local/bin${CX} and add it to your PATH."
+  echo -e "💡 Tip: To avoid having to run the ${C}sudo mv${CX} command above for future installations, you can do the following:"
+  echo -e "- Create the directory ${BOLD}~/.local/bin${CX}"
+  echo -e "- Add ${BOLD}~/.local/bin${CX} to your PATH."
   echo "- Re-run this installation. This installation will detect the directory, and put okctl there."
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -40,6 +40,9 @@ function install_usr() {
   echo
   echo "Then test it by running"
   echo -e "${C}okctl version${CX}"
+  echo
+  echo -e "💡 Tip: To avoid having to run the ${C}sudo mv${CX} command above in the future, create the directory"\
+    "\033[1m~/.local/bin${CX} and add it to your PATH."
 }
 
 if [[ -z $1 ]]; then

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-C='\033[0;32m'
+CMD='\033[1;32m'
 BOLD='\033[1m'
 CX='\033[0m'
 USER_AGENT=$(grep -Po "userAgent: \K[a-zA-Z0-9]+$" ~/.okctl/conf.yml 2>/dev/null || echo okctl)
@@ -19,14 +19,14 @@ function fetch_binary() {
 
 function install_local_bin() {
   if [[ -f /usr/local/bin/okctl ]]; then
-    echo "You need to remove the old version of okctl before continuing. Run the following command:"
-    echo -e "${C}sudo rm /usr/local/bin/okctl${CX}"
+    echo "❗ Installation NOT complete. You need to remove the old version of okctl before continuing. Run the following command:"
+    echo -e "${CMD}sudo rm /usr/local/bin/okctl${CX}"
     echo
     echo "and then re-run this installation."
     echo
     echo -e "Reason: This installation has detected that you have ${BOLD}~/.local/bin${CX} added to your PATH, so the okctl"\
       "binary will be put there instead. By doing this, future installations should be completely automatic, without the need"\
-      "for running the ${C}sudo rm${CX} command above."
+      "for running the ${CMD}sudo rm${CX} command above."
     exit 1
   fi
 
@@ -34,21 +34,22 @@ function install_local_bin() {
 
   mv /tmp/okctl $HOME/.local/bin
   echo "Successfully installed okctl. You can test it by running:"
-  echo -e "${C}okctl version${CX}"
+  echo -e "${CMD}okctl version${CX}"
 }
 
 function install_usr() {
   fetch_binary $1
 
-  echo "okctl downloaded. To complete installation, run:"
-  printf $C
-  echo sudo mv /tmp/okctl /usr/local/bin
+  echo "Done."
+  echo
+  echo "-------------------------------------------------------------------------------------------------------------------------"
+  echo "To complete installation, run:"
+  printf $CMD
+  echo "sudo mv /tmp/okctl /usr/local/bin"
   printf $CX
+  echo "-------------------------------------------------------------------------------------------------------------------------"
   echo
-  echo "You can then test it by running:"
-  echo -e "${C}okctl version${CX}"
-  echo
-  echo -e "💡 Tip: To avoid having to run the ${C}sudo mv${CX} command above for future installations, you can do the following:"
+  echo -e "💡 Tip: To avoid having to run the ${CMD}sudo mv${CX} command above for future installations, you can do the following:"
   echo -e "- Create the directory ${BOLD}~/.local/bin${CX}"
   echo -e "- Add ${BOLD}~/.local/bin${CX} to your PATH."
   echo "- Re-run this installation. This installation will detect the directory, and put okctl there."
@@ -99,9 +100,8 @@ if command -v brew &> /dev/null; then
     # publish_event brew_uninstall
 
     echo Uninstalling okctl from brew
-    brew uninstall okctl
-    brew untap oslokommune/tap
-    echo
+    brew uninstall okctl &> /tmp/okctl_brew_uninstall.txt
+    brew untap oslokommune/tap &>> /tmp/okctl_brew_uninstall.txt
   fi
 fi
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+C='\033[0;32m'
+CX='\033[0m'
+
+function fetch_binary() {
+  VERSION=$1
+  if [[ $VERSION == "latest" ]]; then
+    echo "Downloading latest version of okctl..."
+    curl --silent --location "https://github.com/oslokommune/okctl/releases/latest/download/okctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp okctl
+  else
+    echo "Downloading version '$VERSION' of okctl..."
+    curl --silent --location "https://github.com/oslokommune/okctl/releases/download/v$VERSION/okctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp okctl
+  fi
+}
+
+function install_local_bin() {
+  if [[ -f /usr/local/bin/okctl ]]; then
+    echo "You need to remove the old version of okctl before continuing. Run the following command"
+    echo -e "${C}sudo rm /usr/local/bin/okctl${CX}"
+    echo
+    echo "and then re-run this installation."
+    exit 1
+  fi
+
+  fetch_binary $1
+
+  mv /tmp/okctl $HOME/.local/bin
+  echo "Successfully installed okctl. Test it by running:"
+  echo -e "${C}okctl version${CX}"
+}
+
+function install_usr() {
+  fetch_binary $1
+
+  echo "okctl downloaded. To complete installation, run"
+  printf $C
+  echo sudo mv /tmp/okctl /usr/local/bin
+  printf $CX
+  echo
+  echo "Then test it by running"
+  echo -e "${C}okctl version${CX}"
+}
+
+if [[ -z $1 ]]; then
+  VERSION=latest
+else
+  VERSION=$1
+fi
+
+# Check if brew exists
+if command -v brew &> /dev/null; then
+  # Check if okctl exists
+  if brew list okctl &> /dev/null; then
+    echo Uninstalling okctl from brew
+    brew uninstall okctl
+    brew untap oslokommune/tap
+    echo
+  fi
+fi
+
+if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]] && [[ -d $HOME/.local/bin ]]
+then
+  install_local_bin $VERSION
+else
+  install_usr $VERSION
+fi
+

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 C='\033[0;32m'
+BOLD='\033[1m'
 CX='\033[0m'
+
 
 function fetch_binary() {
   VERSION=$1
@@ -16,33 +18,39 @@ function fetch_binary() {
 
 function install_local_bin() {
   if [[ -f /usr/local/bin/okctl ]]; then
-    echo "You need to remove the old version of okctl before continuing. Run the following command"
+    echo "You need to remove the old version of okctl before continuing. Run the following command:"
     echo -e "${C}sudo rm /usr/local/bin/okctl${CX}"
     echo
     echo "and then re-run this installation."
+    echo
+    echo -e "Reason: This installation has detected that you have ${BOLD}~/.local/bin${CX} added to your PATH, so the okctl"\
+      "binary will be put there instead. By doing this, future installations should be completely automatic, without the need"\
+      "for running the ${C}sudo rm${CX} command above."
     exit 1
   fi
 
   fetch_binary $1
 
   mv /tmp/okctl $HOME/.local/bin
-  echo "Successfully installed okctl. Test it by running:"
+  echo "Successfully installed okctl. You can test it by running:"
   echo -e "${C}okctl version${CX}"
 }
 
 function install_usr() {
   fetch_binary $1
 
-  echo "okctl downloaded. To complete installation, run"
+  echo "okctl downloaded. To complete installation, run:"
   printf $C
   echo sudo mv /tmp/okctl /usr/local/bin
   printf $CX
   echo
-  echo "Then test it by running"
+  echo "You can then test it by running:"
   echo -e "${C}okctl version${CX}"
   echo
-  echo -e "💡 Tip: To avoid having to run the ${C}sudo mv${CX} command above in the future, create the directory"\
-    "\033[1m~/.local/bin${CX} and add it to your PATH."
+  echo -e "💡 Tip: To avoid having to run the ${C}sudo mv${CX} command above for future installations, you can ignore the"\
+    "${C}sudo mv${CX} command above, and instead do the following:"
+  echo -e "- Create the directory ${BOLD}~/.local/bin${CX} and add it to your PATH."
+  echo "- Re-run this installation. This installation will detect the directory, and put okctl there."
 }
 
 if [[ -z $1 ]]; then

--- a/pkg/clusterconfig/clusterconfig_test.go
+++ b/pkg/clusterconfig/clusterconfig_test.go
@@ -2,9 +2,10 @@ package clusterconfig_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/oslokommune/okctl/pkg/github"
 	"github.com/oslokommune/okctl/pkg/version/developmentversion"
-	"testing"
 
 	"github.com/oslokommune/okctl/pkg/config/constant"
 

--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -1,7 +1,59 @@
 package commands
 
+import (
+	"fmt"
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/oslokommune/okctl/pkg/upgrade/clusterversion"
+	"github.com/oslokommune/okctl/pkg/version"
+)
+
 // ValidateBinaryVsClusterVersionErr contains the error message for invalid binary vs cluster version
 const ValidateBinaryVsClusterVersionErr = "validating binary against cluster version: %w"
 
 // SaveClusterVersionErr contains the error message for error with saving cluster version
 const SaveClusterVersionErr = "saving cluster version: %w"
+
+// ValidateBinaryEqualsClusterVersion is a wrapper for clusterVersioner.ValidateBinaryEqualsClusterVersion
+func ValidateBinaryEqualsClusterVersion(o *okctl.Okctl) error {
+	clusterID := api.ID{
+		Region:       o.Declaration.Metadata.Region,
+		AWSAccountID: o.Declaration.Metadata.AccountID,
+		ClusterName:  o.Declaration.Metadata.Name,
+	}
+
+	clusterVersioner := clusterversion.New(
+		o.Out,
+		clusterID,
+		o.StateHandlers(o.StateNodes()).Upgrade,
+	)
+
+	err := clusterVersioner.ValidateBinaryEqualsClusterVersion(version.GetVersionInfo().Version)
+	if err != nil {
+		return fmt.Errorf(ValidateBinaryVsClusterVersionErr, err)
+	}
+
+	return nil
+}
+
+// ValidateBinaryVersionNotLessThanClusterVersion is a wrapper for clusterVersioner.ValidateBinaryVersionNotLessThanClusterVersion
+func ValidateBinaryVersionNotLessThanClusterVersion(o *okctl.Okctl) error {
+	clusterID := api.ID{
+		Region:       o.Declaration.Metadata.Region,
+		AWSAccountID: o.Declaration.Metadata.AccountID,
+		ClusterName:  o.Declaration.Metadata.Name,
+	}
+
+	clusterVersioner := clusterversion.New(
+		o.Out,
+		clusterID,
+		o.StateHandlers(o.StateNodes()).Upgrade,
+	)
+
+	err := clusterVersioner.ValidateBinaryVersionNotLessThanClusterVersion(version.GetVersionInfo().Version)
+	if err != nil {
+		return fmt.Errorf(ValidateBinaryVsClusterVersionErr, err)
+	}
+
+	return nil
+}

--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/oslokommune/okctl/pkg/api"
 	"github.com/oslokommune/okctl/pkg/okctl"
 	"github.com/oslokommune/okctl/pkg/upgrade/clusterversion"

--- a/pkg/upgrade/clusterversion/api_test.go
+++ b/pkg/upgrade/clusterversion/api_test.go
@@ -1,0 +1,58 @@
+package clusterversion_test
+
+import (
+	"bytes"
+	"github.com/oslokommune/okctl/pkg/client/mock"
+	"github.com/oslokommune/okctl/pkg/upgrade/clusterversion"
+	"github.com/oslokommune/okctl/pkg/upgrade/testutils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidateBinaryEqualsClusterVersion(t *testing.T) {
+	testCases := []struct {
+		name                string
+		withBinaryVersion   string
+		withClusterVersion  string
+		expectErrorContains string
+	}{
+		{
+			name:                "Should fail when binary version is less than cluster version",
+			withBinaryVersion:   "0.0.49",
+			withClusterVersion:  "0.0.50",
+			expectErrorContains: "okctl binary version must be equal to cluster version 0.0.50, but was 0.0.49",
+		},
+		{
+			name:               "Should validate without error when binary version is equal to cluster version",
+			withBinaryVersion:  "0.0.50",
+			withClusterVersion: "0.0.50",
+		},
+		{
+			name:                "Should fail when binary version is greater than cluster version",
+			withBinaryVersion:   "0.0.51",
+			withClusterVersion:  "0.0.50",
+			expectErrorContains: "okctl binary version must be equal to cluster version 0.0.50, but was 0.0.51",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			clusterID := mock.Cluster().ID
+			upgradeState := testutils.MockUpgradeState("0.0.50")
+			versioner := clusterversion.New(&out, clusterID, upgradeState)
+
+			// When
+			err := versioner.ValidateBinaryEqualsClusterVersion(tc.withBinaryVersion)
+
+			// Then
+			if len(tc.expectErrorContains) > 0 {
+				assert.Contains(t, err.Error(), tc.expectErrorContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+}

--- a/pkg/upgrade/clusterversion/api_test.go
+++ b/pkg/upgrade/clusterversion/api_test.go
@@ -2,11 +2,12 @@ package clusterversion_test
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/oslokommune/okctl/pkg/client/mock"
 	"github.com/oslokommune/okctl/pkg/upgrade/clusterversion"
 	"github.com/oslokommune/okctl/pkg/upgrade/testutils"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestValidateBinaryEqualsClusterVersion(t *testing.T) {
@@ -54,5 +55,4 @@ func TestValidateBinaryEqualsClusterVersion(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -373,7 +373,7 @@ type Upgrader struct {
 
 // New returns a new Upgrader, or an error if initialization fails
 func New(opts Opts) (Upgrader, error) {
-	err := opts.ClusterVersioner.ValidateBinaryVsClusterVersion(opts.OkctlVersion)
+	err := opts.ClusterVersioner.ValidateBinaryVersionNotLessThanClusterVersion(opts.OkctlVersion)
 	if err != nil {
 		return Upgrader{}, fmt.Errorf(commands.ValidateBinaryVsClusterVersionErr, err)
 	}

--- a/userdocs/src/getting-started/install.md
+++ b/userdocs/src/getting-started/install.md
@@ -31,7 +31,7 @@ brew untap oslokommune/tap
 
 Then install with the instructions below.
 
-Read more about this change in https://github.com/oslokommune/okctl/pull/786.
+Read more about this change in [#786](https://github.com/oslokommune/okctl/pull/786).
 
 ### macOS and Linux
 
@@ -52,4 +52,3 @@ sudo mv /tmp/okctl /usr/local/bin # or somewhere else on your $PATH
 ## Enable shell autocompletion
 
 To get autocompletion in your shell working run `okctl completion -h` and follow the steps for your preferred shell.
-

--- a/userdocs/src/getting-started/install.md
+++ b/userdocs/src/getting-started/install.md
@@ -1,18 +1,40 @@
+## Automatic installation
 
+To automatically install the latest version of okctl, run
 
-## Install on Linux
-
-```bash
-curl --silent --location "https://github.com/oslokommune/okctl/releases/latest/download/okctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+```shell
+curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/HEAD/install/install.sh | /bin/bash
 sudo mv /tmp/okctl /usr/local/bin
 ```
 
-## Install on macOS
+To get a specific version of okctl, run (replace `0.0.73` with the version you want)
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/HEAD/install/install.sh | /bin/bash -s 0.0.73
+sudo mv /tmp/okctl /usr/local/bin
+```
+
+## Manual installation
+
+### macOS
+
+If you previously installed okctl with `brew`, uninstall it first, by running
 
 ```bash
-brew tap oslokommune/tap
-brew install oslokommune/tap/okctl
+brew uninstall oslokommune/tap/okctl
+brew untap oslokommune/tap
 ```
+
+Then install with the instructions below.
+
+### macOS and Linux
+
+```bash
+curl --silent --location "https://github.com/oslokommune/okctl/releases/latest/download/okctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+sudo mv /tmp/okctl /usr/local/bin # or somewhere else on your $PATH
+```
+
+To get a specific version, see the release assets on the [releases](https://github.com/oslokommune/okctl/releases) page.
 
 ## Enable shell autocompletion
 

--- a/userdocs/src/getting-started/install.md
+++ b/userdocs/src/getting-started/install.md
@@ -7,7 +7,7 @@ The automatic installation script does the same steps as described in the "Manua
 To automatically install the latest version of okctl, run
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/KM445-okctl_version_must_equal_cluster_version/install/install.sh | /bin/bash
+curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/HEAD/install/install.sh | /bin/bash
 ```
 
 and follow the instructions.
@@ -17,7 +17,7 @@ and follow the instructions.
 To get a specific version of okctl, run (replace `0.0.74` with the version you want)
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/KM445-okctl_version_must_equal_cluster_version/install/install.sh | /bin/bash -s 0.0.74
+curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/HEAD/install/install.sh | /bin/bash -s 0.0.74
 ```
 
 and follow the instructions.

--- a/userdocs/src/getting-started/install.md
+++ b/userdocs/src/getting-started/install.md
@@ -50,3 +50,4 @@ sudo mv /tmp/okctl /usr/local/bin # or somewhere else on your $PATH
 ## Enable shell autocompletion
 
 To get autocompletion in your shell working run `okctl completion -h` and follow the steps for your preferred shell.
+

--- a/userdocs/src/getting-started/install.md
+++ b/userdocs/src/getting-started/install.md
@@ -1,5 +1,9 @@
 ## Automatic installation 🆕
 
+The automatic installation script does the same steps as described in the "Manual installation" section, while trying to put the okctl binary at a location that avoids using `sudo`.
+
+
+### macOS and Linux
 To automatically install the latest version of okctl, run
 
 ```shell
@@ -8,6 +12,8 @@ curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/KM445-okctl_versi
 
 and follow the instructions.
 
+<br/>
+
 To get a specific version of okctl, run (replace `0.0.74` with the version you want)
 
 ```shell
@@ -15,8 +21,6 @@ curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/KM445-okctl_versi
 ```
 
 and follow the instructions.
-
-ℹ The automatic installation script does the steps described below, while trying to put the okctl binary at a location that avoids using `sudo`.
 
 ## Manual installation
 
@@ -41,6 +45,8 @@ To get the latest version of okctl, run
 curl --silent --location "https://github.com/oslokommune/okctl/releases/latest/download/okctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 sudo mv /tmp/okctl /usr/local/bin # or somewhere else on your $PATH
 ```
+
+<br/>
 
 To get a specific version of okctl, run (replace `0.0.74` with the version you want)
 

--- a/userdocs/src/getting-started/install.md
+++ b/userdocs/src/getting-started/install.md
@@ -3,7 +3,7 @@
 To automatically install the latest version of okctl, run
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/HEAD/install/install.sh | /bin/bash
+curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/KM445-okctl_version_must_equal_cluster_version/install/install.sh | /bin/bash
 ```
 
 and follow the instructions.
@@ -11,7 +11,7 @@ and follow the instructions.
 To get a specific version of okctl, run (replace `0.0.74` with the version you want)
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/HEAD/install/install.sh | /bin/bash -s 0.0.74
+curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/KM445-okctl_version_must_equal_cluster_version/install/install.sh | /bin/bash -s 0.0.74
 ```
 
 and follow the instructions.

--- a/userdocs/src/getting-started/install.md
+++ b/userdocs/src/getting-started/install.md
@@ -1,24 +1,26 @@
-## Automatic installation
+## Automatic installation 🆕
 
 To automatically install the latest version of okctl, run
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/HEAD/install/install.sh | /bin/bash
-sudo mv /tmp/okctl /usr/local/bin
 ```
 
-To get a specific version of okctl, run (replace `0.0.73` with the version you want)
+and follow the instructions.
+
+To get a specific version of okctl, run (replace `0.0.74` with the version you want)
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/HEAD/install/install.sh | /bin/bash -s 0.0.73
-sudo mv /tmp/okctl /usr/local/bin
+curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/HEAD/install/install.sh | /bin/bash -s 0.0.74
 ```
+
+and follow the instructions.
 
 ## Manual installation
 
 ### macOS
 
-If you previously installed okctl with `brew`, uninstall it first, by running
+🆕 If you previously installed okctl with `brew`, uninstall it first, by running
 
 ```bash
 brew uninstall oslokommune/tap/okctl
@@ -27,14 +29,23 @@ brew untap oslokommune/tap
 
 Then install with the instructions below.
 
+Read more about this change in https://github.com/oslokommune/okctl/pull/786.
+
 ### macOS and Linux
+
+To get the latest version of okctl, run
 
 ```bash
 curl --silent --location "https://github.com/oslokommune/okctl/releases/latest/download/okctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 sudo mv /tmp/okctl /usr/local/bin # or somewhere else on your $PATH
 ```
 
-To get a specific version, see the release assets on the [releases](https://github.com/oslokommune/okctl/releases) page.
+To get a specific version of okctl, run (replace `0.0.74` with the version you want)
+
+```shell
+curl --silent --location "https://github.com/oslokommune/okctl/releases/download/v0.0.74/okctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+sudo mv /tmp/okctl /usr/local/bin # or somewhere else on your $PATH
+```
 
 ## Enable shell autocompletion
 

--- a/userdocs/src/getting-started/install.md
+++ b/userdocs/src/getting-started/install.md
@@ -16,6 +16,8 @@ curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/KM445-okctl_versi
 
 and follow the instructions.
 
+ℹ The automatic installation script does the steps described below, while trying to put the okctl binary at a location that avoids using `sudo`.
+
 ## Manual installation
 
 ### macOS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Makes sure okctl binary version is equal or greater than cluster version, depending which command is being run.

## Description

<!--- Describe your changes in detail -->

### Added validations

I have added these validations for some commands.

I did not add validations for these commands:
* scaffold application -c somecluster.yaml: because it doesn't do `o.Initialize()`, meaning state handlers hasn't been initialized so we can get cluster state. We could add it, but then the user has to login to the cluster just to do a scaffold.
* version: We don't want to require cluster login just to get version
* completion: We don't want to require cluster login just to get completion
* scaffold cluster: N/A, version doesn't exist

### Removed brew support
This PR also removes brew support for okctl. The rationale is that since okctl isn't backwards compatible* with clusters of older versions, the okctl binary must either be equal or greater than the cluster version at all times (depending which command is being run). When the user decides to upgrade the cluster, and only then, should the user get a new version of okctl.

By using brew, as soon as the user runs `brew update && brew upgrade` (and there is a new version of okctl available), many commands will stop working, because of the new validations in this PR. This is not the user experience we want, we want the user to decide when to upgrade the cluster (i.e. running `okctl upgrade`).

Also, we want the user to be able to install a specific version of okctl. This is needed for instance when a user wants to use a cluster set up by a previous version of okctl. It is possible to pin versions in brew (`brew pin`), meaning it doesn't get upgraded automatically. However, there [isn't a simple way](https://stackoverflow.com/questions/3987683/homebrew-install-specific-version-of-formula) of installing specific versions of a package with brew. `brew extract` is reported to work, but requires enabling "developer mode", which makes brew behave differently, and thus has unintented side effects.

There could be other uses cases as well, and not being able to easily switch versions isn't great. We could instead choose to create `ovm` - okctl version manager, similar to `nvm`, so the user just types `ovm install 0.0.70`. Or take it one step further and somehow implement `okctl install 0.0.70`.

\* We have decided for now to not attempt to make okctl backwards compatible for `okctl apply` commands, because this adds lots of complexity: We would have to introduce git flows for managing major, minor and patch versions, and for every new commit, decide where it should go. This process is also more prone to errors.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[KM445](https://trello.com/c/3ViH3EKz/445-upgrade-new-validation-okctl-binary-version-must-be-equal-to-cluster-version)

## How to prove the effect of this PR?

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

1. Set cluster version: Edit cluster version in state.db with boltbrowser. Set upgrade ->  ClusterVersion -> Value to something.
1. Set okctl version: Either build (using ldflags to set version) okctl with a version less than your cluster version, or set release.go -> Version to some semantic version.
1. Then go ahead and run the commands in this PR to see that the validations work (note there are two different version validations).

To test the installation script, run

```shell
curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/KM445-okctl_version_must_equal_cluster_version/install/install.sh | /bin/bash
```

or

```shell
curl -fsSL https://raw.githubusercontent.com/oslokommune/okctl/KM445-okctl_version_must_equal_cluster_version/install/install.sh | /bin/bash -s 0.0.74
```

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
