### PR TITLE
🐛 Fix various idempotency issues

### DIFF
--- a/cmd/okctl/delete.go
+++ b/cmd/okctl/delete.go
@@ -60,7 +60,6 @@ func buildDeleteClusterCommand(o *okctl.Okctl) *cobra.Command {
 			hooks.InitializeOkctl(o),
 			hooks.AcquireStateLock(o),
 			hooks.DownloadState(o, true),
-			hooks.VerifyClusterExistsInState(o),
 		),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			var spinnerWriter io.Writer

--- a/docs/release_notes/0.0.87.md
+++ b/docs/release_notes/0.0.87.md
@@ -8,6 +8,8 @@ KM530 🐛 Fix graceful shutdown of forward postgres (#887)
 
 KM531 🐛 Fix forwarding stdout and stderr (#888)
 
+🐛 Fix various idempotency issues regarding delete cluster and Postgres (#893)
+
 ## Changes
 
 ## Other

--- a/pkg/api/core/service_component.go
+++ b/pkg/api/core/service_component.go
@@ -33,7 +33,7 @@ func (c *componentService) DeleteS3Bucket(_ context.Context, opts *api.DeleteS3B
 
 	err = c.provider.DeleteS3Bucket(opts)
 	if err != nil {
-		return errors.E(err, "deleting S3 bucket", errors.Internal)
+		return errors.E(err, "deleting S3 bucket")
 	}
 
 	return nil

--- a/pkg/api/core/service_kube.go
+++ b/pkg/api/core/service_kube.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
-	"github.com/oslokommune/okctl/pkg/kube"
 	"strings"
+
+	"github.com/oslokommune/okctl/pkg/kube"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 

--- a/pkg/api/core/service_kube.go
+++ b/pkg/api/core/service_kube.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"github.com/oslokommune/okctl/pkg/kube"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -72,7 +73,13 @@ func (k *kubeService) DeleteConfigMap(_ context.Context, opts api.DeleteConfigMa
 
 	err = k.run.DeleteConfigMap(opts)
 	if err != nil {
-		return errors.E(err, "removing configmap", errors.Internal)
+		kind := errors.Internal
+
+		if stderrors.Is(err, kube.ErrClusterNotFound) {
+			kind = errors.NotExist
+		}
+
+		return errors.E(err, "removing configmap", kind)
 	}
 
 	return nil
@@ -86,7 +93,13 @@ func (k *kubeService) DeleteExternalSecrets(_ context.Context, opts api.DeleteEx
 
 	err = k.run.DeleteExternalSecrets(opts)
 	if err != nil {
-		return errors.E(err, "removing external secrets", errors.Internal)
+		kind := errors.Internal
+
+		if stderrors.Is(err, kube.ErrClusterNotFound) {
+			kind = errors.NotExist
+		}
+
+		return errors.E(err, "removing external secrets", kind)
 	}
 
 	return nil
@@ -114,7 +127,13 @@ func (k *kubeService) DeleteNamespace(_ context.Context, opts api.DeleteNamespac
 
 	err = k.run.DeleteNamespace(opts)
 	if err != nil {
-		return errors.E(err, "deleting namespace", errors.Internal)
+		kind := errors.Internal
+
+		if stderrors.Is(err, kube.ErrClusterNotFound) {
+			kind = errors.NotExist
+		}
+
+		return errors.E(err, "deleting namespace", kind)
 	}
 
 	return nil

--- a/pkg/api/core/service_objectstorage.go
+++ b/pkg/api/core/service_objectstorage.go
@@ -1,7 +1,10 @@
 package core
 
 import (
+	stderrors "errors"
 	"io"
+
+	"github.com/oslokommune/okctl/pkg/s3api"
 
 	"github.com/mishudark/errors"
 	"github.com/oslokommune/okctl/pkg/api"
@@ -35,7 +38,18 @@ func (o objectStorageService) EmptyBucket(opts api.EmptyBucketOpts) error {
 		return errors.E(err, validatingObjectStorageOptsErrFormat)
 	}
 
-	return o.provider.EmptyBucket(opts)
+	err = o.provider.EmptyBucket(opts)
+	if err != nil {
+		kind := errors.Internal
+
+		if stderrors.Is(err, s3api.ErrBucketDoesNotExist) {
+			kind = errors.NotExist
+		}
+
+		return errors.E(err, "calling provider's empty bucket function", kind)
+	}
+
+	return nil
 }
 
 func (o objectStorageService) PutObject(opts api.PutObjectOpts) error {

--- a/pkg/client/core/service_component.go
+++ b/pkg/client/core/service_component.go
@@ -3,9 +3,12 @@ package core
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
 	"fmt"
 	"regexp"
 	"strconv"
+
+	"github.com/mishudark/errors"
 
 	"github.com/oslokommune/okctl/pkg/smapi"
 
@@ -262,7 +265,7 @@ func (c *componentService) DeletePostgresDatabase(ctx context.Context, opts clie
 		bucketName,
 		postgresRotaterLambdaKey,
 	)
-	if err != nil {
+	if err != nil && !stderrors.Is(err, s3api.ErrBucketDoesNotExist) {
 		return err
 	}
 
@@ -270,7 +273,7 @@ func (c *componentService) DeletePostgresDatabase(ctx context.Context, opts clie
 		ID:        opts.ID,
 		StackName: cfn.NewStackNamer().S3Bucket(opts.ApplicationName, opts.ID.ClusterName),
 	})
-	if err != nil {
+	if err != nil && errors.IsKind(err, errors.NotExist) {
 		return err
 	}
 

--- a/pkg/client/core/service_component.go
+++ b/pkg/client/core/service_component.go
@@ -200,7 +200,7 @@ func (c *componentService) CreatePostgresDatabase(ctx context.Context, opts clie
 	return postgres, nil
 }
 
-// nolint: funlen
+// nolint: funlen,gocyclo
 func (c *componentService) DeletePostgresDatabase(ctx context.Context, opts client.DeletePostgresDatabaseOpts) error {
 	stackName := cfn.NewStackNamer().RDSPostgres(opts.ApplicationName, opts.ID.ClusterName)
 
@@ -214,7 +214,7 @@ func (c *componentService) DeletePostgresDatabase(ctx context.Context, opts clie
 		db.OutgoingSecurityGroupID,
 		opts.VpcID,
 	)
-	if err != nil {
+	if err != nil && !stderrors.Is(err, ec2api.ErrNotFound) {
 		return err
 	}
 

--- a/pkg/client/core/service_manifest_client.go
+++ b/pkg/client/core/service_manifest_client.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/mishudark/errors"
 	"github.com/oslokommune/okctl/pkg/api"
 
 	"github.com/oslokommune/okctl/pkg/client"
@@ -51,7 +52,7 @@ func (s *manifestService) DeleteConfigMap(_ context.Context, opts client.DeleteC
 		Name:      opts.Name,
 		Namespace: opts.Namespace,
 	})
-	if err != nil {
+	if err != nil && !errors.IsKind(err, errors.NotExist) {
 		return err
 	}
 
@@ -68,7 +69,7 @@ func (s *manifestService) DeleteExternalSecret(_ context.Context, opts client.De
 		ID:        opts.ID,
 		Manifests: opts.Secrets,
 	})
-	if err != nil {
+	if err != nil && !errors.IsKind(err, errors.NotExist) {
 		return err
 	}
 
@@ -125,7 +126,7 @@ func (s *manifestService) CreateNamespace(_ context.Context, opts api.CreateName
 
 func (s *manifestService) DeleteNamespace(_ context.Context, opts api.DeleteNamespaceOpts) error {
 	err := s.api.DeleteNamespace(opts)
-	if err != nil {
+	if err != nil && !errors.IsKind(err, errors.NotExist) {
 		return err
 	}
 

--- a/pkg/client/core/service_remotestate_client.go
+++ b/pkg/client/core/service_remotestate_client.go
@@ -123,7 +123,7 @@ func (r *remoteStateService) Purge(clusterID api.ID) error {
 	stateDBBucketName := generateStateDBBucketName(clusterID.ClusterName)
 
 	err := r.objectAPI.EmptyBucket(api.EmptyBucketOpts{BucketName: stateDBBucketName})
-	if err != nil {
+	if err != nil && !errors.IsKind(err, errors.NotExist) {
 		return fmt.Errorf("emptying state bucket: %w", err)
 	}
 

--- a/pkg/controller/cluster/reconciliation/postgres_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/postgres_reconciler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+
 	"github.com/oslokommune/okctl/pkg/controller/common/reconciliation"
 
 	"github.com/oslokommune/okctl/pkg/cfn"
@@ -93,6 +95,10 @@ func (z *postgresReconciler) determineActions(meta reconciliation.Metadata, stat
 	actionMap := make(map[database]reconciliation.Action)
 
 	indicatedDatabases := meta.ClusterDeclaration.Databases.Postgres
+
+	if meta.Purge {
+		indicatedDatabases = []v1alpha1.ClusterDatabasesPostgres{}
+	}
 
 	existingDatabases, err := state.Component.GetPostgresDatabases()
 	if err != nil {

--- a/pkg/ec2api/ec2api.go
+++ b/pkg/ec2api/ec2api.go
@@ -42,7 +42,11 @@ func (a *EC2API) securityGroupForNodeGroup(name, vpcID string) (string, error) {
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("getting security group for node: %w", err)
+		return "", fmt.Errorf("calling EC2 API: %w", err)
+	}
+
+	if len(sgs.SecurityGroups) == 0 {
+		return "", ErrNotFound
 	}
 
 	return *sgs.SecurityGroups[0].GroupId, nil
@@ -75,7 +79,7 @@ func (a *EC2API) permissionsForPodToNodeGroup(podSecurityGroup, vpcID string) []
 func (a *EC2API) AuthorizePodToNodeGroupTraffic(nodegroupName, podSecurityGroup, vpcID string) error {
 	nodegroupSecurityGroup, err := a.securityGroupForNodeGroup(nodegroupName, vpcID)
 	if err != nil {
-		return err
+		return fmt.Errorf("finding security group for node group: %w", err)
 	}
 
 	_, err = a.provider.EC2().AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
@@ -97,7 +101,7 @@ func (a *EC2API) AuthorizePodToNodeGroupTraffic(nodegroupName, podSecurityGroup,
 func (a *EC2API) RevokePodToNodeGroupTraffic(nodegroupName, podSecurityGroup, vpcID string) error {
 	nodegroupSecurityGroup, err := a.securityGroupForNodeGroup(nodegroupName, vpcID)
 	if err != nil {
-		return err
+		return fmt.Errorf("finding security group for node group: %w", err)
 	}
 
 	_, err = a.provider.EC2().RevokeSecurityGroupIngress(&ec2.RevokeSecurityGroupIngressInput{

--- a/pkg/ec2api/ec2api_test.go
+++ b/pkg/ec2api/ec2api_test.go
@@ -38,7 +38,7 @@ func TestEC2APIAuthorizePodToNodeGroupTraffic(t *testing.T) {
 			name: "Fails describing security group",
 			provider: mock.NewCloudProvider().
 				DescribeSecurityGroupsResponse(nil, fmt.Errorf("something bad")),
-			expect:    "getting security group for node: something bad",
+			expect:    "finding security group for node group: calling EC2 API: something bad",
 			expectErr: true,
 		},
 		{
@@ -96,7 +96,7 @@ func TestEC2APIRevokePodToNodeGroupTraffic(t *testing.T) {
 			name: "Fails describing security group",
 			provider: mock.NewCloudProvider().
 				DescribeSecurityGroupsResponse(nil, fmt.Errorf("something bad")),
-			expect:    "getting security group for node: something bad",
+			expect:    "finding security group for node group: calling EC2 API: something bad",
 			expectErr: true,
 		},
 		{

--- a/pkg/ec2api/errors.go
+++ b/pkg/ec2api/errors.go
@@ -1,0 +1,6 @@
+package ec2api
+
+import "errors"
+
+// ErrNotFound indicates something is missing
+var ErrNotFound = errors.New("not found")

--- a/pkg/kube/errors.go
+++ b/pkg/kube/errors.go
@@ -1,0 +1,6 @@
+package kube
+
+import "errors"
+
+// ErrClusterNotFound represents the specified cluster is missing
+var ErrClusterNotFound = errors.New("cluster not found")

--- a/pkg/s3api/errors.go
+++ b/pkg/s3api/errors.go
@@ -1,0 +1,6 @@
+package s3api
+
+import "errors"
+
+// ErrBucketDoesNotExist represents that the specified bucket does not exist
+var ErrBucketDoesNotExist = errors.New("bucket does not exist")

--- a/pkg/s3api/s3api.go
+++ b/pkg/s3api/s3api.go
@@ -98,6 +98,12 @@ func (a *S3API) deleteAllObjects(bucketName string) error {
 			Marker: nextMarker,
 		})
 		if err != nil {
+			var aerr awserr.Error
+
+			if stderrors.As(err, &aerr) && aerr.Code() == s3.ErrCodeNoSuchBucket {
+				return ErrBucketDoesNotExist
+			}
+
 			return err
 		}
 

--- a/pkg/s3api/s3api_test.go
+++ b/pkg/s3api/s3api_test.go
@@ -60,7 +60,7 @@ func TestS3APIDeleteObject(t *testing.T) {
 		{
 			name:      "Should fail",
 			provider:  mock.NewBadCloudProvider(),
-			expect:    "something bad",
+			expect:    "calling delete object API: something bad",
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Nightly failed after adding postgres provisioning to it. Turns out postgres deletion could not handle being
run after a cluster had been deleted. This PR adds necessary tweaks to ensure idempotency when trying
to delete already deleted resources.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Nightly crash](https://github.com/oslokommune/okctl/actions/runs/1754081168)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
Hmm. Argggh. I guess:
1. Remove all reconcilers in `apply_cluster` except the postgres reconciler
2. Provision postgres using `okctl apply cluster`
3. Delete the postgres instance using `okctl delete cluster`

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
