### PR TITLE
KM455 ✅ Add post-mortem template

### DIFF
--- a/docs/post-mortems/0000-post-mortem-template.md
+++ b/docs/post-mortems/0000-post-mortem-template.md
@@ -8,8 +8,11 @@ proaktiv melding.
 -->
 
 ## Timeline
-<!-- 
-Describe the relevant activites in a timeline format. Remember activities leading up to the event being triggered.
+<!--
+Describe the relevant activites in a timeline format. Remember activities
+leading up to the event being triggered. Make sure to link to graphs, logs and
+other relevant information sources.
+
 
 2019-12-30
     23:30 A proactive message got sendt out to all the citizens of Oslo

--- a/docs/post-mortems/0000-post-mortem-template.md
+++ b/docs/post-mortems/0000-post-mortem-template.md
@@ -13,7 +13,6 @@ Describe the relevant activites in a timeline format. Remember activities
 leading up to the event being triggered. Make sure to link to graphs, logs and
 other relevant information sources.
 
-
 2019-12-30
     23:30 A proactive message got sendt out to all the citizens of Oslo
 2019-12-31
@@ -68,12 +67,13 @@ Example:
 - Deploying the database update was fast
 -->
 
-## What could we have done better
+## What went wrong
 <!--
 Describe what went wrong trying to handle the event.
 
 Example:
 - Had to manually roll back the database while testing fixes
+- We missed the notification regarding Keycloak upgrade
 -->
 
 ## Where were we lucky

