### PR TITLE
KM491 - Give better error message if cluster is not found in state.db

### DIFF
--- a/cmd/okctl/apply_application.go
+++ b/cmd/okctl/apply_application.go
@@ -51,6 +51,7 @@ func buildApplyApplicationCommand(o *okctl.Okctl) *cobra.Command {
 			hooks.InitializeOkctl(o),
 			hooks.AcquireStateLock(o),
 			hooks.DownloadState(o, true),
+			hooks.VerifyClusterExistsInState(o),
 			func(cmd *cobra.Command, args []string) (err error) {
 				err = commands.ValidateBinaryEqualsClusterVersion(o)
 				if err != nil {

--- a/cmd/okctl/apply_cluster.go
+++ b/cmd/okctl/apply_cluster.go
@@ -82,6 +82,7 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 			hooks.InitializeOkctl(o),
 			hooks.AcquireStateLock(o),
 			hooks.DownloadState(o, true),
+			hooks.VerifyClusterExistsInState(o),
 			func(cmd *cobra.Command, args []string) (err error) {
 				state := o.StateHandlers(o.StateNodes())
 

--- a/cmd/okctl/delete.go
+++ b/cmd/okctl/delete.go
@@ -60,6 +60,7 @@ func buildDeleteClusterCommand(o *okctl.Okctl) *cobra.Command {
 			hooks.InitializeOkctl(o),
 			hooks.AcquireStateLock(o),
 			hooks.DownloadState(o, true),
+			hooks.VerifyClusterExistsInState(o),
 		),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			var spinnerWriter io.Writer

--- a/cmd/okctl/forward_postgres.go
+++ b/cmd/okctl/forward_postgres.go
@@ -67,6 +67,7 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 			hooks.EmitStartCommandExecutionEvent(metrics.ActionForwardPostgres),
 			hooks.InitializeOkctl(o),
 			hooks.DownloadState(o, false),
+			hooks.VerifyClusterExistsInState(o),
 			func(_ *cobra.Command, _ []string) error {
 				if len(opts.ApplicationName) == 0 {
 					return fmt.Errorf("missing database instance name")

--- a/cmd/okctl/hooks/state.go
+++ b/cmd/okctl/hooks/state.go
@@ -239,7 +239,8 @@ func VerifyClusterExistsInState(o *okctl.Okctl) RunEer {
 
 		_, err := handlers.Cluster.GetCluster(o.Declaration.Metadata.Name)
 		if err != nil {
-			o.Logger.Debug("Could not find cluster in current state: ", err)
+			log := logging.GetLogger(logComponent, "VerifyClusterExistsInState")
+			log.Debug("Could not find cluster in current state")
 
 			if errors.Is(err, storm.ErrNotFound) {
 				return fmt.Errorf("getting existing cluster %s: %w", o.Declaration.Metadata.Name, err)

--- a/cmd/okctl/hooks/state.go
+++ b/cmd/okctl/hooks/state.go
@@ -243,6 +243,14 @@ func VerifyClusterExistsInState(o *okctl.Okctl) RunEer {
 			log.Debug("Could not find cluster in current state")
 
 			if errors.Is(err, storm.ErrNotFound) {
+				_, _ = fmt.Fprintln(
+					o.Out,
+					"Could not find a cluster in your state.db. If you have recently upgraded from okctl version 0.0.80, "+
+						"you need to do some manual maintenance before continuing. See: "+
+						"https://www.okctl.io/common-issues/#i-get-an-error-message-with-getting-existing-cluster-cluster-name-not-found and "+
+						"https://www.okctl.io/concerning-upgrades-and-patches/",
+				)
+
 				return fmt.Errorf("getting existing cluster %s: %w", o.Declaration.Metadata.Name, err)
 			}
 

--- a/cmd/okctl/show.go
+++ b/cmd/okctl/show.go
@@ -53,6 +53,7 @@ func buildShowCredentialsCommand(o *okctl.Okctl) *cobra.Command {
 			hooks.EmitStartCommandExecutionEvent(metrics.ActionShowCredentials),
 			hooks.InitializeOkctl(o),
 			hooks.DownloadState(o, false),
+			hooks.VerifyClusterExistsInState(o),
 			func(_ *cobra.Command, args []string) error {
 				okctlEnvironment, err = commands.GetOkctlEnvironment(o, declarationPath)
 				if err != nil {

--- a/cmd/okctl/upgrade.go
+++ b/cmd/okctl/upgrade.go
@@ -48,6 +48,7 @@ binaries used by okctl (kubectl, etc), and internal state.`,
 			hooks.InitializeOkctl(o),
 			hooks.AcquireStateLock(o),
 			hooks.DownloadState(o, true),
+			hooks.VerifyClusterExistsInState(o),
 			func(cmd *cobra.Command, args []string) error {
 				okctlEnvironment, err := commands.GetOkctlEnvironment(o, declarationPath)
 				if err != nil {

--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -46,6 +46,7 @@ func buildVenvCommand(o *okctl.Okctl) *cobra.Command { //nolint: funlen
 			hooks.EmitStartCommandExecutionEvent(metrics.ActionVenv),
 			hooks.InitializeOkctl(o),
 			hooks.DownloadState(o, false),
+			hooks.VerifyClusterExistsInState(o),
 			func(_ *cobra.Command, args []string) error {
 				e, err := venvPreRunE(o)
 				if err != nil {

--- a/docs/release_notes/0.0.86.md
+++ b/docs/release_notes/0.0.86.md
@@ -7,6 +7,7 @@ KM478 ✅ Add support for authenticating with AWS profiles and AWS SSO (#856)
 ## Bugfixes
 
 KM519 🐛 Upgrade aws-iam-authenticator to support AWS SSO (#874)
+KM491 Better error message if cluster is not found in state.db
 
 ## Changes
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a user have created a cluster, not run the maintenance commands,
then upgraded to 0.0.80 or higher, a "not found" message will be
displayed. This gives a better error message, and will be accompanied
with a okctl.io common-issues for fixing the issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See [KM491](https://trello.com/c/2YlRCshT/491-after-updating-to-okctl-0080-users-get-error-not-found): let the user know that we cannot find a cluster that hen is trying to apply a command to 

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
To reproduce: rename `state.db` to ex `state2.db` in your S3 bucket and run `okctl venv -c cluster.yaml`, this will generate a error message about missing cluster

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->
Have added the verify functionality on all commands that download state.db, take a good look at those to ensure there are no side-effects I haven't thought about


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
