### PR TITLE
KM530 🐛 Fix graceful shutdown of forward postgres

### DIFF
--- a/docs/release_notes/0.0.87.md
+++ b/docs/release_notes/0.0.87.md
@@ -4,6 +4,8 @@
 
 ## Bugfixes
 
+KM530 🐛 Fix graceful shutdown of forward postgres (#887)
+
 ## Changes
 
 ## Other


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Done by muting the persistent pre run function inherited from main.go. main.go already handles SIGINT and forces an exit of the app killing the graceful shutdown handler routine.

Also adds a graceful shutdown handler for forward postgres, defer doesn't cut it

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM530](https://trello.com/c/L3D9z4tY)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
1. Run `okctl forward postgres` and wait until it prints out "forwarding ...*"
2. Run `kubectl -n <database namespace> get pods` and verify running pod
3. Send a SIGINT signal to the okctl running forward postgres (CTRL+C)
4. Run `kubectl -n <database namespace> get pods` and verify no running pods

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
