### PR TITLE
KM528 🐛 Fix forward postgres failing due to DNS lookup failure

### DIFF
--- a/cmd/okctl/forward_postgres.go
+++ b/cmd/okctl/forward_postgres.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/oslokommune/okctl/pkg/client"
 	"os"
 	"strings"
+
+	"github.com/oslokommune/okctl/pkg/client"
 
 	"github.com/oslokommune/okctl/pkg/commands"
 

--- a/cmd/okctl/forward_postgres.go
+++ b/cmd/okctl/forward_postgres.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"github.com/oslokommune/okctl/pkg/client"
 	"os"
 	"strings"
 
@@ -102,6 +104,19 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 			},
 		),
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
+			services, err := o.ClientServices(o.StateHandlers(o.StateNodes()))
+			if err != nil {
+				return fmt.Errorf("acquiring client services: %w", err)
+			}
+
+			clusterSecurityGroupID, err := services.Cluster.GetClusterSecurityGroupID(
+				context.Background(),
+				client.GetClusterSecurityGroupIDOpts{ID: opts.ID},
+			)
+			if err != nil {
+				return fmt.Errorf("acquiring cluster security group ID: %w", err)
+			}
+
 			clientSet, config, err := kube.NewFromEKSCluster(
 				opts.ID.ClusterName,
 				opts.ID.Region,
@@ -136,7 +151,10 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 					app,
 					opts.Namespace,
 					labels,
-					[]string{opts.SecurityGroup},
+					[]string{
+						opts.SecurityGroup,
+						clusterSecurityGroupID.Value,
+					},
 				),
 				config,
 			)
@@ -157,7 +175,7 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 				}
 			}()
 
-			client := pgbouncer.New(&pgbouncer.Config{
+			pgBouncerClient := pgbouncer.New(&pgbouncer.Config{
 				Name:                  app,
 				Database:              opts.DatabaseName,
 				Namespace:             opts.Namespace,
@@ -175,14 +193,14 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 				Logger:                o.Logger,
 			})
 
-			err = client.Create()
+			err = pgBouncerClient.Create()
 			if err != nil {
 				return err
 			}
 
 			defer func() {
 				o.Logger.Info("removing pgbouncer pod")
-				cerr := client.Delete()
+				cerr := pgBouncerClient.Delete()
 				if cerr != nil {
 					o.Logger.Warnf("deleting pgbouncer pod: %s", cerr)
 					err = cerr

--- a/docs/release_notes/0.0.86.md
+++ b/docs/release_notes/0.0.86.md
@@ -10,7 +10,9 @@ KM519 🐛 Upgrade aws-iam-authenticator to support AWS SSO (#874)
 
 KM508 🐛 Allow usernames with between 4 and 7 numbers (#882)
 
-KM491 👌 Better error message if cluster is not found in state.db (#879) 
+KM491 👌 Better error message if cluster is not found in state.db (#879)
+
+KM528 🐛 Fix forward postgres failing due to DNS lookup failure (#886)
 
 ## Changes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR gives the postgres bouncer pod the cluster security group as well, ensuring DNS resolution

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM528](https://trello.com/c/zdYvFWq2)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
1. Run `forward postgres` using latest version of okctl, then try connecting with a tool, for example `psql`
2. Verify that you get a DNS lookup failure in the pgbouncer pod logs
3. Run `forward postgres` using this version of okctl, then try connecting with a tool, for example `psql`
4. Verify that you are able to connect and run a query

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
