### PR TITLE
KM512 🐛 Use repository dir when running upgrades

### DIFF
--- a/cmd/okctl/upgrade.go
+++ b/cmd/okctl/upgrade.go
@@ -73,7 +73,7 @@ binaries used by okctl (kubectl, etc), and internal state.`,
 					return err
 				}
 
-				repoDir, err := o.GetHomeDir()
+				repoDir, err := o.GetRepoDir()
 				if err != nil {
 					return err
 				}

--- a/docs/release_notes/0.0.85.md
+++ b/docs/release_notes/0.0.85.md
@@ -4,7 +4,8 @@
 
 ## Bugfixes
 
+KM512 🐛 Use repository dir when running upgrades (#869)
+
 ## Changes
 
 ## Other
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Change upgrade binary directory to repository dir instead of home dir.

## Description
<!--- Describe your changes in detail -->

Upgrades are being run in the home directory instead of the IAC repository directory.

This leads to the error:

```shell
2022/01/17 13:24:50 [keyring] Considering backends: [secret-service kwallet pass file]
DEBU[0000] binary already exists: eksctl (0.41.0)       
DEBU[0000] binary already exists: aws-iam-authenticator (0.5.2) 
DEBU[0000] binary already exists: kubectl (1.18.9)      
Found 2 upgrade(s):
0.0.78.bump-grafana, 0.0.81.argocd

2 remaining upgrades after removing already executed:
0.0.78.bump-grafana, 0.0.81.argocd

2 remaining upgrades after removing too new upgrades:
0.0.78.bump-grafana, 0.0.81.argocd

2 remaining upgrades after removing too old upgrades:
0.0.78.bump-grafana, 0.0.81.argocd

Found 2 applicable upgrade(s):
0.0.78.bump-grafana, 0.0.81.argocd

DEBU[0003] binary already exists: okctl-upgrade_0.0.78.bump-grafana (0.0.78.bump-grafana) 
preloading missing binary: okctl-upgrade_0.0.81.argocd (0.0.81.argocd)
DEBU[0003] preloading missing binary: okctl-upgrade_0.0.81.argocd (0.0.81.argocd) 
Simulating upgrades (we're not doing any actual changes yet, just printing what's going to happen)... 

--- Simulating upgrade: okctl-upgrade_0.0.78.bump-grafana ---
Upgrading Grafana
Simulating upgrade
Current version is 7.5.12, ignoring upgrade
--- Simulating upgrade: okctl-upgrade_0.0.81.argocd ---
Upgrading ArgoCD
2022/01/17 13:24:56 [keyring] Considering backends: [secret-service kwallet pass file]
time="2022-01-17T13:24:56+01:00" level=debug msg="binary already exists: eksctl (0.41.0)"
time="2022-01-17T13:24:56+01:00" level=debug msg="binary already exists: aws-iam-authenticator (0.5.2)"
time="2022-01-17T13:24:56+01:00" level=debug msg="binary already exists: kubectl (1.18.9)"
getting repository root directory: exit status 128
--- Upgrade failed: okctl-upgrade_0.0.81.argocd ---
Error: upgrading: running upgrade binaries: simulating upgrades: running upgrade binary okctl-upgrade_0.0.81.argocd: executing command: /home/x/.okctl/binaries/okctl-upgrade_0.0.81.argocd/0.0.81.argocd/Linux/amd64/okctl-upgrade_0.0.81.argocd, got: exit status 1
DEBU[0006] starting                                      activity=UploadState component=hooks
DEBU[0006] uploading state                               activity=UploadState component=hooks
```

Since code is outside unit tests, it wasn't detected. Nighly for upgrades should catch such bugs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

* Build the branch
* Then

```shell
okctl venv
kubectl -n argocd edit deploy argocd-application-controller # change image version to 1.7.2
okctl upgrade
```

See that upgrade doesn't crash on simulation. You can answer no to the question about actually upgrading.

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
