### PR TITLE
KM523 👌 Make ArgoCD handle ArgoCD app manifests

### DIFF
--- a/docs/release_notes/0.0.88.md
+++ b/docs/release_notes/0.0.88.md
@@ -3,9 +3,13 @@
 ## Features
 
 ## Bugfixes
-KM266 - 🐛 Validate `databases.postgres.name` as early as possible to give user feedback about invalid database name (#899)
+
+KM266 - 🐛 Validate `databases.postgres.name` as early as possible to give user feedback about invalid database name (
+#899)
 
 ## Changes
+
+KM523 - 👌 Improve ArgoCD handling by automating ArgoCD application manifest discovery (#897)
 
 ## Other
 

--- a/pkg/client/argocd_client.go
+++ b/pkg/client/argocd_client.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+
 	"github.com/oslokommune/okctl/pkg/api"
 )
 
@@ -24,14 +26,13 @@ type ArgoCD struct {
 // CreateArgoCDOpts contains the required inputs
 // for setting up argo cd
 type CreateArgoCDOpts struct {
-	ID                 api.ID
-	Domain             string
-	FQDN               string
-	HostedZoneID       string
-	GithubOrganisation string
-	UserPoolID         string
-	AuthDomain         string
-	Repository         *GithubRepository
+	ClusterManifest v1alpha1.Cluster
+	Domain          string
+	FQDN            string
+	HostedZoneID    string
+	UserPoolID      string
+	AuthDomain      string
+	Repository      *GithubRepository
 }
 
 // DeleteArgoCDOpts contains the required inputs
@@ -44,6 +45,7 @@ type DeleteArgoCDOpts struct {
 type ArgoCDService interface {
 	CreateArgoCD(ctx context.Context, opts CreateArgoCDOpts) (*ArgoCD, error)
 	DeleteArgoCD(ctx context.Context, opts DeleteArgoCDOpts) error
+	SetupApplicationsSync(ctx context.Context, cluster v1alpha1.Cluster) error
 }
 
 // ArgoCDState implements the state layer

--- a/pkg/client/argocd_client.go
+++ b/pkg/client/argocd_client.go
@@ -43,8 +43,12 @@ type DeleteArgoCDOpts struct {
 
 // ArgoCDService is a business logic implementation
 type ArgoCDService interface {
+	// CreateArgoCD defines functionality for installing ArgoCD into a cluster
 	CreateArgoCD(ctx context.Context, opts CreateArgoCDOpts) (*ArgoCD, error)
+	// DeleteArgoCD defines functionality for uninstalling ArgoCD from a cluster
 	DeleteArgoCD(ctx context.Context, opts DeleteArgoCDOpts) error
+	// SetupApplicationsSync defines functionality for preparing a directory where ArgoCD application manifests will be
+	// automatically synced
 	SetupApplicationsSync(ctx context.Context, cluster v1alpha1.Cluster) error
 }
 

--- a/pkg/client/core/service_application_client.go
+++ b/pkg/client/core/service_application_client.go
@@ -15,8 +15,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-const defaultArgoCDApplicationManifestFilename = "argocd-application.yaml"
-
 type applicationService struct {
 	certificateService    client.CertificateService
 	appManifestService    client.ApplicationManifestService
@@ -101,7 +99,8 @@ func (s *applicationService) CreateArgoCDApplicationManifest(opts client.CreateA
 	absoluteArgoCDApplicationManifestPath := path.Join(s.absoluteRepositoryDir,
 		opts.Cluster.Github.OutputPath,
 		opts.Cluster.Metadata.Name,
-		constant.DefaultApplicationsOutputDir,
+		constant.DefaultArgoCDClusterConfigDir,
+		constant.DefaultArgoCDClusterConfigApplicationsDir,
 		fmt.Sprintf("%s.yaml", opts.Application.Metadata.Name),
 	)
 

--- a/pkg/client/core/service_application_client.go
+++ b/pkg/client/core/service_application_client.go
@@ -98,12 +98,16 @@ func (s *applicationService) CreateArgoCDApplicationManifest(opts client.CreateA
 		opts.Cluster.Metadata.Name,
 	)
 
-	absoluteOverlayDir := path.Join(s.absoluteRepositoryDir, relativeOverlayDir)
-	absoluteArgoCDApplicationManifestPath := path.Join(absoluteOverlayDir, defaultArgoCDApplicationManifestFilename)
+	absoluteArgoCDApplicationManifestPath := path.Join(s.absoluteRepositoryDir,
+		opts.Cluster.Github.OutputPath,
+		opts.Cluster.Metadata.Name,
+		constant.DefaultApplicationsOutputDir,
+		fmt.Sprintf("%s.yaml", opts.Application.Metadata.Name),
+	)
 
-	err := s.fs.MkdirAll(absoluteOverlayDir, 0o700)
+	err := s.fs.MkdirAll(path.Dir(absoluteArgoCDApplicationManifestPath), 0o700)
 	if err != nil {
-		return errors.E(err, "ensuring overlay directory: %w", err)
+		return errors.E(err, "ensuring cluster applications directory: %w", err)
 	}
 
 	manifest, err := scaffold.GenerateArgoCDApplicationManifest(scaffold.GenerateArgoCDApplicationManifestOpts{

--- a/pkg/client/core/service_application_client_test.go
+++ b/pkg/client/core/service_application_client_test.go
@@ -3,6 +3,7 @@ package core_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"path"
 	"path/filepath"
 	"testing"
@@ -124,6 +125,12 @@ func TestNewApplicationService(t *testing.T) {
 	appDir := filepath.Join(absoluteApplicationsDir, application.Metadata.Name)
 	appBaseDir := filepath.Join(appDir, constant.DefaultApplicationBaseDir)
 	appOverlayDir := filepath.Join(appDir, constant.DefaultApplicationOverlayDir, cluster.Metadata.Name)
+	clusterApplicationsDir := filepath.Join(
+		absoluteRepoDir,
+		absoluteOutputDir,
+		cluster.Metadata.Name,
+		constant.DefaultApplicationsOutputDir,
+	)
 
 	g.Assert(t, "kustomization-base.yaml", readFile(t, fs, filepath.Join(appBaseDir, "kustomization.yaml")))
 	g.Assert(t, "namespace.yaml", readFile(t, fs, filepath.Join(appBaseDir, "namespace.yaml")))
@@ -136,7 +143,10 @@ func TestNewApplicationService(t *testing.T) {
 	g.Assert(t, "kustomization-overlay.yaml", readFile(t, fs, filepath.Join(appOverlayDir, "kustomization.yaml")))
 	g.Assert(t, "deployment-patch.yaml", readFile(t, fs, filepath.Join(appOverlayDir, "deployment-patch.json")))
 	g.Assert(t, "ingress-patch.yaml", readFile(t, fs, filepath.Join(appOverlayDir, "ingress-patch.json")))
-	g.Assert(t, "argocd-application.yaml", readFile(t, fs, filepath.Join(appOverlayDir, "argocd-application.yaml")))
+	g.Assert(t, "argocd-application.yaml", readFile(t, fs, filepath.Join(
+		clusterApplicationsDir,
+		fmt.Sprintf("%s.yaml", application.Metadata.Name),
+	)))
 }
 
 // nolint: funlen

--- a/pkg/client/core/service_application_client_test.go
+++ b/pkg/client/core/service_application_client_test.go
@@ -126,10 +126,10 @@ func TestNewApplicationService(t *testing.T) {
 	appBaseDir := filepath.Join(appDir, constant.DefaultApplicationBaseDir)
 	appOverlayDir := filepath.Join(appDir, constant.DefaultApplicationOverlayDir, cluster.Metadata.Name)
 	clusterApplicationsDir := filepath.Join(
-		absoluteRepoDir,
 		absoluteOutputDir,
 		cluster.Metadata.Name,
-		constant.DefaultApplicationsOutputDir,
+		constant.DefaultArgoCDClusterConfigDir,
+		constant.DefaultArgoCDClusterConfigApplicationsDir,
 	)
 
 	g.Assert(t, "kustomization-base.yaml", readFile(t, fs, filepath.Join(appBaseDir, "kustomization.yaml")))

--- a/pkg/client/core/service_argocd_client.go
+++ b/pkg/client/core/service_argocd_client.go
@@ -1,10 +1,21 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"path"
 	"time"
+
+	"github.com/oslokommune/okctl/pkg/binaries"
+	"github.com/oslokommune/okctl/pkg/clients/kubectl/binary"
+	"github.com/oslokommune/okctl/pkg/credentials"
+
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/scaffold"
+	"github.com/spf13/afero"
 
 	"github.com/asdine/storm/v3"
 
@@ -19,12 +30,16 @@ import (
 )
 
 type argoCDService struct {
-	state    client.ArgoCDState
-	identity client.IdentityManagerService
-	cert     client.CertificateService
-	manifest client.ManifestService
-	param    client.ParameterService
-	helm     client.HelmService
+	state               client.ArgoCDState
+	identity            client.IdentityManagerService
+	cert                client.CertificateService
+	manifest            client.ManifestService
+	param               client.ParameterService
+	helm                client.HelmService
+	fs                  *afero.Afero
+	absoluteRepoDir     string
+	binaryProvider      binaries.Provider
+	credentialsProvider credentials.Provider
 }
 
 // nolint: gosec
@@ -116,8 +131,10 @@ func (s *argoCDService) DeleteArgoCD(ctx context.Context, opts client.DeleteArgo
 
 // nolint: funlen
 func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgoCDOpts) (*client.ArgoCD, error) {
+	clusterID := clusterMetaAsID(opts.ClusterManifest.Metadata)
+
 	cert, err := s.cert.CreateCertificate(ctx, client.CreateCertificateOpts{
-		ID:           opts.ID,
+		ID:           clusterID,
 		FQDN:         fmt.Sprintf("argocd.%s", opts.FQDN),
 		Domain:       fmt.Sprintf("argocd.%s", opts.Domain),
 		HostedZoneID: opts.HostedZoneID,
@@ -127,7 +144,7 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	}
 
 	identityClient, err := s.identity.CreateIdentityPoolClient(ctx, client.CreateIdentityPoolClientOpts{
-		ID:          opts.ID,
+		ID:          clusterID,
 		UserPoolID:  opts.UserPoolID,
 		Purpose:     argoPurpose,
 		CallbackURL: fmt.Sprintf("https://%s/api/dex/callback", cert.Domain),
@@ -137,7 +154,7 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	}
 
 	_, err = s.manifest.CreateNamespace(ctx, api.CreateNamespaceOpts{
-		ID:        opts.ID,
+		ID:        clusterID,
 		Namespace: constant.DefaultArgoCDNamespace,
 	})
 	if err != nil {
@@ -145,7 +162,7 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	}
 
 	clientSecret, err := s.param.CreateSecret(ctx, client.CreateSecretOpts{
-		ID:     opts.ID,
+		ID:     clusterID,
 		Name:   argoClientSecretName,
 		Secret: identityClient.ClientSecret,
 	})
@@ -154,7 +171,7 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	}
 
 	secretKey, err := s.param.CreateSecret(ctx, client.CreateSecretOpts{
-		ID:     opts.ID,
+		ID:     clusterID,
 		Name:   argoSecretKeyName,
 		Secret: uuid.New().String(),
 	})
@@ -165,7 +182,7 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	privateKeyDataName := "ssh-private-key"
 
 	priv, err := s.manifest.CreateExternalSecret(ctx, client.CreateExternalSecretOpts{
-		ID:        opts.ID,
+		ID:        clusterID,
 		Name:      argoPrivateKeyName,
 		Namespace: constant.DefaultArgoCDNamespace,
 		Manifest: api.Manifest{
@@ -201,7 +218,7 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	}
 
 	sec, err := s.manifest.CreateExternalSecret(ctx, client.CreateExternalSecretOpts{
-		ID:        opts.ID,
+		ID:        clusterID,
 		Name:      argoSecretName,
 		Namespace: constant.DefaultArgoCDNamespace,
 		Manifest: api.Manifest{
@@ -234,10 +251,10 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	chart := argocd.New(argocd.NewDefaultValues(argocd.ValuesOpts{
 		URL:                  fmt.Sprintf("https://%s", cert.Domain),
 		HostName:             cert.Domain,
-		Region:               opts.ID.Region,
+		Region:               clusterID.Region,
 		CertificateARN:       cert.ARN,
 		ClientID:             identityClient.ClientID,
-		Organisation:         opts.GithubOrganisation,
+		Organisation:         opts.ClusterManifest.Github.Organisation,
 		AuthDomain:           opts.AuthDomain,
 		UserPoolID:           opts.UserPoolID,
 		RepoURL:              opts.Repository.GitURL,
@@ -252,7 +269,7 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	}
 
 	a, err := s.helm.CreateHelmRelease(ctx, client.CreateHelmReleaseOpts{
-		ID:             opts.ID,
+		ID:             clusterID,
 		RepositoryName: chart.RepositoryName,
 		RepositoryURL:  chart.RepositoryURL,
 		ReleaseName:    chart.ReleaseName,
@@ -266,7 +283,7 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	}
 
 	argo := &client.ArgoCD{
-		ID:             opts.ID,
+		ID:             clusterID,
 		ArgoDomain:     cert.Domain,
 		ArgoURL:        fmt.Sprintf("https://%s", cert.Domain),
 		AuthDomain:     opts.AuthDomain,
@@ -283,6 +300,11 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 		},
 	}
 
+	err = s.SetupApplicationsSync(ctx, opts.ClusterManifest)
+	if err != nil {
+		return nil, fmt.Errorf("setting up application sync: %w", err)
+	}
+
 	err = s.state.SaveArgoCD(argo)
 	if err != nil {
 		return nil, fmt.Errorf("storing state: %w", err)
@@ -291,21 +313,72 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 	return argo, nil
 }
 
+// SetupApplicationsSync applies an ArgoCD Application manifest which ensures syncing of an application folder
+func (s *argoCDService) SetupApplicationsSync(_ context.Context, cluster v1alpha1.Cluster) error {
+	relativeArgoCDManifestPath := path.Join(
+		cluster.Github.OutputPath,
+		cluster.Metadata.Name,
+		constant.DefaultApplicationsOutputDir,
+		defaultArgoCDApplicationManifestFilename,
+	)
+
+	absoluteArgoCDManifestPath := path.Join(s.absoluteRepoDir, relativeArgoCDManifestPath)
+
+	manifest, err := scaffold.GenerateArgoCDApplicationManifest(scaffold.GenerateArgoCDApplicationManifestOpts{
+		Name:          "cluster-applications",
+		Namespace:     argocd.Namespace,
+		IACRepoURL:    cluster.Github.URL(),
+		SourceSyncDir: path.Dir(relativeArgoCDManifestPath),
+	})
+	if err != nil {
+		return fmt.Errorf("generating ArgoCD application manifest: %w", err)
+	}
+
+	buf := bytes.Buffer{}
+
+	reader := io.TeeReader(manifest, &buf)
+
+	err = s.fs.WriteReader(absoluteArgoCDManifestPath, reader)
+	if err != nil {
+		return fmt.Errorf("writing manifest: %w", err)
+	}
+
+	kubectlClient := binary.New(s.fs, s.binaryProvider, s.credentialsProvider, cluster)
+
+	err = kubectlClient.Apply(&buf)
+	if err != nil {
+		return fmt.Errorf("applying ArgoCD application manifest: %w", err)
+	}
+
+	return nil
+}
+
+// NewArgoCDServiceOpts defines required data for an ArgoCD service
+type NewArgoCDServiceOpts struct {
+	Fs                  *afero.Afero
+	BinaryProvider      binaries.Provider
+	CredentialsProvider credentials.Provider
+	AbsoluteRepoDir     string
+	Identity            client.IdentityManagerService
+	Cert                client.CertificateService
+	Manifest            client.ManifestService
+	Param               client.ParameterService
+	Helm                client.HelmService
+	State               client.ArgoCDState
+}
+
 // NewArgoCDService returns an initialised service
-func NewArgoCDService(
-	identity client.IdentityManagerService,
-	cert client.CertificateService,
-	manifest client.ManifestService,
-	param client.ParameterService,
-	helm client.HelmService,
-	state client.ArgoCDState,
-) client.ArgoCDService {
+func NewArgoCDService(opts NewArgoCDServiceOpts) client.ArgoCDService {
 	return &argoCDService{
-		state:    state,
-		identity: identity,
-		cert:     cert,
-		manifest: manifest,
-		param:    param,
-		helm:     helm,
+		fs:                  opts.Fs,
+		absoluteRepoDir:     opts.AbsoluteRepoDir,
+		binaryProvider:      opts.BinaryProvider,
+		credentialsProvider: opts.CredentialsProvider,
+		state:               opts.State,
+		identity:            opts.Identity,
+		cert:                opts.Cert,
+		manifest:            opts.Manifest,
+		param:               opts.Param,
+		helm:                opts.Helm,
 	}
 }

--- a/pkg/client/core/service_argocd_client.go
+++ b/pkg/client/core/service_argocd_client.go
@@ -316,20 +316,27 @@ func (s *argoCDService) CreateArgoCD(ctx context.Context, opts client.CreateArgo
 
 // SetupApplicationsSync applies an ArgoCD Application manifest which ensures syncing of an application folder
 func (s *argoCDService) SetupApplicationsSync(_ context.Context, cluster v1alpha1.Cluster) error {
-	relativeArgoCDManifestPath := path.Join(
+	relativeArgoCDConfigDir := path.Join(
 		cluster.Github.OutputPath,
 		cluster.Metadata.Name,
 		constant.DefaultArgoCDClusterConfigDir,
-		fmt.Sprintf("%s.yaml", defaultArgoCDApplicationManifestName),
 	)
 
-	absoluteArgoCDManifestPath := path.Join(s.absoluteRepoDir, relativeArgoCDManifestPath)
+	relativeArgoCDApplicationsSyncDir := path.Join(
+		relativeArgoCDConfigDir,
+		constant.DefaultArgoCDClusterConfigApplicationsDir,
+	)
+
+	absoluteArgoCDManifestPath := path.Join(s.absoluteRepoDir,
+		relativeArgoCDConfigDir,
+		fmt.Sprintf("%s.yaml", defaultArgoCDApplicationManifestName),
+	)
 
 	originalManifest, err := scaffold.GenerateArgoCDApplicationManifest(scaffold.GenerateArgoCDApplicationManifestOpts{
 		Name:          defaultArgoCDApplicationManifestName,
 		Namespace:     argocd.Namespace,
 		IACRepoURL:    cluster.Github.URL(),
-		SourceSyncDir: path.Dir(relativeArgoCDManifestPath),
+		SourceSyncDir: relativeArgoCDApplicationsSyncDir,
 		Prune:         true,
 	})
 	if err != nil {

--- a/pkg/client/core/service_argocd_client.go
+++ b/pkg/client/core/service_argocd_client.go
@@ -330,6 +330,7 @@ func (s *argoCDService) SetupApplicationsSync(_ context.Context, cluster v1alpha
 		Namespace:     argocd.Namespace,
 		IACRepoURL:    cluster.Github.URL(),
 		SourceSyncDir: path.Dir(relativeArgoCDManifestPath),
+		Prune:         true,
 	})
 	if err != nil {
 		return fmt.Errorf("generating ArgoCD application manifest: %w", err)

--- a/pkg/clients/kubectl/binary/api.go
+++ b/pkg/clients/kubectl/binary/api.go
@@ -1,0 +1,42 @@
+package binary
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/binaries"
+	"github.com/oslokommune/okctl/pkg/credentials"
+
+	"github.com/oslokommune/okctl/pkg/clients/kubectl"
+	"github.com/spf13/afero"
+)
+
+// Apply runs kubectl apply on a manifest
+func (c client) Apply(manifest io.Reader) error {
+	targetPath, teardowner, err := c.cacheReaderOnFs(manifest)
+	if err != nil {
+		return fmt.Errorf("caching manifest on file system: %w", err)
+	}
+
+	defer func() {
+		_ = teardowner()
+	}()
+
+	err = c.applyFile(targetPath)
+	if err != nil {
+		return fmt.Errorf("applying manifest: %w", err)
+	}
+
+	return nil
+}
+
+// New returns an initialized kubectl binary client
+func New(fs *afero.Afero, binaryProvider binaries.Provider, credentialsProvider credentials.Provider, cluster v1alpha1.Cluster) kubectl.Client {
+	return &client{
+		fs:                  fs,
+		binaryProvider:      binaryProvider,
+		credentialsProvider: credentialsProvider,
+		cluster:             cluster,
+	}
+}

--- a/pkg/clients/kubectl/binary/apply_helpers.go
+++ b/pkg/clients/kubectl/binary/apply_helpers.go
@@ -1,0 +1,45 @@
+package binary
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/oslokommune/okctl/pkg/binaries/run/kubectl"
+
+	"github.com/oslokommune/okctl/pkg/logging"
+)
+
+func (c client) applyFile(manifestPath string) error {
+	log := logging.GetLogger("kubectl/binary", "applyFile")
+
+	k, err := c.binaryProvider.Kubectl(kubectl.Version)
+	if err != nil {
+		return fmt.Errorf("acquiring kubectl binary path: %w", err)
+	}
+
+	args := []string{
+		"apply", "-f", manifestPath,
+	}
+
+	cmd := exec.Command(k.BinaryPath, args...) //nolint:gosec
+
+	multiwriter := bytes.Buffer{}
+
+	cmd.Stdout = &multiwriter
+	cmd.Stderr = &multiwriter
+
+	cmd.Env, err = c.generateEnv()
+	if err != nil {
+		return fmt.Errorf("generating environment: %w", err)
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		log.Error(multiwriter.String())
+
+		return fmt.Errorf("running command: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/clients/kubectl/binary/doc.go
+++ b/pkg/clients/kubectl/binary/doc.go
@@ -1,0 +1,2 @@
+// Package binary exposes kubectl commands through a binary provider
+package binary

--- a/pkg/clients/kubectl/binary/helpers.go
+++ b/pkg/clients/kubectl/binary/helpers.go
@@ -49,6 +49,7 @@ func (c *client) cacheReaderOnFs(r io.Reader) (string, teardownFn, error) {
 	return targetPath, teardowner, nil
 }
 
+// generateEnv knows how to produce an array of environment variables required to run kubectl commands
 func (c client) generateEnv() ([]string, error) {
 	awsEnvCredentials, err := c.credentialsProvider.Aws().AsEnv()
 	if err != nil {
@@ -80,6 +81,8 @@ func (c client) generateEnv() ([]string, error) {
 	return env, nil
 }
 
+// generatePath knows how to produce the value of a PATH environment variable containing all necessary binaries to run
+// kubectl commands
 func (c client) generatePath() ([]string, error) {
 	k, err := c.binaryProvider.Kubectl(kubectl.Version)
 	if err != nil {

--- a/pkg/clients/kubectl/binary/helpers.go
+++ b/pkg/clients/kubectl/binary/helpers.go
@@ -1,0 +1,98 @@
+package binary
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/oslokommune/okctl/pkg/binaries/run/awsiamauthenticator"
+	"github.com/oslokommune/okctl/pkg/binaries/run/kubectl"
+	"github.com/oslokommune/okctl/pkg/config/constant"
+
+	"github.com/google/uuid"
+)
+
+// envAsArray converts a map to a string array of KEY=VALUE pairs
+func envAsArray(m map[string]string) []string {
+	result := make([]string, len(m))
+	index := 0
+
+	for key, value := range m {
+		result[index] = fmt.Sprintf("%s=%s", key, value)
+
+		index++
+	}
+
+	return result
+}
+
+// cacheReaderOnFs writes f to a temporary file, then returns the path and a clean up function
+func (c *client) cacheReaderOnFs(r io.Reader) (string, teardownFn, error) {
+	dir, err := c.fs.TempDir("", "okctl")
+	if err != nil {
+		return "", nil, fmt.Errorf("opening temporary file: %w", err)
+	}
+
+	targetPath := path.Join(dir, uuid.New().String())
+
+	err = c.fs.WriteReader(targetPath, r)
+	if err != nil {
+		return "", nil, fmt.Errorf("writing file: %w", err)
+	}
+
+	teardowner := func() error {
+		return c.fs.RemoveAll(dir)
+	}
+
+	return targetPath, teardowner, nil
+}
+
+func (c client) generateEnv() ([]string, error) {
+	awsEnvCredentials, err := c.credentialsProvider.Aws().AsEnv()
+	if err != nil {
+		return []string{}, fmt.Errorf("acquiring AWS credentials: %w", err)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return []string{}, fmt.Errorf("acquiring user home directory: %w", err)
+	}
+
+	generatedPaths, err := c.generatePath()
+	if err != nil {
+		return []string{}, fmt.Errorf("generating PATH: %w", err)
+	}
+
+	env := envAsArray(map[string]string{
+		"KUBECONFIG": path.Join(homeDir,
+			constant.DefaultDir,
+			constant.DefaultCredentialsDirName,
+			c.cluster.Metadata.Name,
+			constant.DefaultClusterKubeConfig,
+		),
+		"PATH": strings.Join(generatedPaths, ":"),
+	})
+
+	env = append(env, awsEnvCredentials...)
+
+	return env, nil
+}
+
+func (c client) generatePath() ([]string, error) {
+	k, err := c.binaryProvider.Kubectl(kubectl.Version)
+	if err != nil {
+		return []string{}, fmt.Errorf("acquiring kubectl binary path: %w", err)
+	}
+
+	a, err := c.binaryProvider.AwsIamAuthenticator(awsiamauthenticator.Version)
+	if err != nil {
+		return []string{}, fmt.Errorf("acquiring AWS IAM authenticator binary path: %w", err)
+	}
+
+	return []string{
+		path.Dir(k.BinaryPath),
+		path.Dir(a.BinaryPath),
+	}, nil
+}

--- a/pkg/clients/kubectl/binary/types.go
+++ b/pkg/clients/kubectl/binary/types.go
@@ -1,0 +1,17 @@
+package binary
+
+import (
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/binaries"
+	"github.com/oslokommune/okctl/pkg/credentials"
+	"github.com/spf13/afero"
+)
+
+type teardownFn func() error
+
+type client struct {
+	fs                  *afero.Afero
+	binaryProvider      binaries.Provider
+	credentialsProvider credentials.Provider
+	cluster             v1alpha1.Cluster
+}

--- a/pkg/clients/kubectl/doc.go
+++ b/pkg/clients/kubectl/doc.go
@@ -1,0 +1,2 @@
+// Package kubectl defines different ways of communicating with a cluster
+package kubectl

--- a/pkg/clients/kubectl/types.go
+++ b/pkg/clients/kubectl/types.go
@@ -4,5 +4,6 @@ import "io"
 
 // Client defines functionality expected of a kubectl client
 type Client interface {
+	// Apply knows how to apply manifests to a cluster
 	Apply(manifest io.Reader) error
 }

--- a/pkg/clients/kubectl/types.go
+++ b/pkg/clients/kubectl/types.go
@@ -1,0 +1,8 @@
+package kubectl
+
+import "io"
+
+// Client defines functionality expected of a kubectl client
+type Client interface {
+	Apply(manifest io.Reader) error
+}

--- a/pkg/commands/testdata/TestApplyApplicationSuccessMessage/Should_get_expected_success_message_when_using_image_URI.golden
+++ b/pkg/commands/testdata/TestApplyApplicationSuccessMessage/Should_get_expected_success_message_when_using_image_URI.golden
@@ -1,7 +1,6 @@
 
-	Successfully scaffolded my-app
-	To deploy your application:
-		- Commit and push the changes done by okctl
-		- Run [32mkubectl apply -f infrastructure/applications/my-app/overlays/test-cluster/argocd-application.yaml[0m
+Successfully applied my-app
 
-    If using an ingress, it can take up to five minutes for the routing to configure
+To finalize the changes:
+- Commit and push the changes done by okctl
+

--- a/pkg/commands/testdata/TestApplyApplicationSuccessMessage/Should_get_expected_success_message_when_using_image_name.golden
+++ b/pkg/commands/testdata/TestApplyApplicationSuccessMessage/Should_get_expected_success_message_when_using_image_name.golden
@@ -1,9 +1,8 @@
 
-	Successfully scaffolded my-app
-	To deploy your application:
-		- Commit and push the changes done by okctl
-        - Tag and push a docker image to your container repository. See instructions on
-          https://okctl.io/help/docker-registry/#push-a-docker-image-to-the-amazon-elastic-container-registry-ecr
-		- Run [32mkubectl apply -f infrastructure/applications/my-app/overlays/test-cluster/argocd-application.yaml[0m
+Successfully applied my-app
 
-    If using an ingress, it can take up to five minutes for the routing to configure
+To finalize the changes:
+- Commit and push the changes done by okctl
+- Tag and push a docker image to your container repository. See instructions on
+  https://www.okctl.io/running-a-docker-image-in-your-cluster/#push-a-docker-image-to-the-amazon-elastic-container-registry-ecr
+

--- a/pkg/config/constant/api.go
+++ b/pkg/config/constant/api.go
@@ -94,6 +94,10 @@ const (
 	// EnvGithubCredentialsType enables setting the --github-credentials-type flag through environment vars
 	EnvGithubCredentialsType = EnvPrefix + "_" + "GITHUB_CREDENTIALS_TYPE"
 
+	// DefaultArgoCDClusterConfigDir is where we do cluster specific ArgoCD configuration
+	DefaultArgoCDClusterConfigDir = "argocd"
+	// DefaultArgoCDClusterConfigApplicationsDir is where we put ArgoCD application manifests for applications
+	DefaultArgoCDClusterConfigApplicationsDir = "applications"
 	// DefaultApplicationsOutputDir is where the application declarations reside
 	DefaultApplicationsOutputDir = "applications"
 	// DefaultApplicationBaseDir is where the directory where application base files reside

--- a/pkg/controller/cluster/reconciliation/argocd_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/argocd_reconciler.go
@@ -86,16 +86,14 @@ func (z *argocdReconciler) createArgoCD(ctx context.Context, meta reconciliation
 	}
 
 	_, err = z.argocdClient.CreateArgoCD(ctx, client.CreateArgoCDOpts{
-		ID:                 reconciliation.ClusterMetaAsID(meta.ClusterDeclaration.Metadata),
-		Domain:             meta.ClusterDeclaration.ClusterRootDomain,
-		FQDN:               dns.Fqdn(meta.ClusterDeclaration.ClusterRootDomain),
-		HostedZoneID:       hz.HostedZoneID,
-		GithubOrganisation: meta.ClusterDeclaration.Github.Organisation,
-		UserPoolID:         im.UserPoolID,
-		AuthDomain:         im.AuthDomain,
-		Repository:         repo,
+		ClusterManifest: *meta.ClusterDeclaration,
+		Domain:          meta.ClusterDeclaration.ClusterRootDomain,
+		FQDN:            dns.Fqdn(meta.ClusterDeclaration.ClusterRootDomain),
+		HostedZoneID:    hz.HostedZoneID,
+		UserPoolID:      im.UserPoolID,
+		AuthDomain:      im.AuthDomain,
+		Repository:      repo,
 	})
-
 	if err != nil {
 		// nolint: godox
 		// TODO: Need to identify the correct error

--- a/pkg/controller/cluster/reconciliation/argocd_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/argocd_reconciler_test.go
@@ -139,6 +139,10 @@ type mockArgocdService struct {
 	deletionBump func()
 }
 
+func (m mockArgocdService) SetupApplicationsSync(_ context.Context, _ v1alpha1.Cluster) error {
+	return nil
+}
+
 func (m mockArgocdService) CreateArgoCD(_ context.Context, _ client.CreateArgoCDOpts) (*client.ArgoCD, error) {
 	m.creationBump()
 

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -332,14 +332,18 @@ func (o *Okctl) ClientServices(handlers *clientCore.StateHandlers) (*clientCore.
 		o.CloudProvider,
 	)
 
-	argocdService := clientCore.NewArgoCDService(
-		identityManagerService,
-		certificateService,
-		manifestService,
-		paramService,
-		helmService,
-		handlers.ArgoCD,
-	)
+	argocdService := clientCore.NewArgoCDService(clientCore.NewArgoCDServiceOpts{
+		Fs:                  o.FileSystem,
+		BinaryProvider:      o.BinariesProvider,
+		CredentialsProvider: o.CredentialsProvider,
+		AbsoluteRepoDir:     absoluteRepositoryPath,
+		Identity:            identityManagerService,
+		Cert:                certificateService,
+		Manifest:            manifestService,
+		Param:               paramService,
+		Helm:                helmService,
+		State:               handlers.ArgoCD,
+	})
 
 	applicationService := clientCore.NewApplicationService(
 		o.FileSystem,

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -141,6 +141,7 @@ func GenerateApplicationOverlay(opts GenerateApplicationOverlayOpts) error {
 // GenerateArgoCDApplicationManifest generates an ArgoCD Application manifest
 func GenerateArgoCDApplicationManifest(opts GenerateArgoCDApplicationManifestOpts) (io.Reader, error) {
 	argoApp := resources.CreateArgoApp(opts.Name, opts.Namespace, opts.IACRepoURL, opts.SourceSyncDir)
+	argoApp.Spec.SyncPolicy.Automated.Prune = opts.Prune
 
 	raw, err := ResourceAsBytes(argoApp)
 	if err != nil {

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -2,7 +2,9 @@
 package scaffold
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 
 	"github.com/oslokommune/okctl/pkg/jsonpatch"
 
@@ -137,15 +139,15 @@ func GenerateApplicationOverlay(opts GenerateApplicationOverlayOpts) error {
 }
 
 // GenerateArgoCDApplicationManifest generates an ArgoCD Application manifest
-func GenerateArgoCDApplicationManifest(opts GenerateArgoCDApplicationManifestOpts) error {
-	argoApp := resources.CreateArgoApp(opts.Application, opts.IACRepoURL, opts.RelativeApplicationOverlayDir)
+func GenerateArgoCDApplicationManifest(opts GenerateArgoCDApplicationManifestOpts) (io.Reader, error) {
+	argoApp := resources.CreateArgoApp(opts.Name, opts.Namespace, opts.IACRepoURL, opts.SourceSyncDir)
 
 	raw, err := ResourceAsBytes(argoApp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return opts.Saver(raw)
+	return bytes.NewReader(raw), nil
 }
 
 func createIngressPatch(subDomain, domain, certArn string) jsonpatch.Patch {

--- a/pkg/scaffold/resources/argo.go
+++ b/pkg/scaffold/resources/argo.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	argo "github.com/oslokommune/okctl/internal/third_party/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -37,13 +36,13 @@ func generateDefaultArgoApp() argo.Application {
 }
 
 // CreateArgoApp creates an ArgoCD definition customized for okctl
-func CreateArgoApp(app v1alpha1.Application, sourceRepositoryURL string, sourceRepositoryPath string) argo.Application {
+func CreateArgoApp(name string, namespace string, sourceRepositoryURL string, sourceRepositoryPath string) argo.Application {
 	argoApp := generateDefaultArgoApp()
 
-	argoApp.ObjectMeta.Name = app.Metadata.Name
+	argoApp.ObjectMeta.Name = name
 
-	if app.Metadata.Namespace != "" {
-		argoApp.Spec.Destination.Namespace = app.Metadata.Namespace
+	if namespace != "" {
+		argoApp.Spec.Destination.Namespace = namespace
 	}
 
 	argoApp.Spec.Source.Path = sourceRepositoryPath

--- a/pkg/scaffold/types.go
+++ b/pkg/scaffold/types.go
@@ -32,4 +32,5 @@ type GenerateArgoCDApplicationManifestOpts struct {
 	Namespace     string
 	IACRepoURL    string
 	SourceSyncDir string
+	Prune         bool
 }

--- a/pkg/scaffold/types.go
+++ b/pkg/scaffold/types.go
@@ -11,9 +11,6 @@ type ManifestSaver func(filename string, content []byte) error
 // PatchSaver defines a function which store patches
 type PatchSaver func(kind string, patch jsonpatch.Patch) error
 
-// argoApplicationManifestSaver defines a function which stores an ArgoCD Application manifest
-type argoApplicationManifestSaver func(content []byte) error
-
 // GenerateApplicationBaseOpts contains required data to generate application base manifests
 type GenerateApplicationBaseOpts struct {
 	SaveManifest ManifestSaver
@@ -31,8 +28,8 @@ type GenerateApplicationOverlayOpts struct {
 
 // GenerateArgoCDApplicationManifestOpts contains required information to generate an ArgoCD Application Manifest
 type GenerateArgoCDApplicationManifestOpts struct {
-	Saver                         argoApplicationManifestSaver
-	Application                   v1alpha1.Application
-	IACRepoURL                    string
-	RelativeApplicationOverlayDir string
+	Name          string
+	Namespace     string
+	IACRepoURL    string
+	SourceSyncDir string
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Moves ArgoCD application manifests from `infrastructure/applications/<app>/overlays/<cluster` to `infrastructure/<cluster>/applications`
- Sets ArgoCD up to sync ArgoCD application manifests automatically from the `infrastructure/<cluster>/applications` directory
- Fixes link in `apply application` success message
- Polishes some indentation and wording in the `apply application` success message

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM523](https://trello.com/c/2fbXVXPP)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
1. Reinstall ArgoCD by running toggling `integrations.argoCD` to false, then apply cluster, then toggle true, then apply cluster
2. Apply a new application and push the changes done by okctl (DO NOT RUN kubectl apply argo app)
3. Sit back and watch argocd pick up the new app and deploy it

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
