### PR TITLE
KM372 👌 Extract ArgoCD application handling into its own reconciler

### DIFF
--- a/cmd/okctl/apply_application.go
+++ b/cmd/okctl/apply_application.go
@@ -94,6 +94,7 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 				reconciliation.NewApplicationReconciler(services.ApplicationService),
 				reconciliation.NewContainerRepositoryReconciler(services.ContainerRepository),
 				reconciliation.NewPostgresReconciler(services.ApplicationPostgresService),
+				reconciliation.NewArgoCDApplicationReconciler(services.ApplicationService),
 			)
 
 			_, err = scheduler.Run(o.Ctx, state)

--- a/docs/release_notes/0.0.80.md
+++ b/docs/release_notes/0.0.80.md
@@ -5,6 +5,7 @@
 ## Bugfixes
 
 ## Changes
+KM372 👌 Extract ArgoCD application handling into its own reconciler (#831)
 
 ## Other
 

--- a/pkg/client/core/service_application_client.go
+++ b/pkg/client/core/service_application_client.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/mishudark/errors"
+
 	"github.com/oslokommune/okctl/pkg/api"
 	"github.com/oslokommune/okctl/pkg/client"
 	"github.com/oslokommune/okctl/pkg/config/constant"
@@ -102,7 +104,12 @@ func (s *applicationService) CreateArgoCDApplicationManifest(opts client.CreateA
 	absoluteOverlayDir := path.Join(s.absoluteRepositoryDir, relativeOverlayDir)
 	absoluteArgoCDApplicationManifestPath := path.Join(absoluteOverlayDir, defaultArgoCDApplicationManifestFilename)
 
-	err := scaffold.GenerateArgoCDApplicationManifest(scaffold.GenerateArgoCDApplicationManifestOpts{
+	err := s.fs.MkdirAll(absoluteOverlayDir, 0o700)
+	if err != nil {
+		return errors.E(err, "ensuring overlay directory: %w", err)
+	}
+
+	err = scaffold.GenerateArgoCDApplicationManifest(scaffold.GenerateArgoCDApplicationManifestOpts{
 		Saver: func(content []byte) error {
 			return s.fs.WriteFile(absoluteArgoCDApplicationManifestPath, content, defaultArgoCDApplicationManifestPermissions)
 		},
@@ -111,7 +118,7 @@ func (s *applicationService) CreateArgoCDApplicationManifest(opts client.CreateA
 		RelativeApplicationOverlayDir: relativeOverlayDir,
 	})
 	if err != nil {
-		return fmt.Errorf("generating ArgoCD Application manifest: %w", err)
+		return errors.E(err, "generating ArgoCD Application manifest")
 	}
 
 	return nil

--- a/pkg/controller/application/reconciliation/application_reconciler.go
+++ b/pkg/controller/application/reconciliation/application_reconciler.go
@@ -64,14 +64,6 @@ func (a *applicationReconciler) createApplication(ctx context.Context, meta reco
 		return reconciliation.Result{}, err
 	}
 
-	err = a.client.CreateArgoCDApplicationManifest(client.CreateArgoCDApplicationManifestOpts{
-		Cluster:     *meta.ClusterDeclaration,
-		Application: meta.ApplicationDeclaration,
-	})
-	if err != nil {
-		return reconciliation.Result{}, fmt.Errorf("creating ArgoCD Application manifest: %w", err)
-	}
-
 	return reconciliation.Result{Requeue: false}, nil
 }
 

--- a/pkg/controller/application/reconciliation/argocd_reconciler.go
+++ b/pkg/controller/application/reconciliation/argocd_reconciler.go
@@ -1,0 +1,71 @@
+package reconciliation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mishudark/errors"
+	"github.com/oslokommune/okctl/pkg/client"
+	clientCore "github.com/oslokommune/okctl/pkg/client/core"
+	"github.com/oslokommune/okctl/pkg/controller/common/reconciliation"
+)
+
+const argoCDApplicationReconcilerIdentifier = "ArgoCD"
+
+// argoCDApplicationReconciler handles reconciliation for this feature
+type argoCDApplicationReconciler struct {
+	client client.ApplicationService
+}
+
+// Reconcile knows how to do what is necessary to ensure the desired state is achieved
+func (a *argoCDApplicationReconciler) Reconcile(_ context.Context, meta reconciliation.Metadata, _ *clientCore.StateHandlers) (reconciliation.Result, error) {
+	action, err := a.determineAction(meta)
+	if err != nil {
+		return reconciliation.Result{}, errors.E(err, "determining course of action")
+	}
+
+	switch action {
+	case reconciliation.ActionCreate:
+		err = a.client.CreateArgoCDApplicationManifest(client.CreateArgoCDApplicationManifestOpts{
+			Cluster:     *meta.ClusterDeclaration,
+			Application: meta.ApplicationDeclaration,
+		})
+		if err != nil {
+			return reconciliation.Result{}, errors.E(err, "creating ArgoCD application manifest")
+		}
+
+		return reconciliation.Result{}, nil
+	case reconciliation.ActionDelete:
+		return reconciliation.Result{}, errors.New("deletion of an ArgoCD Application is not implemented")
+	case reconciliation.ActionNoop:
+		return reconciliation.Result{Requeue: false}, nil
+	case reconciliation.ActionWait:
+		return reconciliation.Result{Requeue: true}, nil
+	}
+
+	return reconciliation.Result{}, fmt.Errorf("action %s is not implemented", action)
+}
+
+func (a *argoCDApplicationReconciler) String() string {
+	return argoCDApplicationReconcilerIdentifier
+}
+
+func (a *argoCDApplicationReconciler) determineAction(meta reconciliation.Metadata) (reconciliation.Action, error) {
+	userIndication := reconciliation.DetermineUserIndication(meta, meta.ClusterDeclaration.Integrations.ArgoCD)
+
+	switch userIndication {
+	case reconciliation.ActionCreate:
+		return reconciliation.ActionCreate, nil
+	case reconciliation.ActionDelete:
+		return reconciliation.ActionDelete, nil
+	}
+
+	return reconciliation.ActionNoop, reconciliation.ErrIndecisive
+}
+
+// NewArgoCDApplicationReconciler initializes a new ArgoCDApplicationReconciler
+func NewArgoCDApplicationReconciler(client client.ApplicationService) reconciliation.Reconciler {
+	return &argoCDApplicationReconciler{
+		client: client,
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Moves ArgoCD into its own reconciler. This will improve implementing delete
application, and potentially prepare for letting apply application apply the
argocd manifest automatically

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM372](https://trello.com/c/eB19corW)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
1. Run `okctl apply application` using the latest release.
2. Commit the new application
3. Delete the created argocd-application manifest file
4. Run `okctl apply application` using this branch
5. Verify that there are no changes

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
