### PR TITLE
KM531 🐛 Fix forwarding stdout and stderr

### DIFF
--- a/docs/release_notes/0.0.87.md
+++ b/docs/release_notes/0.0.87.md
@@ -6,6 +6,8 @@
 
 KM530 🐛 Fix graceful shutdown of forward postgres (#887)
 
+KM531 🐛 Fix forwarding stdout and stderr (#888)
+
 ## Changes
 
 ## Other

--- a/pkg/binaries/run/okctlupgrade/okctlupgrade.go
+++ b/pkg/binaries/run/okctlupgrade/okctlupgrade.go
@@ -16,7 +16,7 @@ const (
 // BinaryRunner stores state for running the cli
 type BinaryRunner struct {
 	repoDir              string
-	progress             io.Writer
+	out                  io.Writer
 	logger               *logrus.Logger
 	environmentVariables []string
 	binaryPath           string
@@ -63,7 +63,7 @@ func (r *BinaryRunner) doRun(flags Flags, dryRun bool) ([]byte, error) {
 
 	runner := run.New(nil, r.repoDir, r.binaryPath, r.environmentVariables, r.cmdFn)
 
-	output, err := runner.Run(r.progress, args)
+	output, err := runner.Run(r.out, args)
 	if err != nil {
 		return nil, err
 	}
@@ -72,10 +72,10 @@ func (r *BinaryRunner) doRun(flags Flags, dryRun bool) ([]byte, error) {
 }
 
 // New creates a new okctl upgrade cli wrapper
-func New(repoDir string, progress io.Writer, logger *logrus.Logger, environmentVariables []string, binaryPath string, cmdFn run.CmdFn) *BinaryRunner {
+func New(repoDir string, out io.Writer, logger *logrus.Logger, environmentVariables []string, binaryPath string, cmdFn run.CmdFn) *BinaryRunner {
 	return &BinaryRunner{
 		repoDir:              repoDir,
-		progress:             progress,
+		out:                  out,
 		logger:               logger,
 		environmentVariables: environmentVariables,
 		binaryPath:           binaryPath,

--- a/pkg/upgrade/binary_provider.go
+++ b/pkg/upgrade/binary_provider.go
@@ -13,10 +13,10 @@ import (
 )
 
 type upgradeBinaryProvider struct {
-	repoDir  string
-	progress io.Writer
-	fetcher  fetch.Provider
-	logger   *logrus.Logger
+	repoDir string
+	out     io.Writer
+	fetcher fetch.Provider
+	logger  *logrus.Logger
 
 	binaryRunners        map[string]*okctlupgrade.BinaryRunner
 	environmentVariables map[string]string
@@ -35,7 +35,7 @@ func (p *upgradeBinaryProvider) okctlUpgradeRunner(version string) (*okctlupgrad
 
 		envs := toSlice(p.environmentVariables)
 
-		p.binaryRunners[version] = okctlupgrade.New(p.repoDir, p.progress, p.logger, envs, binaryPath, cmd())
+		p.binaryRunners[version] = okctlupgrade.New(p.repoDir, p.out, p.logger, envs, binaryPath, cmd())
 	}
 
 	return p.binaryRunners[version], nil
@@ -66,13 +66,13 @@ func cmd() run.CmdFn {
 func newUpgradeBinaryProvider(
 	repoDir string,
 	logger *logrus.Logger,
-	progress io.Writer,
+	out io.Writer,
 	fetcher fetch.Provider,
 	binaryEnvironmentVariables map[string]string,
 ) upgradeBinaryProvider {
 	return upgradeBinaryProvider{
 		repoDir:              repoDir,
-		progress:             progress,
+		out:                  out,
 		fetcher:              fetcher,
 		logger:               logger,
 		binaryRunners:        map[string]*okctlupgrade.BinaryRunner{},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When running a cmd, we now set cmd.Stdout and Stderr directly, instead of using a scanner to process the cmd's output.

## Description
<!--- Describe your changes in detail -->

The best explanation I'm able to do while keeping it short:

In the old implementation suffered from race conditions. The code

```golang
_, err = io.Copy(multiWriter, multiReader)
```

always, but by chance, was able to run when the command had been running for a short while. Thus okctl was able to copy seemingly all output from reader to the writer.

For longer running commands, only the start of the buffer was copied.

Also, for some reason, this made the Run command run forever. Probably because the blocking call `scanner.Scan()` never ended somehow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[KM531](https://trello.com/b/rimCUYVC/km)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

From master (i.e. before using code from this PR):

Run `OKCTL_DEBUG=true okctl upgrade` while making sure that the ArgoCD upgrade will run. It produces tons of output (but you won't see it), making `okctl upgrade` eventually hang.

Then apply this PR, and rerun. You will now see the previosly missing enormous amounts of debug output. The upgrade will succeed.

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
