### PR TITLE
KM486 🐛 Remove version validation in okctl scaffold cluster

### DIFF
--- a/cmd/okctl/scaffold_application.go
+++ b/cmd/okctl/scaffold_application.go
@@ -39,11 +39,6 @@ func buildScaffoldApplicationCommand(o *okctl.Okctl) *cobra.Command {
 
 					o.Declaration = clusterDeclaration
 
-					err = commands.ValidateBinaryVersionNotLessThanClusterVersion(o)
-					if err != nil {
-						return err
-					}
-
 					opts.PrimaryHostedZone = clusterDeclaration.ClusterRootDomain
 				} else {
 					opts.PrimaryHostedZone = "okctl.io"

--- a/docs/release_notes/0.0.80.md
+++ b/docs/release_notes/0.0.80.md
@@ -22,8 +22,6 @@ KM290 ✅ Add remote state (#807)
 
 ## Bugfixes
 
-KM486 🐛 Remove version validation in okctl scaffold cluster (#828)
-
 ## Changes
 KM372 👌 Extract ArgoCD application handling into its own reconciler (#831)
 

--- a/docs/release_notes/0.0.80.md
+++ b/docs/release_notes/0.0.80.md
@@ -22,6 +22,8 @@ KM290 ✅ Add remote state (#807)
 
 ## Bugfixes
 
+KM486 🐛 Remove version validation in okctl scaffold cluster (#828)
+
 ## Changes
 KM372 👌 Extract ArgoCD application handling into its own reconciler (#831)
 

--- a/docs/release_notes/0.0.81.md
+++ b/docs/release_notes/0.0.81.md
@@ -8,6 +8,8 @@
 
 🐛 Fix apply cluster crashing due to nil reference (#836)
 
+KM486 🐛 Remove version validation in okctl scaffold cluster (#828)
+
 ## Changes
 
 ## Other


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

okctl scaffold currently crashes, because after we added versioning validation, it attempts to read state. However, we haven't called `o.Initialize()`. That would require specifying the `--cluster-declaration` flag when running scaffold. Maybe we should do that, but for now, I just want to get the command working again.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[KM486](https://trello.com/c/l64Or6t6/486-scaffold-application-crashes)

## How to prove the effect of this PR?

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

Build it and run `okctl scaffold application` and verify that it works.

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
