### PR TITLE
Run CI Github action only once for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: ci
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   ci:


### PR DESCRIPTION
Run the `ci` Github action only once for PRs

## Description

The `ci` Github action is currently triggered twice for pushes to PRs, both for the `push` event and the `pull_request` event. This changes the Github workflow so that `push` only triggers the `ci` action on pushes to the `master` branch. This means that `ci` will also not be triggered on other non-PR branches.

## Motivation and Context

Reduce amount of resources we use for running Github workflows.

## How to prove the effect of this PR?

Pushes to PRs should only trigger a single `ci` Github action.

## Additional info

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
