### PR TITLE
KM451: Use core service directly in container repository client api

### DIFF
--- a/pkg/client/core/api/direct/container_repository_direct_api.go
+++ b/pkg/client/core/api/direct/container_repository_direct_api.go
@@ -1,0 +1,27 @@
+package direct
+
+import (
+	"context"
+
+	"github.com/oslokommune/okctl/pkg/api"
+	"github.com/oslokommune/okctl/pkg/client"
+)
+
+type containerRepositoryDirectClient struct {
+	service api.ContainerRepositoryService
+}
+
+func (c *containerRepositoryDirectClient) CreateContainerRepository(opts api.CreateContainerRepositoryOpts) (*api.ContainerRepository, error) {
+	return c.service.CreateContainerRepository(context.Background(), &opts)
+}
+
+func (c *containerRepositoryDirectClient) DeleteContainerRepository(opts api.DeleteContainerRepositoryOpts) error {
+	return c.service.DeleteContainerRepository(context.Background(), &opts)
+}
+
+// NewContainerRepositoryAPI returns an initialised REST API invoker
+func NewContainerRepositoryAPI(service api.ContainerRepositoryService) client.ContainerRepositoryAPI {
+	return &containerRepositoryDirectClient{
+		service: service,
+	}
+}

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -371,7 +371,9 @@ func (o *Okctl) ClientServices(handlers *clientCore.StateHandlers) (*clientCore.
 	nameserverService := clientCore.NewNameserverHandlerService(ghClient)
 
 	containerRepositoryService := clientCore.NewContainerRepositoryService(
-		rest.NewContainerRepositoryAPI(o.restClient),
+		clientDirectAPI.NewContainerRepositoryAPI(core.NewContainerRepositoryService(
+			awsProvider.NewContainerRepositoryCloudProvider(o.CloudProvider),
+		)),
 		handlers.ContainerRepository,
 		o.CloudProvider,
 	)


### PR DESCRIPTION
Use core service directly in container repository client api