### PR TITLE
KM473 🐛 Use git tag for upgrade binaries download URL

### DIFF
--- a/pkg/upgrade/github_release_parser.go
+++ b/pkg/upgrade/github_release_parser.go
@@ -53,7 +53,7 @@ func (g GithubReleaseParser) parseRelease(release *github.RepositoryRelease) (ok
 		return okctlUpgradeBinary{}, err
 	}
 
-	releaseUpgradeVersion := *release.TagName
+	releaseUpgradeVersion := ToUpgradeVersion(*release.TagName)
 
 	var binaryChecksums []state.Checksum
 
@@ -89,7 +89,7 @@ func (g GithubReleaseParser) parseRelease(release *github.RepositoryRelease) (ok
 		return okctlUpgradeBinary{}, fmt.Errorf("parsing upgrade version: %w", err)
 	}
 
-	return newOkctlUpgradeBinary(binaryVersion, binaryChecksums), nil
+	return newOkctlUpgradeBinary(binaryVersion, binaryChecksums, *release.TagName), nil
 }
 
 func (g GithubReleaseParser) validateRelease(r *github.RepositoryRelease) error {
@@ -208,11 +208,16 @@ func (g GithubReleaseParser) validateUpgradeBinaryAsset(asset *ghPkg.ReleaseAsse
 
 	if upgradeFile.version != releaseUpgradeVersion {
 		return fmt.Errorf(
-			"expected okctl upgrade binary version '%s' to equal release upgrade version (i.e. tag) '%s'",
+			"expected okctl upgrade binary version '%s' to equal release upgrade version '%s'",
 			upgradeFile.version, releaseUpgradeVersion)
 	}
 
 	return nil
+}
+
+// ToUpgradeVersion converts a git tag to an upgrade version
+func ToUpgradeVersion(tagName string) string {
+	return strings.Replace(tagName, "+", ".", 1)
 }
 
 // NewGithubReleaseParser returns a new GithubReleaseParser

--- a/pkg/upgrade/github_release_parser_test.go
+++ b/pkg/upgrade/github_release_parser_test.go
@@ -21,7 +21,7 @@ func TestGithubReleaseParser(t *testing.T) {
 	}{
 		{
 			name:         "Should work when everything is OK",
-			releases:     createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			releases:     createGithubReleases(t, []string{linux, darwin}, amd64, []string{"0.0.61"}),
 			checksumFile: fmt.Sprintf("%s/0.0.61/%s", folderWorking, upgrade.ChecksumsTxt),
 		},
 		{
@@ -65,7 +65,7 @@ func TestGithubReleaseParser(t *testing.T) {
 		},
 		{
 			name:         "Should return error about invalid substrings in checksum file",
-			releases:     createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			releases:     createGithubReleases(t, []string{linux, darwin}, amd64, []string{"0.0.61"}),
 			checksumFile: "github_release_parser/okctl-upgrade-checksums-substring-error.txt",
 			expectError: "expected 2 substrings when splitting digest line on whitespace, got 3 in string " +
 				"'716c5b3f517c197bdb748a55983b7a6de9045a66c759ee3f10863d19bbf90a61  " +
@@ -73,14 +73,14 @@ func TestGithubReleaseParser(t *testing.T) {
 		},
 		{
 			name:         "Should return error about invalid filename in checksum file",
-			releases:     createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			releases:     createGithubReleases(t, []string{linux, darwin}, amd64, []string{"0.0.61"}),
 			checksumFile: "github_release_parser/okctl-upgrade-checksums-filename-error.txt",
 			expectError: "expected 4 substrings when splitting on underscore (_), got 5 in string " +
 				"'okctl-upgrade_0.0.61_Darwin_amd64_invalidstuff.tar.gz'",
 		},
 		{
 			name:         "Should return error about too many dots in checksum file",
-			releases:     createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			releases:     createGithubReleases(t, []string{linux, darwin}, amd64, []string{"0.0.61"}),
 			checksumFile: "github_release_parser/okctl-upgrade-checksums-osarch-error.txt",
 			expectError: "expected at least 2 substrings when splitting on dot (.), got 1 in string " +
 				"'okctl-upgrade_0.0.61_Darwin_amd64'",
@@ -93,12 +93,12 @@ func TestGithubReleaseParser(t *testing.T) {
 					TagName: github.StringPtr("0.0.61"),
 					Name:    github.StringPtr("0.0.61"),
 					Assets: []*github.ReleaseAsset{
-						createGihubReleaseAssetBinary(linux, amd64, "0.0.55"),
-						createGihubReleaseAssetBinary(linux, amd64, "0.0.55"),
+						createGihubReleaseAssetBinary(linux, amd64, "0.0.55", "0.0.55"),
+						createGihubReleaseAssetBinary(linux, amd64, "0.0.55", "0.0.55"),
 					},
 				},
 			},
-			expectError: "expected okctl upgrade binary version '0.0.55' to equal release upgrade version (i.e. tag) '0.0.61'",
+			expectError: "expected okctl upgrade binary version '0.0.55' to equal release upgrade version '0.0.61'",
 		},
 	}
 

--- a/pkg/upgrade/okctl_ugrade_binary.go
+++ b/pkg/upgrade/okctl_ugrade_binary.go
@@ -15,18 +15,20 @@ import (
 type okctlUpgradeBinary struct {
 	// fileExtension can be for instance "tar.gz"
 	fileExtension string
-	// version is the upgrade version, for instance "0.0.56" or "0.0.56_some_hotfix"
+	// version is the upgrade version
 	version upgradeBinaryVersion
 	// checksum is a list of checksums, one for every combination of host OS and architecture that exists for this
 	// binary, for instance Linux-amd64
 	checksums []state.Checksum
+	// git tag associated with the binary
+	gitTag string
 }
 
 func (b okctlUpgradeBinary) String() string {
 	return b.BinaryName()
 }
 
-// BinaryName returns a string with a version, for instance "okctl-upgrade_0.0.56"
+// BinaryName returns a string with a version, for instance "okctl-upgrade_0.0.56.some-component"
 func (b okctlUpgradeBinary) BinaryName() string {
 	return fmt.Sprintf(okctlupgrade.BinaryNameFormat, b.RawVersion())
 }
@@ -41,6 +43,10 @@ func (b okctlUpgradeBinary) SemverVersion() *semverPkg.Version {
 
 func (b okctlUpgradeBinary) HotfixVersion() string {
 	return b.version.hotfix
+}
+
+func (b okctlUpgradeBinary) GitTag() string {
+	return b.gitTag
 }
 
 func sort(upgradeBinaries []okctlUpgradeBinary) {
@@ -58,10 +64,11 @@ func sort(upgradeBinaries []okctlUpgradeBinary) {
 	})
 }
 
-func newOkctlUpgradeBinary(version upgradeBinaryVersion, checksums []state.Checksum) okctlUpgradeBinary {
+func newOkctlUpgradeBinary(version upgradeBinaryVersion, checksums []state.Checksum, gitTag string) okctlUpgradeBinary {
 	return okctlUpgradeBinary{
 		fileExtension: ".tar.gz",
 		version:       version,
 		checksums:     checksums,
+		gitTag:        gitTag,
 	}
 }

--- a/pkg/upgrade/okctl_ugrade_binary.go_test.go
+++ b/pkg/upgrade/okctl_ugrade_binary.go_test.go
@@ -48,7 +48,7 @@ func createUpgradeBinaries(t *testing.T, versions []string) []okctlUpgradeBinary
 		version, err := parseUpgradeBinaryVersion(versionString)
 		assert.NoError(t, err)
 
-		b := newOkctlUpgradeBinary(version, nil)
+		b := newOkctlUpgradeBinary(version, nil, "")
 		binaries = append(binaries, b)
 	}
 

--- a/pkg/upgrade/testhelper_http_mocker_test.go
+++ b/pkg/upgrade/testhelper_http_mocker_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/upgrade"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/jarcoal/httpmock"
@@ -16,7 +18,9 @@ import (
 )
 
 // mockHTTPResponsesForGithubReleases mocks Github releases from the folder [baseFolder/release.TagName]
-func mockHTTPResponsesForGithubReleases(t *testing.T, baseFolder string, releases []*github.RepositoryRelease) {
+func mockHTTPResponsesForGithubReleases(t *testing.T, baseFolder string, githubReleases GithubReleases) {
+	releases := createGithubReleasesFromTestCase(t, githubReleases)
+
 	// shuffle slice to better test sorting of releases
 	shuffled := shuffle(releases)
 
@@ -45,7 +49,7 @@ func shuffle(src []*github.RepositoryRelease) []*github.RepositoryRelease {
 }
 
 func registerHTTPResponseFromReleaseTagFolder(t *testing.T, baseFolder string, release *github.RepositoryRelease) {
-	versionFolder := *release.TagName
+	versionFolder := upgrade.ToUpgradeVersion(*release.TagName)
 	mockHTTPResponseForGithubRelease(t, path.Join(baseFolder, versionFolder), release)
 }
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -3,9 +3,10 @@ package upgrade
 
 import (
 	"fmt"
-	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"io"
 	"strings"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 
 	"github.com/oslokommune/okctl/pkg/binaries/run/okctlupgrade"
 
@@ -234,7 +235,7 @@ func (u Upgrader) toStateBinaries(upgradeBinaries []okctlUpgradeBinary) []state.
 		URLPattern := fmt.Sprintf(
 			"%s/releases/download/%s/okctl-upgrade_%s_#{os}_#{arch}.tar.gz",
 			OkctlUpgradeRepoURL,
-			upgradeBinary.RawVersion(),
+			upgradeBinary.GitTag(),
 			upgradeBinary.RawVersion(),
 		)
 

--- a/pkg/upgrade/upgrade_binary_version.go
+++ b/pkg/upgrade/upgrade_binary_version.go
@@ -8,12 +8,14 @@ import (
 )
 
 const (
-	dotCountForRegularSemver    = 3
-	dotCountForSemverWithHotfix = 4
+	// DotCountForRegularSemver contains the amount of dots in a regular semver version
+	DotCountForRegularSemver = 3
+	// DotCountForSemverWithHotfix contains the amount of dots in a semver plus hotfix version
+	DotCountForSemverWithHotfix = 4
 )
 
 type upgradeBinaryVersion struct {
-	// raw is semver + hotfix, for instance "0.0.56_a"
+	// raw is semver + hotfix, for instance "0.0.56.a"
 	raw string
 	// semver is the semantic version, for instance "0.0.56"
 	semver *semverPkg.Version
@@ -38,13 +40,13 @@ func parseUpgradeBinaryVersion(text string) (upgradeBinaryVersion, error) {
 	parts := strings.Split(text, ".")
 
 	switch {
-	case len(parts) == dotCountForRegularSemver:
+	case len(parts) == DotCountForRegularSemver:
 		semver, err = semverPkg.NewVersion(text)
 		if err != nil {
 			return upgradeBinaryVersion{}, fmt.Errorf(
 				"parsing to semantic version from '%s': %w", text, err)
 		}
-	case len(parts) == dotCountForSemverWithHotfix:
+	case len(parts) == DotCountForSemverWithHotfix:
 		semverString := strings.Join(parts[0:3], ".")
 
 		semver, err = semverPkg.NewVersion(semverString)

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -42,7 +42,7 @@ type TestCase struct {
 	withOkctlVersion                   string
 	withOriginalClusterVersion         string
 	withClusterVersion                 string
-	withGithubReleases                 []*github.RepositoryRelease
+	withGithubReleases                 GithubReleases
 	withGithubReleaseAssetsFromFolder  string
 	withHost                           state.Host
 	withUserAnswers                    []bool
@@ -53,6 +53,12 @@ type TestCase struct {
 	expectErrorContains                string
 }
 
+type GithubReleases struct {
+	oses     []string
+	arch     string
+	versions []string
+}
+
 //nolint:funlen
 func TestRunUpgrades(t *testing.T) {
 	testCases := []TestCase{
@@ -60,7 +66,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should detect if binary's digest doesn't match the expected digest",
 			withOkctlVersion:                  "0.0.61",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61"}},
 			withGithubReleaseAssetsFromFolder: "invalid_digest",
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{},
@@ -72,7 +78,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should print upgrade's stdout to stdout",
 			withOkctlVersion:                  "0.0.61",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.61"},
@@ -81,7 +87,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should print upgrade's stdout and stderr to stdout",
 			withOkctlVersion:                  "0.0.62",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.62"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.62"}},
 			withGithubReleaseAssetsFromFolder: folderCrashing,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectErrorContains:               "exit status 1",
@@ -90,7 +96,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should return exit status if upgrade crashes",
 			withOkctlVersion:                  "0.0.58",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.58"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.58"}},
 			withGithubReleaseAssetsFromFolder: folderCrashing,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{},
@@ -101,7 +107,7 @@ func TestRunUpgrades(t *testing.T) {
 			withOkctlVersion:            "0.0.60",
 			withOriginalClusterVersion:  "0.0.50",
 			withClusterVersion:          "0.0.52",
-			withGithubReleases:          []*github.RepositoryRelease{},
+			withGithubReleases:          GithubReleases{},
 			withHost:                    state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce: []string{},
 		},
@@ -109,7 +115,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should run a Linux upgrade",
 			withOkctlVersion:                  "0.0.61",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.61"},
@@ -118,7 +124,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should run a Darwin upgrade",
 			withOkctlVersion:                  "0.0.61",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: darwin, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.61"},
@@ -134,7 +140,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should bump cluster version to the current okctl version after upgrading",
 			withOkctlVersion:                  "0.0.70",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.61"},
@@ -150,7 +156,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should not bump cluster version if user aborts upgrading",
 			withOkctlVersion:                  "0.0.70",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			withUserAnswers: []bool{
@@ -164,7 +170,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should return error if okctl version is below cluster version",
 			withOkctlVersion:                  "0.0.60",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: darwin, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{},
@@ -185,7 +191,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should save original cluster version if it doesn't exist",
 			withOkctlVersion:                  "0.0.61",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: darwin, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.61"},
@@ -206,7 +212,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should set correct environment variables for the upgrade binary run",
 			withOkctlVersion:                  "0.0.70",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.70.somecomponent"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.70.somecomponent"}},
 			withGithubReleaseAssetsFromFolder: "verify_environment_variables",
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			withBinaryEnvironmentVaribles:     map[string]string{"SOME_VAR": "hello"},
@@ -216,7 +222,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should run multiple upgrades",
 			withOkctlVersion:                  "0.0.64",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61", "0.0.62", "0.0.64"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61", "0.0.62", "0.0.64"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.61", "0.0.62", "0.0.64"},
@@ -225,7 +231,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should run upgrades once",
 			withOkctlVersion:                  "0.0.64",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61", "0.0.62", "0.0.64"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61", "0.0.62", "0.0.64"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.61", "0.0.62", "0.0.64"},
@@ -279,7 +285,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should run upgrades with version up to and including current okctl version, but no newer",
 			withOkctlVersion:                  "0.0.63",
 			withOriginalClusterVersion:        "0.0.50",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61", "0.0.62", "0.0.63", "0.0.64"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61", "0.0.62", "0.0.63", "0.0.64"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.61", "0.0.62", "0.0.63"},
@@ -288,7 +294,7 @@ func TestRunUpgrades(t *testing.T) {
 			name:                              "Should not run upgrades that are older than the first installed okctl version",
 			withOkctlVersion:                  "0.0.64",
 			withOriginalClusterVersion:        "0.0.62",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61", "0.0.62", "0.0.63", "0.0.64"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61", "0.0.62", "0.0.63", "0.0.64"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.63", "0.0.64"},
@@ -298,7 +304,7 @@ func TestRunUpgrades(t *testing.T) {
 			withDebug:                         true,
 			withOkctlVersion:                  "0.0.63",
 			withOriginalClusterVersion:        "0.0.61",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.61", "0.0.62", "0.0.63", "0.0.64"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.61", "0.0.62", "0.0.63", "0.0.64"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.62", "0.0.63"},
@@ -308,7 +314,7 @@ func TestRunUpgrades(t *testing.T) {
 			withConfirm:                       boolPtr(true),
 			withOkctlVersion:                  "0.0.65",
 			withOriginalClusterVersion:        "0.0.60",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.62"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.62"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.62"},
@@ -319,7 +325,7 @@ func TestRunUpgrades(t *testing.T) {
 			withConfirm:                       boolPtr(false),
 			withOkctlVersion:                  "0.0.65",
 			withOriginalClusterVersion:        "0.0.60",
-			withGithubReleases:                createGithubReleases([]string{linux, darwin}, amd64, []string{"0.0.62"}),
+			withGithubReleases:                GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: []string{"0.0.62"}},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.62"},
@@ -328,8 +334,10 @@ func TestRunUpgrades(t *testing.T) {
 			name:                       "Should run upgrade hot fixes, and in correct order",
 			withOkctlVersion:           "0.0.63",
 			withOriginalClusterVersion: "0.0.50",
-			withGithubReleases: createGithubReleases([]string{linux, darwin}, amd64,
-				[]string{"0.0.63.a", "0.0.62", "0.0.62.b", "0.0.61", "0.0.62.a", "0.0.64.a", "0.0.63"}),
+			withGithubReleases: GithubReleases{
+				oses: []string{linux, darwin}, arch: amd64,
+				versions: []string{"0.0.63.a", "0.0.62", "0.0.62.b", "0.0.61", "0.0.62.a", "0.0.64.a", "0.0.63"},
+			},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.61", "0.0.62", "0.0.62.a", "0.0.62.b", "0.0.63", "0.0.63.a"},
@@ -338,8 +346,10 @@ func TestRunUpgrades(t *testing.T) {
 			name:                       "Should not run upgrades, including hot fixes, that are older than the first installed okctl version",
 			withOkctlVersion:           "0.0.63",
 			withOriginalClusterVersion: "0.0.62",
-			withGithubReleases: createGithubReleases([]string{linux, darwin}, amd64,
-				[]string{"0.0.62", "0.0.62.a", "0.0.62.b", "0.0.63", "0.0.63.a", "0.0.64.a"}),
+			withGithubReleases: GithubReleases{
+				oses: []string{linux, darwin}, arch: amd64,
+				versions: []string{"0.0.62", "0.0.62.a", "0.0.62.b", "0.0.63", "0.0.63.a", "0.0.64.a"},
+			},
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			expectBinaryVersionsRunOnce:       []string{"0.0.63", "0.0.63.a"},
@@ -356,9 +366,9 @@ func TestRunUpgrades(t *testing.T) {
 			withTestRun: func(t *testing.T, tc TestCase, defaultOpts DefaultTestOpts) {
 				// Given settings for first upgrade
 				githubReleaseVersions := []string{"0.0.61", "0.0.62", "0.0.63"}
-				githubReleases := createGithubReleases([]string{linux, darwin}, amd64, githubReleaseVersions)
+				githubReleases := GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: githubReleaseVersions}
 
-				defaultOpts.GithubService = newGithubServiceMock(githubReleases)
+				defaultOpts.GithubService = newGithubServiceMock(createGithubReleasesFromTestCase(t, githubReleases))
 
 				mockHTTPResponsesForGithubReleases(t, folderWorking, githubReleases)
 				defer httpmock.DeactivateAndReset()
@@ -387,9 +397,9 @@ func TestRunUpgrades(t *testing.T) {
 
 				// Given settings for second upgrade
 				githubReleaseVersions = []string{"0.0.61", "0.0.62", "0.0.62.a", "0.0.62.b", "0.0.63", "0.0.63.a", "0.0.64"}
-				githubReleases = createGithubReleases([]string{linux, darwin}, amd64, githubReleaseVersions)
+				githubReleases = GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: githubReleaseVersions}
 
-				defaultOpts.GithubService = newGithubServiceMock(githubReleases)
+				defaultOpts.GithubService = newGithubServiceMock(createGithubReleasesFromTestCase(t, githubReleases))
 
 				mockHTTPResponsesForGithubReleases(t, folderWorking, githubReleases)
 
@@ -414,17 +424,19 @@ func TestRunUpgrades(t *testing.T) {
 			},
 		},
 		{
-			name:                       "Should return error if github release isn't valid",
-			withOkctlVersion:           "0.0.61",
-			withOriginalClusterVersion: "0.0.50",
-			withGithubReleases: []*github.RepositoryRelease{
-				{
-					ID: github.Int64Ptr(123),
-				},
-			},
+			name:                              "Should return error if github release isn't valid",
+			withOkctlVersion:                  "0.0.61",
+			withOriginalClusterVersion:        "0.0.50",
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			withTestRun: func(t *testing.T, tc TestCase, defaultOpts DefaultTestOpts) {
+				githubReleases := []*github.RepositoryRelease{
+					{
+						ID: github.Int64Ptr(123),
+					},
+				}
+				defaultOpts.GithubService = newGithubServiceMock(githubReleases)
+
 				upgrader, err := upgrade.New(defaultOpts.Opts)
 				require.NoError(t, err)
 
@@ -438,23 +450,25 @@ func TestRunUpgrades(t *testing.T) {
 			},
 		},
 		{
-			name:                       "Should return error if github release assets don't include checksum",
-			withOkctlVersion:           "0.0.64",
-			withOriginalClusterVersion: "0.0.50",
-			withGithubReleases: []*github.RepositoryRelease{
-				{
-					ID:      github.Int64Ptr(123),
-					TagName: github.StringPtr("0.0.61"),
-					Name:    github.StringPtr("0.0.61"),
-					Assets: []*github.ReleaseAsset{
-						createGihubReleaseAssetBinary(linux, amd64, "0.0.61"),
-						createGihubReleaseAssetBinary(darwin, amd64, "0.0.61"),
-					},
-				},
-			},
+			name:                              "Should return error if github release assets don't include checksum",
+			withOkctlVersion:                  "0.0.64",
+			withOriginalClusterVersion:        "0.0.50",
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			withTestRun: func(t *testing.T, tc TestCase, defaultOpts DefaultTestOpts) {
+				githubReleases := []*github.RepositoryRelease{
+					{
+						ID:      github.Int64Ptr(123),
+						TagName: github.StringPtr("0.0.61"),
+						Name:    github.StringPtr("0.0.61"),
+						Assets: []*github.ReleaseAsset{
+							createGihubReleaseAssetBinary(linux, amd64, "0.0.61", "0.0.61"),
+							createGihubReleaseAssetBinary(darwin, amd64, "0.0.61", "0.0.61"),
+						},
+					},
+				}
+				defaultOpts.GithubService = newGithubServiceMock(githubReleases)
+
 				upgrader, err := upgrade.New(defaultOpts.Opts)
 				require.NoError(t, err)
 
@@ -469,33 +483,35 @@ func TestRunUpgrades(t *testing.T) {
 			},
 		},
 		{
-			name:                       "Should return error if release version does not match release download URL version",
-			withOkctlVersion:           "0.0.64",
-			withOriginalClusterVersion: "0.0.50",
-			withGithubReleases: []*github.RepositoryRelease{
-				{
-					ID:      github.Int64Ptr(123),
-					TagName: github.StringPtr("0.0.61"),
-					Name:    github.StringPtr("0.0.61"),
-					Assets: []*github.ReleaseAsset{
-						{
-							Name: github.StringPtr("okctl_upgrade-linux_amd64_0.0.61.tar.gz"),
-							BrowserDownloadURL: github.StringPtr(fmt.Sprintf(
-								"%s/releases/download/%s/okctl-upgrade_%s_%s_%s.tar.gz",
-								upgrade.OkctlUpgradeRepoURL, "0.0.61", "0.0.61", linux, amd64)),
-						},
-						{
-							Name: github.StringPtr("okctl_upgrade-darwin_amd64_0.0.61.tar.gz"),
-							BrowserDownloadURL: github.StringPtr(fmt.Sprintf(
-								"%s/releases/download/%s/okctl-upgrade_%s_%s_%s.tar.gz",
-								upgrade.OkctlUpgradeRepoURL, "0.0.61", "0.0.61", darwin, amd64)),
-						},
-					},
-				},
-			},
+			name:                              "Should return error if release version does not match release download URL version",
+			withOkctlVersion:                  "0.0.64",
+			withOriginalClusterVersion:        "0.0.50",
 			withGithubReleaseAssetsFromFolder: folderWorking,
 			withHost:                          state.Host{Os: linux, Arch: amd64},
 			withTestRun: func(t *testing.T, tc TestCase, defaultOpts DefaultTestOpts) {
+				githubReleases := []*github.RepositoryRelease{
+					{
+						ID:      github.Int64Ptr(123),
+						TagName: github.StringPtr("0.0.61"),
+						Name:    github.StringPtr("0.0.61"),
+						Assets: []*github.ReleaseAsset{
+							{
+								Name: github.StringPtr("okctl_upgrade-linux_amd64_0.0.61.tar.gz"),
+								BrowserDownloadURL: github.StringPtr(fmt.Sprintf(
+									"%s/releases/download/%s/okctl-upgrade_%s_%s_%s.tar.gz",
+									upgrade.OkctlUpgradeRepoURL, "0.0.61", "0.0.61", linux, amd64)),
+							},
+							{
+								Name: github.StringPtr("okctl_upgrade-darwin_amd64_0.0.61.tar.gz"),
+								BrowserDownloadURL: github.StringPtr(fmt.Sprintf(
+									"%s/releases/download/%s/okctl-upgrade_%s_%s_%s.tar.gz",
+									upgrade.OkctlUpgradeRepoURL, "0.0.61", "0.0.61", darwin, amd64)),
+							},
+						},
+					},
+				}
+				defaultOpts.GithubService = newGithubServiceMock(githubReleases)
+
 				upgrader, err := upgrade.New(defaultOpts.Opts)
 				require.NoError(t, err)
 
@@ -519,7 +535,8 @@ func TestRunUpgrades(t *testing.T) {
 			withTestRun: func(t *testing.T, tc TestCase, defaultOpts DefaultTestOpts) {
 				// Given configuration for first run
 				githubReleaseVersions := []string{"0.0.61", "0.0.62", "0.0.63"}
-				githubReleases := createGithubReleases([]string{linux, darwin}, amd64, githubReleaseVersions)
+				githubReleases := createGithubReleasesFromTestCase(t,
+					GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: githubReleaseVersions})
 
 				defaultOpts.GithubService = newGithubServiceMock(githubReleases)
 
@@ -560,7 +577,8 @@ func TestRunUpgrades(t *testing.T) {
 
 				// Given configuration for second run
 				githubReleaseVersions = []string{"0.0.61", "0.0.62.a", "0.0.63"}
-				githubReleases = createGithubReleases([]string{linux, darwin}, amd64, githubReleaseVersions)
+				githubReleases = createGithubReleasesFromTestCase(t,
+					GithubReleases{oses: []string{linux, darwin}, arch: amd64, versions: githubReleaseVersions})
 
 				defaultOpts.GithubService = newGithubServiceMock(githubReleases)
 
@@ -619,6 +637,8 @@ func TestRunUpgrades(t *testing.T) {
 			err = tmpStore.MkdirAll(repoDir)
 			assert.NoError(t, err)
 
+			githubReleases := createGithubReleasesFromTestCase(t, tc.withGithubReleases)
+
 			if len(tc.withClusterVersion) == 0 {
 				tc.withClusterVersion = tc.withOriginalClusterVersion
 			}
@@ -646,7 +666,7 @@ func TestRunUpgrades(t *testing.T) {
 					Logger:                   logrus.StandardLogger(),
 					Out:                      stdOutBuffer,
 					RepositoryDirectory:      repositoryAbsoluteDir,
-					GithubService:            newGithubServiceMock(tc.withGithubReleases),
+					GithubService:            newGithubServiceMock(githubReleases),
 					ChecksumDownloader:       upgrade.NewChecksumDownloader(),
 					ClusterVersioner:         clusterVersioner,
 					OriginalClusterVersioner: originalClusterVersioner,
@@ -775,15 +795,22 @@ func getActualUpgradesRun(stdOutBuffer *bytes.Buffer) []string {
 	return actualUpgradesRun
 }
 
+func createGithubReleasesFromTestCase(t *testing.T, releases GithubReleases) []*github.RepositoryRelease {
+	return createGithubReleases(t, releases.oses, releases.arch, releases.versions)
+}
+
 //nolint:unparam
-func createGithubReleases(oses []string, arch string, versions []string) []*github.RepositoryRelease {
+func createGithubReleases(t *testing.T, oses []string, arch string, versions []string) []*github.RepositoryRelease {
 	releases := make([]*github.RepositoryRelease, 0, len(versions))
 
 	for i, version := range versions {
 		assets := make([]*github.ReleaseAsset, 0, len(oses)+1)
 
+		gitTag, err := toGitTag(versions[i])
+		require.NoErrorf(t, err, "creating git tag from version '%s': %s", versions[i], err)
+
 		for _, os := range oses {
-			asset := createGihubReleaseAssetBinary(os, arch, version)
+			asset := createGihubReleaseAssetBinary(os, arch, gitTag, version)
 			assets = append(assets, asset)
 		}
 
@@ -791,12 +818,12 @@ func createGithubReleases(oses []string, arch string, versions []string) []*gith
 			Name:        github.StringPtr(upgrade.ChecksumsTxt),
 			ContentType: github.StringPtr("text/plain"),
 			BrowserDownloadURL: github.StringPtr(fmt.Sprintf(
-				"%s/releases/download/%s/okctl-upgrade-checksums.txt", upgrade.OkctlUpgradeRepoURL, version)),
+				"%s/releases/download/%s/okctl-upgrade-checksums.txt", upgrade.OkctlUpgradeRepoURL, gitTag)),
 		})
 
 		release := &github.RepositoryRelease{
 			ID:      github.Int64Ptr(int64(i + 1)),
-			TagName: &versions[i],
+			TagName: &gitTag,
 			Name:    &versions[i],
 			Assets:  assets,
 		}
@@ -807,12 +834,30 @@ func createGithubReleases(oses []string, arch string, versions []string) []*gith
 	return releases
 }
 
-func createGihubReleaseAssetBinary(os, arch, version string) *github.ReleaseAsset {
+func createGihubReleaseAssetBinary(os, arch, gitTag, version string) *github.ReleaseAsset {
 	return &github.ReleaseAsset{
 		Name:        github.StringPtr(fmt.Sprintf("okctl_upgrade-%s_%s_%s.tar.gz", os, arch, version)),
 		ContentType: github.StringPtr("application/gzip"),
 		BrowserDownloadURL: github.StringPtr(fmt.Sprintf(
-			"%s/releases/download/%s/okctl-upgrade_%s_%s_%s.tar.gz", upgrade.OkctlUpgradeRepoURL, version, version, os, arch)),
+			"%s/releases/download/%s/okctl-upgrade_%s_%s_%s.tar.gz", upgrade.OkctlUpgradeRepoURL, gitTag, version, os, arch)),
+	}
+}
+
+// Converts an upgrade version to the expected associated git tag
+//
+// Examples:
+// 0.0.50.something to 0.0.50+something
+// 0.0.50 to 0.0.50
+func toGitTag(version string) (string, error) {
+	parts := strings.Split(version, ".")
+
+	switch {
+	case len(parts) == upgrade.DotCountForRegularSemver:
+		return version, nil
+	case len(parts) == upgrade.DotCountForSemverWithHotfix:
+		return fmt.Sprintf("%s.%s.%s+%s", parts[0], parts[1], parts[2], parts[3]), nil
+	default:
+		return "", fmt.Errorf("not a valid version: %s", version)
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Change download URL for upgrade binaries.

Dependent on https://github.com/oslokommune/okctl-upgrade/pull/6

## Description

<!--- Describe your changes in detail -->

### Problem

In the [okctl-upgrade](https://github.com/oslokommune/okctl-upgrade) repository, we need to produce github releases containing binaries. A github releases is associated with a tag, and the tag must be a valid semantic version, because GoReleaser refuses to produce a release whose tag isn't a valid semantic version *.

However, okctl was made to download releases with tags on the form `0.0.74.somecomponent`, which isn't a valid semver. `0.0.74+somecomponent` is the [valid form](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions). This PR fixes this.

None of this would be needed if we could just make GoReleaser publish releases using an overriden URLs, but I've not found any way of doing this.

\* The error message from GoReleaser is: `release failed after 0.02s error=failed to parse tag '0.0.74.somecomponent' as semver: Invalid Semantic Version`

### Solution

I've tried to limit the impact on the code, by doing rewrites of tag to okctl version and back, instead of supporting the new form everywhere. Also, we don't want to have directory and file names containing `+`, as it's not POSIX compliant and might bite us later ([1](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282), [2](https://stackoverflow.com/a/1976172/915441)).

Also, I made a huge refactoring in `upgrade_test.go` because calling functions when defining test cases is a bad idea. They get called regardless if that test is run, making debugging a hell.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Get upgrades to work with build identifiers in tag.

[KM473](https://trello.com/c/RJ1ubWLc/473-releasing-upgrades-fails-due-to-invalid-semantic-version)
## How to prove the effect of this PR?

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

upgrade.go -> change to repo okctl-upgrade-test, and verify that upgrade for 0.0.78 for grafana is run, when running `okctl upgrade`.

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
