### PR TITLE
KM519 Upgrade aws-iam-authenticator to support AWS SSO login

### DIFF
--- a/docs/release_notes/0.0.86.md
+++ b/docs/release_notes/0.0.86.md
@@ -6,6 +6,8 @@ KM478 ✅ Add support for authenticating with AWS profiles and AWS SSO (#856)
 
 ## Bugfixes
 
+KM519 🐛 Upgrade aws-iam-authenticator to support AWS SSO (#874)
+
 ## Changes
 
 ## Other

--- a/pkg/binaries/run/awsiamauthenticator/awsiamauthenticator.go
+++ b/pkg/binaries/run/awsiamauthenticator/awsiamauthenticator.go
@@ -5,7 +5,7 @@ const (
 	// Name sets the name of the binary/cli
 	Name = "aws-iam-authenticator"
 	// Version sets the currently used version of the binary/cli
-	Version = "0.5.2"
+	Version = "0.5.3"
 )
 
 // AwsIamAuthenticator stores state for running the cli

--- a/pkg/config/state/binary.go
+++ b/pkg/config/state/binary.go
@@ -14,7 +14,7 @@ func AWSIamAuthenticatorKnownBinaries() []Binary {
 	return []Binary{
 		{
 			Name:       "aws-iam-authenticator",
-			Version:    "0.5.2",
+			Version:    "0.5.3",
 			BufferSize: "100mb",
 			URLPattern: "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v#{ver}/aws-iam-authenticator_#{ver}_#{os}_#{arch}",
 			Checksums: []Checksum{
@@ -22,13 +22,13 @@ func AWSIamAuthenticatorKnownBinaries() []Binary {
 					Os:     "darwin",
 					Arch:   "amd64",
 					Type:   "sha256",
-					Digest: "f418c52d90947e56c9d9b01d3f32bbe52a0ba5ec02b65fc1ca9b85bff1652c2b",
+					Digest: "effd376c6ad00e90e45384000decac89f8495c76a3f52dee9eec389cfda236b7",
 				},
 				{
 					Os:     "linux",
 					Arch:   "amd64",
 					Type:   "sha256",
-					Digest: "5bbe44ad7f6dd87a02e0b463a2aed9611836eb2f40d7fbe8c517460a4385621b",
+					Digest: "20f4d8ece0f867c38b917ebe37dff934a31aabe385e26986183b14d72c70c137",
 				},
 			},
 		},


### PR DESCRIPTION
We need to upgrade aws-iam-authenticator to latest version v0.5.3 in order to support authenticating with AWS Single Sign-On (SSO).

## Description

The newest aws-iam-authenticator upgrades to AWS Go SDK v1.37 which adds support for AWS SSO authentication.

## Motivation and Context

Bugfix.

## How to prove the effect of this PR?

Users should be able to use `okctl` with AWS SSO based profile.

## Additional info

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the release notes (for the next release).
