### PR TITLE
🐛 Fix graceful teardown not triggering upon segfault

### DIFF
--- a/docs/release_notes/0.0.81.md
+++ b/docs/release_notes/0.0.81.md
@@ -4,6 +4,8 @@
 
 ## Bugfixes
 
+🐛 Fix graceful teardown not triggering upon segfault (#835)
+
 ## Changes
 
 ## Other


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Defers the teardown to ensure it happens during a segfault

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Nightly](https://github.com/oslokommune/okctl/commit/4cde4775500ae9e3d9c08f82835aa308b4e21ae5/checks) failed due to a segfault and state did not get pushed

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
1. Add a `panic("oh snap")` in `cmd/apply_cluster.go` on line 99
2. Add a `println("tearing down")` in `cmd/root.go` above line 52

Run `apply cluster` and verify that both "oh snap" and "tearing down" gets printed

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