--- a/docs/post-mortems/0000-post-mortem-template.md
+++ b/docs/post-mortems/0000-post-mortem-template.md
@@ -1,0 +1,109 @@
+## Summary
+<!--
+Describe the reason and the consequences of the event as short and concise as possible.
+
+Example:
+The backend of Oslo Nøkkelen were unavailable for 31 minutes due to an increase in traffic that happened after a
+proaktiv melding.
+-->
+
+## Timeline
+<!-- 
+Describe the relevant activites in a timeline format. Remember activities leading up to the event being triggered.
+
+2019-12-30
+    23:30 A proactive message got sendt out to all the citizens of Oslo
+2019-12-31
+    08:23 Oslonøkkelen had been downloaded 30.000 times, distributed evenly across iOS and Android, during the past 3 hours
+    09:09 DOWNTIME START - backend fails due to the increased load
+    09:14 Received Slack notifications due to an increase in 500 status codes in the backend
+    09:16 Initiated an investigation into the issue
+    09:18 EVENT START - Team creates the Slack channel #citykey-incident-backend to better cooperate on the issue
+    09:20 Manually scaling up the number of backend instances
+    09:24 Found the error. The backend fails when it tries to read an item in the database that doesn't exist. Only happens upon a users first login
+    09:28 Pull request with a fix created: http://github.com/oslokommune/something/something/pr/298
+    09:34 Pull request 298 merged and deployed to production
+    09:39 PROBLEM FIXED - Amount of 500 status code requests are decreasing
+    09:40 DOWNTIME END - Amount of 500 status codes are down to zero
+    10:10 EVENT END - Reaches criteria of 30 minutes with normal activity
+-->
+
+## Impact
+<!--
+Describe the consequences this had for the organization.
+
+Example:
+- Approximately 30.000 users downloaded and experienced an error using the app.
+- Users already logged in experienced some minor delay in the app
+-->
+
+## Cause(s)
+<!--
+Describe relevant factors that played a part in causing the event.
+
+Example:
+The error happened due to a combination of:
+- A spike of new users
+- A bug in the backend code for user creation
+-->
+
+## Solution
+<!--
+Describe how the problem was fixed.
+
+Example:
+- Manually scaled up number of backend instances letting regular traffic stay unaffected
+- Created a fix for the database schema
+-->
+
+## What went well
+<!--
+Describe what went well trying to handle the event.
+
+Example:
+- Alerting mechanisms worked brilliantly when errors started comming in
+- Deploying the database update was fast
+-->
+
+## What could we have done better
+<!--
+Describe what went wrong trying to handle the event.
+
+Example:
+- Had to manually roll back the database while testing fixes
+-->
+
+## Where were we lucky
+<!--
+Describe briefly the situations related to this event where we got lucky.
+
+Example:
+- Updating the database schema fixed the problem
+- Manual horizontal scale up ensured a small amount of users was affected
+-->
+
+## Mitigations
+<!--
+Describe potential steps to prevent this event from happening again, be it technical, processes, etc.
+
+Example:
+- Request that proactive messages will be sendt in smaller batches, ideally during regular work hours, for load to be
+    better distributed.
+- Create tests that cover creation and authentication of users
+-->
+
+## Action items
+<!--
+Describe and reference specific action items
+
+Example:
+[KM123](https://trello.com/c/nJpSSGCs/455-post-mortem-the-github-cert-issue) - Add backoff for login in the iOS app
+[KM221](https://trello.com/c/nJpSSGCs/455-post-mortem-the-github-cert-issue) - Add tests in the backend for creating a user and authenticating
+-->
+
+## Supporting information and documentation
+<!--
+Add relevant additional information or documentation.
+
+Example: images of metrics that show when something went wrong, relevant pieces of logs, etc
+-->

--- a/docs/rfc/0000-rfc-template.md
+++ b/docs/rfc/0000-rfc-template.md
@@ -1,5 +1,4 @@
 # 0000. Request for comments
-
 <!-- 
     Date representing when the RFC was submittet for review 
 
@@ -9,7 +8,6 @@
 Date:
 
 ## Context
-
 <!--
     Short description of why this decision is needed
 
@@ -17,9 +15,7 @@ Date:
     We want to better document our decisions
 -->
 
-
 ## Decision
-
 <!--
     Short summary of the decision
 
@@ -28,11 +24,9 @@ Date:
 -->
 
 ## Consequences
-
 <!--
     Short description of positive and negative consequences of the decision
 
     Example:
     The decisions we deem relevant will be documented in this format here in this folder.
 -->
-

--- a/docs/rfc/0004-post-mortem-template.md
+++ b/docs/rfc/0004-post-mortem-template.md
@@ -27,6 +27,8 @@ We've decided to go for [this](/docs/post-mortems/0000-post-mortem-template.md) 
 
 All post-mortems are to be placed in [/docs/post-mortems](/docs/post-mortems).
 
+The post-mortem template is a guideline. Add and/or remove points you deem reasonable.
+
 ## Consequences
 <!--
     Short description of positive and negative consequences of the decision

--- a/docs/rfc/0004-post-mortem-template.md
+++ b/docs/rfc/0004-post-mortem-template.md
@@ -1,0 +1,49 @@
+# 0004. Post-mortem
+<!-- 
+    Date representing when the RFC was submittet for review.
+
+    Example:
+    Date: 08.02.2021
+-->
+Date: 21.12.2021
+
+## Context
+<!--
+    Short description of why this decision is needed
+
+    Example:
+    We want to better document our decisions
+-->
+We want to streamline the post-mortem process to improve speed and quality of post-mortem productions.
+
+## Decision
+<!--
+    Short summary of the decision
+
+    Example:
+    We've decided to go for AlphaGov's system as explained [here](https://github.com/alphagov/govuk-aws/blob/24d1ea513e58ee938043d71d09815a51229067bf/docs/architecture/decisions/0001-record-architecture-decisions.md)
+-->
+We've decided to go for [this](/docs/post-mortems/0000-post-mortem-template.md) template.
+
+All post-mortems are to be placed in [/docs/post-mortems](/docs/post-mortems).
+
+## Consequences
+<!--
+    Short description of positive and negative consequences of the decision
+
+    Example:
+    The decisions we deem relevant will be documented in this format here in this folder.
+-->
+
+### Pros
+
+- By placing the post-mortems in a folder in a public repository, we will:
+  - lead by example as an openness focused team.
+  - share our hard-earned knowledge with others.
+  - inspire others to both share and implement the post-mortem process.
+- Define the process to establish it for faster and better post-mortem productions.
+
+### Cons
+
+- Difficulties can arise when formulating post-mortems that are to be publicly viewed.
+- Harder to cooperate on a single document than for example Google Docs. (can be mitigated with pair/mob writing)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds an RFC and a template for creating post-mortems.

The template is based on the excellent template made Oslonøkkelen found [here](https://confluence.oslo.kommune.no/pages/viewpage.action?pageId=89102585).

I've translated it and did some minor tweaks, like removing "what did we learn" since I feel like the other fields will adequately convey our learning points. 

I came across a nice source of post-mortem templates [here](https://github.com/dastergon/postmortem-templates).

Remember to view the template in RAW. There's relevant commentary in it. 

Feel free to comment on anything, for example:
- Points that you feel are redundant
- Points that you feel are missing
- Things that should be reworded

The template should be simple to understand and to use. Please review each point critically. Lets make sure we don't write loads of documentation which in hindsight were a waste of time
