### PR TITLE
Stop install script on error

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 function get_user_agent() {
   if [[ -f ~/.okctl/conf.yml ]]; then
     USER_AGENT=$( (grep -E "userAgent:" ~/.okctl/conf.yml || echo okctl) | sed 's/userAgent://')


### PR DESCRIPTION
Install script will continue even if there is an error

![image](https://user-images.githubusercontent.com/219015/148739326-72d7c199-cafc-45b2-84a4-a9cabdb0716d.png)

By setting the -e flag we prevent this.