### PR TITLE
KM471 🐛 Bump cluster version when no upgrades has been applied

### DIFF
--- a/cmd/okctl/apply_application.go
+++ b/cmd/okctl/apply_application.go
@@ -51,6 +51,11 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 			func(cmd *cobra.Command, args []string) (err error) {
 				metrics.Publish(generateStartEvent(metrics.ActionApplyApplication))
 
+				err = commands.ValidateBinaryEqualsClusterVersion(o)
+				if err != nil {
+					return err
+				}
+
 				opts.Application, err = commands.InferApplicationFromStdinOrFile(*o.Declaration, o.In, o.FileSystem, opts.File)
 				if err != nil {
 					return fmt.Errorf("inferring application from stdin or file: %w", err)

--- a/cmd/okctl/apply_cluster.go
+++ b/cmd/okctl/apply_cluster.go
@@ -18,6 +18,8 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/oslokommune/okctl/pkg/upgrade"
 
+	"github.com/oslokommune/okctl/pkg/version"
+
 	"github.com/oslokommune/okctl/pkg/api"
 
 	"github.com/oslokommune/okctl/pkg/controller/cluster/reconciliation"
@@ -147,6 +149,11 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 					clusterID,
 					state.Upgrade,
 				)
+
+				err = clusterVersioner.ValidateBinaryEqualsClusterVersion(version.GetVersionInfo().Version)
+				if err != nil {
+					return fmt.Errorf(commands.ValidateBinaryVsClusterVersionErr, err)
+				}
 
 				// Original version
 				originalClusterVersioner = originalclusterversion.New(

--- a/cmd/okctl/attach_postgres.go
+++ b/cmd/okctl/attach_postgres.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/oslokommune/okctl/cmd/okctl/preruns"
+	"github.com/oslokommune/okctl/pkg/commands"
 	"github.com/oslokommune/okctl/pkg/metrics"
 
 	"github.com/oslokommune/okctl/pkg/cfn"
@@ -53,6 +54,11 @@ func buildAttachPostgres(o *okctl.Okctl) *cobra.Command {
 				metrics.Publish(generateStartEvent(metrics.ActionAttachPostgres))
 
 				err := o.Initialise()
+				if err != nil {
+					return err
+				}
+
+				err = commands.ValidateBinaryEqualsClusterVersion(o)
 				if err != nil {
 					return err
 				}

--- a/cmd/okctl/attach_postgres.go
+++ b/cmd/okctl/attach_postgres.go
@@ -58,7 +58,7 @@ func buildAttachPostgres(o *okctl.Okctl) *cobra.Command {
 					return err
 				}
 
-				err = commands.ValidateBinaryEqualsClusterVersion(o)
+				err = commands.ValidateBinaryVersionNotLessThanClusterVersion(o)
 				if err != nil {
 					return err
 				}

--- a/cmd/okctl/forward_postgres.go
+++ b/cmd/okctl/forward_postgres.go
@@ -74,7 +74,7 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 					return err
 				}
 
-				err = commands.ValidateBinaryEqualsClusterVersion(o)
+				err = commands.ValidateBinaryVersionNotLessThanClusterVersion(o)
 				if err != nil {
 					return err
 				}

--- a/cmd/okctl/forward_postgres.go
+++ b/cmd/okctl/forward_postgres.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/oslokommune/okctl/pkg/commands"
+
 	"github.com/oslokommune/okctl/cmd/okctl/preruns"
 	"github.com/oslokommune/okctl/pkg/metrics"
 
@@ -68,6 +70,11 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 				}
 
 				err := o.Initialise()
+				if err != nil {
+					return err
+				}
+
+				err = commands.ValidateBinaryEqualsClusterVersion(o)
 				if err != nil {
 					return err
 				}

--- a/cmd/okctl/upgrade.go
+++ b/cmd/okctl/upgrade.go
@@ -40,7 +40,6 @@ func buildUpgradeCommand(o *okctl.Okctl) *cobra.Command {
 		Long: `Runs a series of upgrade migrations to upgrade resources made by okctl
 to the current version of okctl. Example of such resources are helm charts, okctl cluster and application declarations,
 binaries used by okctl (kubectl, etc), and internal state.`,
-		Hidden: true,
 		PreRunE: preruns.PreRunECombinator(
 			preruns.LoadUserData(o),
 			preruns.InitializeMetrics(o),

--- a/docs/release_notes/0.0.76.md
+++ b/docs/release_notes/0.0.76.md
@@ -3,7 +3,6 @@
 ## Features
 
 ## Bugfixes
-🐛 Revert validation for equal version, until upgrade path is determined.
 
 ## Changes
 

--- a/docs/release_notes/0.0.76.md
+++ b/docs/release_notes/0.0.76.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Bugfixes
+🐛 Revert validation for equal version, until upgrade path is determined.
 
 ## Changes
 

--- a/docs/release_notes/0.0.77.md
+++ b/docs/release_notes/0.0.77.md
@@ -3,8 +3,8 @@
 ## Features
 
 ## Bugfixes
+KM471 🐛 Bump cluster version when no upgrades has been applied (#802)
 
 ## Changes
 
 ## Other
-

--- a/pkg/upgrade/clusterversion/api.go
+++ b/pkg/upgrade/clusterversion/api.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/logrusorgru/aurora/v3"
+
 	"github.com/Masterminds/semver"
 	"github.com/oslokommune/okctl/pkg/api"
 	"github.com/oslokommune/okctl/pkg/client"
@@ -41,8 +43,9 @@ func (v Versioner) ValidateBinaryEqualsClusterVersion(binaryVersionString string
 		return nil
 	}
 
-	return fmt.Errorf("okctl binary version must be equal to cluster version %s, but was %s",
-		clusterVersion, binaryVersion)
+	return fmt.Errorf("okctl binary version must be equal to cluster version %s, but was %s. Either run %s"+
+		" to upgrade your cluster to the current version of okctl, or install okctl version %s",
+		clusterVersion, binaryVersion, aurora.Green("okctl upgrade"), clusterVersion)
 }
 
 // ValidateBinaryVersionNotLessThanClusterVersion returns an error if binary version is less than cluster version.
@@ -72,7 +75,7 @@ func (v Versioner) ValidateBinaryVersionNotLessThanClusterVersion(binaryVersionS
 
 	// Validate
 	if binaryVersion.LessThan(clusterVersion) {
-		return fmt.Errorf("okctl binary version %s cannot be less than cluster version %s. Get okctl version %s or"+
+		return fmt.Errorf("okctl binary version %s cannot be less than cluster version %s. Install okctl version %s or"+
 			" later and try again", binaryVersion, clusterVersion, clusterVersion)
 	}
 

--- a/pkg/upgrade/testdata/Should be possible to run update with confirm flag.golden
+++ b/pkg/upgrade/testdata/Should be possible to run update with confirm flag.golden
@@ -18,4 +18,4 @@ This is upgrade file for okctl-upgrade_0.0.62_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.65. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.65. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should be possible to run update without confirm flag.golden
+++ b/pkg/upgrade/testdata/Should be possible to run update without confirm flag.golden
@@ -17,4 +17,4 @@ Simulating upgrades complete.
 This is upgrade file for okctl-upgrade_0.0.62_Linux_amd64
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.65. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.65. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should bump cluster version to the current okctl version after upgrading, even if zero upgrades were run.golden
+++ b/pkg/upgrade/testdata/Should bump cluster version to the current okctl version after upgrading, even if zero upgrades were run.golden
@@ -1,6 +1,6 @@
 Okctl needs to initialize parts of the cluster state to support upgrades. Afterwards you should commit and push changes to git.
 If you want more details, see https://okctl.io/getting-started/upgrading
 
-Did not find any applicable upgrades.
+Did not find any applicable upgrades. Cluster version will be updated regardless.
 
-Upgrade complete! Cluster version is now 0.0.70. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.70. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should bump cluster version to the current okctl version after upgrading, even if zero upgrades were run.golden
+++ b/pkg/upgrade/testdata/Should bump cluster version to the current okctl version after upgrading, even if zero upgrades were run.golden
@@ -3,4 +3,4 @@ If you want more details, see https://okctl.io/getting-started/upgrading
 
 Did not find any applicable upgrades.
 
-Upgrade complete! Cluster version is now 0.0.60. Remember to commit and push changes with git.
+Upgrade complete! Cluster version is now 0.0.70. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should bump cluster version to the current okctl version after upgrading.golden
+++ b/pkg/upgrade/testdata/Should bump cluster version to the current okctl version after upgrading.golden
@@ -18,4 +18,4 @@ This is upgrade file for okctl-upgrade_0.0.61_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.70. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.70. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should not run upgrades that are older than the first installed okctl version.golden
+++ b/pkg/upgrade/testdata/Should not run upgrades that are older than the first installed okctl version.golden
@@ -26,4 +26,4 @@ This is upgrade file for okctl-upgrade_0.0.64_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.64. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.64. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should not run upgrades, including hot fixes, that are older than the first installed okctl version.golden
+++ b/pkg/upgrade/testdata/Should not run upgrades, including hot fixes, that are older than the first installed okctl version.golden
@@ -26,4 +26,4 @@ This is upgrade file for okctl-upgrade_0.0.63.a_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.63. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.63. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should print correct debug output.golden
+++ b/pkg/upgrade/testdata/Should print correct debug output.golden
@@ -42,4 +42,4 @@ This is upgrade file for okctl-upgrade_0.0.63_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.63. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.63. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should print upgrades stdout to stdout.golden
+++ b/pkg/upgrade/testdata/Should print upgrades stdout to stdout.golden
@@ -18,4 +18,4 @@ This is upgrade file for okctl-upgrade_0.0.61_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.61. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.61. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run a Darwin upgrade.golden
+++ b/pkg/upgrade/testdata/Should run a Darwin upgrade.golden
@@ -18,4 +18,4 @@ This is upgrade file for okctl-upgrade_0.0.61_Darwin_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.61. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.61. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run a Linux upgrade.golden
+++ b/pkg/upgrade/testdata/Should run a Linux upgrade.golden
@@ -18,4 +18,4 @@ This is upgrade file for okctl-upgrade_0.0.61_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.61. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.61. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run a hotfix even if it is older than the last applied upgrade_run1.golden
+++ b/pkg/upgrade/testdata/Should run a hotfix even if it is older than the last applied upgrade_run1.golden
@@ -34,4 +34,4 @@ This is upgrade file for okctl-upgrade_0.0.63_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.63. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.63. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run a hotfix even if it is older than the last applied upgrade_run2.golden
+++ b/pkg/upgrade/testdata/Should run a hotfix even if it is older than the last applied upgrade_run2.golden
@@ -31,4 +31,4 @@ This is upgrade file for okctl-upgrade_0.0.63.a_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.63. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.63. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run multiple upgrades.golden
+++ b/pkg/upgrade/testdata/Should run multiple upgrades.golden
@@ -34,4 +34,4 @@ This is upgrade file for okctl-upgrade_0.0.64_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.64. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.64. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run upgrade hot fixes, and in correct order.golden
+++ b/pkg/upgrade/testdata/Should run upgrade hot fixes, and in correct order.golden
@@ -58,4 +58,4 @@ This is upgrade file for okctl-upgrade_0.0.63.a_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.63. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.63. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run upgrades once_run1.golden
+++ b/pkg/upgrade/testdata/Should run upgrades once_run1.golden
@@ -34,4 +34,4 @@ This is upgrade file for okctl-upgrade_0.0.64_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.64. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.64. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run upgrades once_run2.golden
+++ b/pkg/upgrade/testdata/Should run upgrades once_run2.golden
@@ -1,1 +1,3 @@
 Did not find any applicable upgrades.
+
+Upgrade complete! Cluster version is now 0.0.64. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run upgrades once_run2.golden
+++ b/pkg/upgrade/testdata/Should run upgrades once_run2.golden
@@ -1,3 +1,3 @@
-Did not find any applicable upgrades.
+Did not find any applicable upgrades. Cluster version will be updated regardless.
 
-Upgrade complete! Cluster version is now 0.0.64. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.64. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run upgrades with version up to and including current okctl version, but no newer.golden
+++ b/pkg/upgrade/testdata/Should run upgrades with version up to and including current okctl version, but no newer.golden
@@ -34,4 +34,4 @@ This is upgrade file for okctl-upgrade_0.0.63_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.63. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.63. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should run zero upgrades.golden
+++ b/pkg/upgrade/testdata/Should run zero upgrades.golden
@@ -1,6 +1,6 @@
 Okctl needs to initialize parts of the cluster state to support upgrades. Afterwards you should commit and push changes to git.
 If you want more details, see https://okctl.io/getting-started/upgrading
 
-Did not find any applicable upgrades.
+Did not find any applicable upgrades. Cluster version will be updated regardless.
 
-Upgrade complete! Cluster version is now 0.0.60. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.60. Remember to commit and push changes with git.

--- a/pkg/upgrade/testdata/Should support replacing an erroneous upgrade binary with a hotfix_run2.golden
+++ b/pkg/upgrade/testdata/Should support replacing an erroneous upgrade binary with a hotfix_run2.golden
@@ -22,4 +22,4 @@ This is upgrade file for okctl-upgrade_0.0.63_Linux_amd64
 --confirm flag was provided
 Doing actual changes.
 
-Upgrade complete! Cluster version is now 0.0.65. Remember to commit and push changes with git.
+Upgrade complete, cluster version is now 0.0.65. Remember to commit and push changes with git.

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -66,7 +66,7 @@ func (u Upgrader) Run() error {
 			return nil
 		}
 	} else {
-		_, _ = fmt.Fprintln(u.out, "Did not find any applicable upgrades.")
+		_, _ = fmt.Fprintln(u.out, "Did not find any applicable upgrades. Cluster version will be updated regardless.")
 	}
 
 	// Update cluster version
@@ -75,7 +75,7 @@ func (u Upgrader) Run() error {
 		return fmt.Errorf(commands.SaveClusterVersionErr, err)
 	}
 
-	_, _ = fmt.Fprintf(u.out, "\nUpgrade complete! Cluster version is now %s."+
+	_, _ = fmt.Fprintf(u.out, "\nUpgrade complete, cluster version is now %s."+
 		" Remember to commit and push changes with git.\n", u.okctlVersion)
 
 	return nil

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -56,18 +56,17 @@ func (u Upgrader) Run() error {
 	// Run
 	if len(upgradeBinaries) > 0 {
 		printUpgrades(u.out, "Found %d applicable upgrade(s):", upgradeBinaries)
+
+		userConfirmedContinue, err := u.runBinaries(upgradeBinaries)
+		if err != nil {
+			return fmt.Errorf("running upgrade binaries: %w", err)
+		}
+
+		if !userConfirmedContinue {
+			return nil
+		}
 	} else {
 		_, _ = fmt.Fprintln(u.out, "Did not find any applicable upgrades.")
-		return nil
-	}
-
-	userConfirmedContinue, err := u.runBinaries(upgradeBinaries)
-	if err != nil {
-		return fmt.Errorf("running upgrade binaries: %w", err)
-	}
-
-	if !userConfirmedContinue {
-		return nil
 	}
 
 	// Update cluster version

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -96,14 +96,13 @@ func TestRunUpgrades(t *testing.T) {
 			expectErrorContains:               "exit status 1",
 		},
 		{
-			name:                               "Should run zero upgrades",
-			withOkctlVersion:                   "0.0.60",
-			withOriginalClusterVersion:         "0.0.50",
-			withClusterVersion:                 "0.0.52",
-			withGithubReleases:                 []*github.RepositoryRelease{},
-			withHost:                           state.Host{Os: linux, Arch: amd64},
-			expectBinaryVersionsRunOnce:        []string{},
-			expectedClusterVersionAfterUpgrade: "0.0.60",
+			name:                        "Should run zero upgrades",
+			withOkctlVersion:            "0.0.60",
+			withOriginalClusterVersion:  "0.0.50",
+			withClusterVersion:          "0.0.52",
+			withGithubReleases:          []*github.RepositoryRelease{},
+			withHost:                    state.Host{Os: linux, Arch: amd64},
+			expectBinaryVersionsRunOnce: []string{},
 		},
 		{
 			name:                              "Should run a Linux upgrade",
@@ -131,22 +130,20 @@ func TestRunUpgrades(t *testing.T) {
 			//
 			// If creating a new cluster, the cluster version would be 0.0.70 (not 0.0.61). Therefore, we do a final
 			// bump of cluster version to the current version of okctl, which is what this test verifies.
-			name:                               "Should bump cluster version to the current okctl version after upgrading",
-			withOkctlVersion:                   "0.0.70",
-			withOriginalClusterVersion:         "0.0.50",
-			withGithubReleases:                 createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
-			withGithubReleaseAssetsFromFolder:  folderWorking,
-			withHost:                           state.Host{Os: linux, Arch: amd64},
-			expectBinaryVersionsRunOnce:        []string{"0.0.61"},
-			expectedClusterVersionAfterUpgrade: "0.0.70",
+			name:                              "Should bump cluster version to the current okctl version after upgrading",
+			withOkctlVersion:                  "0.0.70",
+			withOriginalClusterVersion:        "0.0.50",
+			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleaseAssetsFromFolder: folderWorking,
+			withHost:                          state.Host{Os: linux, Arch: amd64},
+			expectBinaryVersionsRunOnce:       []string{"0.0.61"},
 		},
 		{
-			name:                               "Should bump cluster version to the current okctl version after upgrading, even if zero upgrades were run",
-			withOkctlVersion:                   "0.0.70",
-			withOriginalClusterVersion:         "0.0.50",
-			withGithubReleaseAssetsFromFolder:  folderWorking,
-			withHost:                           state.Host{Os: linux, Arch: amd64},
-			expectedClusterVersionAfterUpgrade: "0.0.70",
+			name:                              "Should bump cluster version to the current okctl version after upgrading, even if zero upgrades were run",
+			withOkctlVersion:                  "0.0.70",
+			withOriginalClusterVersion:        "0.0.50",
+			withGithubReleaseAssetsFromFolder: folderWorking,
+			withHost:                          state.Host{Os: linux, Arch: amd64},
 		},
 		{
 			name:                              "Should not bump cluster version if user aborts upgrading",
@@ -615,6 +612,10 @@ func TestRunUpgrades(t *testing.T) {
 				tc.withClusterVersion = tc.withOriginalClusterVersion
 			}
 
+			if len(tc.expectedClusterVersionAfterUpgrade) == 0 {
+				tc.expectedClusterVersionAfterUpgrade = tc.withOkctlVersion
+			}
+
 			upgradeState := testutils.MockUpgradeState(tc.withClusterVersion)
 			clusterState := testutils.MockClusterState(tc.withOriginalClusterVersion)
 
@@ -688,12 +689,7 @@ func doAsserts(t *testing.T, tc TestCase, defaultOpts DefaultTestOpts) {
 	// Cluster version
 	clusterVersion, err := defaultOpts.ClusterVersioner.GetClusterVersion()
 	require.NoError(t, err, tc.name)
-
-	if len(tc.expectedClusterVersionAfterUpgrade) > 0 {
-		assert.Equal(t, tc.expectedClusterVersionAfterUpgrade, clusterVersion, tc.name)
-	} else {
-		assert.Equal(t, tc.withOkctlVersion, clusterVersion, tc.name)
-	}
+	assert.Equal(t, tc.expectedClusterVersionAfterUpgrade, clusterVersion, tc.name)
 
 	// Original version
 	originalClusterVersion, err := defaultOpts.OriginalClusterVersioner.GetOriginalClusterVersion()

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -103,7 +103,7 @@ func TestRunUpgrades(t *testing.T) {
 			withGithubReleases:                 []*github.RepositoryRelease{},
 			withHost:                           state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:        []string{},
-			expectedClusterVersionAfterUpgrade: "0.0.52",
+			expectedClusterVersionAfterUpgrade: "0.0.60",
 		},
 		{
 			name:                              "Should run a Linux upgrade",
@@ -131,16 +131,22 @@ func TestRunUpgrades(t *testing.T) {
 			//
 			// If creating a new cluster, the cluster version would be 0.0.70 (not 0.0.61). Therefore, we do a final
 			// bump of cluster version to the current version of okctl, which is what this test verifies.
-			//
-			// The exception to this, is if we have run zero upgrades. Since absolutely no changes have been made,
-			// we don't care about bumping cluster version either. This behavior is verified in another test.
-			name:                              "Should bump cluster version to the current okctl version after upgrading",
-			withOkctlVersion:                  "0.0.70",
-			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
-			withGithubReleaseAssetsFromFolder: folderWorking,
-			withHost:                          state.Host{Os: linux, Arch: amd64},
-			expectBinaryVersionsRunOnce:       []string{"0.0.61"},
+			name:                               "Should bump cluster version to the current okctl version after upgrading",
+			withOkctlVersion:                   "0.0.70",
+			withOriginalClusterVersion:         "0.0.50",
+			withGithubReleases:                 createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleaseAssetsFromFolder:  folderWorking,
+			withHost:                           state.Host{Os: linux, Arch: amd64},
+			expectBinaryVersionsRunOnce:        []string{"0.0.61"},
+			expectedClusterVersionAfterUpgrade: "0.0.70",
+		},
+		{
+			name:                               "Should bump cluster version to the current okctl version after upgrading, even if zero upgrades were run",
+			withOkctlVersion:                   "0.0.70",
+			withOriginalClusterVersion:         "0.0.50",
+			withGithubReleaseAssetsFromFolder:  folderWorking,
+			withHost:                           state.Host{Os: linux, Arch: amd64},
+			expectedClusterVersionAfterUpgrade: "0.0.70",
 		},
 		{
 			name:                              "Should not bump cluster version if user aborts upgrading",
@@ -172,7 +178,7 @@ func TestRunUpgrades(t *testing.T) {
 
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "okctl binary version 0.0.60 cannot be less than cluster"+
-					" version 0.0.70. Get okctl version 0.0.70 or later and try again")
+					" version 0.0.70. Install okctl version 0.0.70 or later and try again")
 			},
 		},
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`okctl upgrade` now bumps cluster version when there are no upgrades applied. This is needed to make sure it's possible to bump cluster version, which is needed for validation `okctl binary version == cluster version` to work.

## Description

<!--- Describe your changes in detail -->

* #786 introduced strict validation of okctl binary version == cluster version, but there was no way of bumping cluster version if there were no upgrades available
* #800 removed these strict validations, until a fix was ready
* This PR is the fix

A slight disadvantage of this way of doing things is perhaps too strict validation. If we fix a spelling error in okctl and release it, and the user downloads the new okctl and runs `apply cluster`, s(he) will get a validation error (non-equal versions). This is theoretically not needed, as okctl with a spelling fix is clearly backwards compatible with the previous okctl version with a spelling error.

It could perhaps be solved by only throwing equal version error if there exists remote applicable upgrades, that hasn't been executed yet. But that's for future us to dive into, and out of scope for now.

## Motivation and Context

[KM471](https://trello.com/c/ewInz1UJ/471-fix-ux-for-equal-versioning)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How to prove the effect of this PR?

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

```shell
# Build okctl with ldflags and make sure version is higher than cluster version

# Then verify with version.
$ okctl version
{"Version":"0.0.78","ShortCommit":"5dded87a-KM445-fix_upgrade_path","BuildDate":"unknown"}

# Attempt to apply cluster, to see the strict validation in place
$ okctl -a access-key apply cluster -f acluster.yaml 
Error: validating binary against cluster version: okctl binary version must be equal to cluster version 0.0.67, but was 0.0.78. Either run okctl upgrade to upgrade your cluster to the current version of okctl, or install okctl version 0.0.67

# Attempt to upgrade, to verify new behavior of this PR (i.e. cluster version is stored regardless)
$ okctl -a access-key upgrade
Did not find any applicable upgrades. Cluster version will be updated regardless.

Upgrade complete, cluster version is now 0.0.78. Remember to commit and push changes with git.

# Optionally, inspect state to see that upgrade.ClusterVersion is now okctl version (0.0.78)
$ git st
 M infrastructure/ykctl-crayon-two/state.db

$ boltbrowser infrastructure/ykctl-crayon-two/state.db 

# Now re-run apply cluster
$ okctl -a access-key apply cluster -f acluster.yaml 
✓   applying cluster

Your cluster is up to date.

To access your cluster, run okctl venv -c acluster.yaml to activate the environment for your cluster
Your cluster should then be available with kubectl
```

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
