### PR TITLE
KM532 🐛 Fix setting zsh/bash shell environment variables

### DIFF
--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -182,7 +182,6 @@ func createVenvOpts(host state.Host, okctlEnvironment commands.OkctlEnvironment)
 		OsEnvVars:            envVars,
 		EtcStorage:           storage.NewFileSystemStorage("/etc"),
 		UserDirStorage:       storage.NewFileSystemStorage(okctlEnvironment.UserDataDir),
-		UserHomeDirStorage:   storage.NewFileSystemStorage(homeDir),
 		TmpStorage:           nil,
 		ClusterName:          okctlEnvironment.ClusterName,
 		CurrentUsername:      currentUser.Username,

--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -182,7 +182,6 @@ func createVenvOpts(host state.Host, okctlEnvironment commands.OkctlEnvironment)
 		OsEnvVars:            envVars,
 		EtcStorage:           storage.NewFileSystemStorage("/etc"),
 		UserDirStorage:       storage.NewFileSystemStorage(okctlEnvironment.UserDataDir),
-		TmpStorage:           nil,
 		ClusterName:          okctlEnvironment.ClusterName,
 		CurrentUsername:      currentUser.Username,
 	}
@@ -191,8 +190,6 @@ func createVenvOpts(host state.Host, okctlEnvironment commands.OkctlEnvironment)
 	if err != nil {
 		return commandlineprompter.CommandLinePromptOpts{}, nil, err
 	}
-
-	venvOpts.TmpStorage = tmpStorage
 
 	return venvOpts, tmpStorage, nil
 }

--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -141,7 +141,7 @@ func venvRunE(o *okctl.Okctl, okctlEnvironment commands.OkctlEnvironment) error 
 		return fmt.Errorf("could not print welcome message: %w", err)
 	}
 
-	shell := exec.Command(venv.ShellCommand) //nolint:gosec
+	shell := exec.Command(venv.ShellCommand, venv.ShellArgs...) //nolint:gosec
 	shell.Env = venv.Environ()
 	shell.Stdout = o.Out
 	shell.Stdin = o.In

--- a/docs/release_notes/0.0.88.md
+++ b/docs/release_notes/0.0.88.md
@@ -4,6 +4,8 @@
 
 ## Bugfixes
 
+KM532 🐛 Fix setting zsh shell environment variables (#898)
+
 ## Changes
 
 ## Other

--- a/docs/release_notes/0.0.88.md
+++ b/docs/release_notes/0.0.88.md
@@ -4,7 +4,7 @@
 
 ## Bugfixes
 
-KM532 🐛 Fix setting zsh shell environment variables (#898)
+KM532 🐛 Fix setting zsh/bash shell environment variables (#898)
 
 ## Changes
 

--- a/pkg/virtualenv/commandlineprompter/command_line_prompts_opts.go
+++ b/pkg/virtualenv/commandlineprompter/command_line_prompts_opts.go
@@ -12,7 +12,6 @@ type CommandLinePromptOpts struct {
 	OsEnvVars            map[string]string
 	EtcStorage           storage.Storer
 	UserDirStorage       storage.Storer
-	TmpStorage           storage.Storer
 	ClusterName          string
 	CurrentUsername      string
 }

--- a/pkg/virtualenv/commandlineprompter/command_line_prompts_opts.go
+++ b/pkg/virtualenv/commandlineprompter/command_line_prompts_opts.go
@@ -12,7 +12,6 @@ type CommandLinePromptOpts struct {
 	OsEnvVars            map[string]string
 	EtcStorage           storage.Storer
 	UserDirStorage       storage.Storer
-	UserHomeDirStorage   storage.Storer
 	TmpStorage           storage.Storer
 	ClusterName          string
 	CurrentUsername      string
@@ -23,7 +22,6 @@ func NewShellGetter(opts CommandLinePromptOpts) *shellgetter.ShellGetter {
 	return shellgetter.NewShellGetter(
 		opts.Os,
 		opts.MacOsUserShellGetter,
-		opts.UserHomeDirStorage.Path(),
 		opts.OsEnvVars,
 		opts.EtcStorage,
 		opts.CurrentUsername)

--- a/pkg/virtualenv/commandlineprompter/commandlineprompter.go
+++ b/pkg/virtualenv/commandlineprompter/commandlineprompter.go
@@ -47,10 +47,8 @@ func New(opts CommandLinePromptOpts, shellType shelltype.ShellType) (CommandLine
 		}, nil
 	case shelltype.Zsh:
 		return &zshPrompter{
-			userHomeDirStorage: opts.UserHomeDirStorage,
-			tmpStorer:          opts.TmpStorage,
-			osEnvVars:          osEnvVars,
-			clusterName:        opts.ClusterName,
+			clusterName: opts.ClusterName,
+			osEnvVars:   osEnvVars,
 		}, nil
 	default:
 		return &noopPrompter{

--- a/pkg/virtualenv/commandlineprompter/prompter_zsh.go
+++ b/pkg/virtualenv/commandlineprompter/prompter_zsh.go
@@ -1,7 +1,6 @@
 package commandlineprompter
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -14,12 +13,11 @@ type zshPrompter struct {
 // The warning is set in case something prevented the prompt to be set the expected way.
 func (p *zshPrompter) CreatePrompt() (CommandLinePrompt, error) {
 	ps1, overridePs1 := p.osEnvVars["OKCTL_PS1"]
-	if overridePs1 {
-		withEnv := strings.ReplaceAll(ps1, "%env", p.clusterName)
-		p.osEnvVars["PS1"] = fmt.Sprintf(`%s`, withEnv)
-	} else {
-		p.osEnvVars["PS1"] = fmt.Sprint(`%F{red}%~ %f%F{blue}($(venv_ps1 ` + p.clusterName + `)%f) $ `)
+	if !overridePs1 {
+		ps1 = `%F{red}%~ %f%F{blue}($(venv_ps1 %env)%f) $ `
 	}
+
+	p.osEnvVars["PS1"] = strings.ReplaceAll(ps1, "%env", p.clusterName)
 
 	return CommandLinePrompt{
 		Env: p.osEnvVars,

--- a/pkg/virtualenv/commandlineprompter/prompter_zsh.go
+++ b/pkg/virtualenv/commandlineprompter/prompter_zsh.go
@@ -1,109 +1,16 @@
 package commandlineprompter
 
-import (
-	"fmt"
-	"regexp"
-	"strings"
-
-	"github.com/oslokommune/okctl/pkg/storage"
-)
-
-const zshrcFilename = ".zshrc"
-
-var reClusterDeclarationExport = regexp.MustCompile("export OKCTL_CLUSTER_DECLARATION.*")
-
 type zshPrompter struct {
-	userHomeDirStorage storage.Storer
-	tmpStorer          storage.Storer
-	osEnvVars          map[string]string
-	clusterName        string
+	clusterName string
+	osEnvVars   map[string]string
 }
 
 // CreatePrompt returns environment variables that when set in zsh will show a command prompt.
 // The warning is set in case something prevented the prompt to be set the expected way.
 func (p *zshPrompter) CreatePrompt() (CommandLinePrompt, error) {
-	if _, ok := p.osEnvVars["ZDOTDIR"]; ok {
-		// We're dependent on being able to set ZDOTDIR ourself to launch zsh to a temporary path with a custom .zshrc
-		// file. If the user has already set ZDOTDIR, we cannot do this. However, instead of returning an error, show
-		// this warning to the user.
-		msg := "WARNING: Could not set command prompt (PS1) because ZDOTDIR is already set. "
-		msg += "Either start okctl venv with no ZDOTDIR set, or set environment variable OKCTL_NO_PS1=true to get "
-		msg += "rid of this message."
-
-		return CommandLinePrompt{
-			Warning: msg,
-			Env:     p.osEnvVars,
-		}, nil
-	}
-
-	zshrcDir, err := p.writeZshrcFile()
-	if err != nil {
-		return CommandLinePrompt{}, fmt.Errorf("could not write .zshrc file: %w", err)
-	}
-
-	// Make zsh use the new .zshrc file
-	p.osEnvVars["ZDOTDIR"] = zshrcDir
+	p.osEnvVars["PS1"] = "%F{red}%~ %f%F{blue}($(venv_ps1 " + p.clusterName + ")%f) $ "
 
 	return CommandLinePrompt{
 		Env: p.osEnvVars,
 	}, nil
-}
-
-func (p *zshPrompter) writeZshrcFile() (string, error) {
-	zshrcTmpFile, err := p.tmpStorer.Create(".", zshrcFilename, 0o644)
-	if err != nil {
-		return "", fmt.Errorf("could not create temporary .zshrc file: %w", err)
-	}
-
-	zshrcContents, err := p.createZshrcContents()
-	if err != nil {
-		return "", fmt.Errorf("could not create temporary .zshrc contents: %w", err)
-	}
-
-	_, err = zshrcTmpFile.WriteString(zshrcContents)
-	if err != nil {
-		return "", fmt.Errorf("could not write contents to temporary .zshrc file: %w", err)
-	}
-
-	return p.tmpStorer.Path(), nil
-}
-
-func (p *zshPrompter) createZshrcContents() (string, error) {
-	zshrcBuilder := strings.Builder{}
-
-	zshrcExists, err := p.userHomeDirStorage.Exists(zshrcFilename)
-	if err != nil {
-		return "", fmt.Errorf("could not check if temporary .zshrc file exists: %w", err)
-	}
-
-	if zshrcExists {
-		zshrcFileContents, err := p.userHomeDirStorage.ReadAll(zshrcFilename)
-		if err != nil {
-			return "", fmt.Errorf("reading existing .zshrc content: %w", err)
-		}
-
-		cleanedContent := reClusterDeclarationExport.ReplaceAll(zshrcFileContents, []byte(""))
-
-		zshrcBuilder.Write(cleanedContent)
-	}
-
-	zshrcBuilder.WriteString(`setopt PROMPT_SUBST
-autoload -U colors && colors # Enable colors
-prompt() {
-`)
-
-	ps1, overridePs1 := p.osEnvVars["OKCTL_PS1"]
-	if overridePs1 {
-		withEnv := strings.ReplaceAll(ps1, "%env", p.clusterName)
-		zshrcBuilder.WriteString(fmt.Sprintf(`PS1="%s"`, withEnv))
-	} else {
-		zshrcBuilder.WriteString(fmt.Sprint(`PS1="%F{red}%~ %f%F{blue}($(venv_ps1 ` + p.clusterName + `)%f) $ "`))
-	}
-
-	zshrcBuilder.WriteString(`
-}
-precmd_functions+=(prompt)
-`)
-
-	return zshrcBuilder.String(), nil
 }

--- a/pkg/virtualenv/commandlineprompter/prompter_zsh.go
+++ b/pkg/virtualenv/commandlineprompter/prompter_zsh.go
@@ -1,5 +1,10 @@
 package commandlineprompter
 
+import (
+	"fmt"
+	"strings"
+)
+
 type zshPrompter struct {
 	clusterName string
 	osEnvVars   map[string]string
@@ -8,7 +13,13 @@ type zshPrompter struct {
 // CreatePrompt returns environment variables that when set in zsh will show a command prompt.
 // The warning is set in case something prevented the prompt to be set the expected way.
 func (p *zshPrompter) CreatePrompt() (CommandLinePrompt, error) {
-	p.osEnvVars["PS1"] = "%F{red}%~ %f%F{blue}($(venv_ps1 " + p.clusterName + ")%f) $ "
+	ps1, overridePs1 := p.osEnvVars["OKCTL_PS1"]
+	if overridePs1 {
+		withEnv := strings.ReplaceAll(ps1, "%env", p.clusterName)
+		p.osEnvVars["PS1"] = fmt.Sprintf(`%s`, withEnv)
+	} else {
+		p.osEnvVars["PS1"] = fmt.Sprint(`%F{red}%~ %f%F{blue}($(venv_ps1 ` + p.clusterName + `)%f) $ `)
+	}
 
 	return CommandLinePrompt{
 		Env: p.osEnvVars,

--- a/pkg/virtualenv/shellgetter/shellgetter.go
+++ b/pkg/virtualenv/shellgetter/shellgetter.go
@@ -52,6 +52,7 @@ func (g *ShellGetter) Get() (*Shell, error) {
 	}
 
 	var shellType shelltype.ShellType
+
 	var shellArgs []string
 
 	switch {

--- a/pkg/virtualenv/shellgetter/shellgetter.go
+++ b/pkg/virtualenv/shellgetter/shellgetter.go
@@ -53,15 +53,16 @@ func (g *ShellGetter) Get() (*Shell, error) {
 
 	var shellType shelltype.ShellType
 
+	// Used to set flags to avoid reading the user configuration files, so that
+	// we can control "standard" environment variables (PS1, AWS_PROFILE)
 	var shellArgs []string
 
 	switch {
 	case g.shellIsBash(shellCmd):
 		shellType = shelltype.Bash
+		shellArgs = []string{"--norc", "--noprofile"}
 	case g.shellIsZsh(shellCmd):
 		shellType = shelltype.Zsh
-		// Don't read the user configuration files, so that we can control
-		// "standard" environment variables (PS1, AWS_PROFILE)
 		shellArgs = []string{"-f"}
 	default:
 		shellType = shelltype.Unknown

--- a/pkg/virtualenv/shellgetter/shellgetter.go
+++ b/pkg/virtualenv/shellgetter/shellgetter.go
@@ -13,7 +13,6 @@ import (
 // ShellGetter is a provider for getting a shell executable based on some environment
 type ShellGetter struct {
 	Os                      Os
-	UserHomeDir             string
 	OsEnvVars               map[string]string
 	EtcStorage              storage.Storer
 	CurrentUsername         string
@@ -24,13 +23,11 @@ type ShellGetter struct {
 func NewShellGetter(
 	os Os,
 	macOsUserShellGetter MacOsUserShellCmdGetter,
-	userHomeDir string,
 	osEnvVars map[string]string,
 	etcStorage storage.Storer,
 	currentUsername string) *ShellGetter {
 	return &ShellGetter{
 		Os:                      os,
-		UserHomeDir:             userHomeDir,
 		OsEnvVars:               osEnvVars,
 		EtcStorage:              etcStorage,
 		CurrentUsername:         currentUsername,

--- a/pkg/virtualenv/shellgetter/shellgetter.go
+++ b/pkg/virtualenv/shellgetter/shellgetter.go
@@ -41,6 +41,7 @@ func NewShellGetter(
 // Shell contains data about a shell executable (like bash)
 type Shell struct {
 	Command   string
+	Args      []string
 	ShellType shelltype.ShellType
 }
 
@@ -54,18 +55,23 @@ func (g *ShellGetter) Get() (*Shell, error) {
 	}
 
 	var shellType shelltype.ShellType
+	var shellArgs []string
 
 	switch {
 	case g.shellIsBash(shellCmd):
 		shellType = shelltype.Bash
 	case g.shellIsZsh(shellCmd):
 		shellType = shelltype.Zsh
+		// Don't read the user configuration files, so that we can control
+		// "standard" environment variables (PS1, AWS_PROFILE)
+		shellArgs = []string{"-f"}
 	default:
 		shellType = shelltype.Unknown
 	}
 
 	return &Shell{
 		Command:   shellCmd,
+		Args:      shellArgs,
 		ShellType: shellType,
 	}, nil
 }

--- a/pkg/virtualenv/testdata/zshrc_custom_ps1.golden
+++ b/pkg/virtualenv/testdata/zshrc_custom_ps1.golden
@@ -1,6 +1,0 @@
-setopt PROMPT_SUBST
-autoload -U colors && colors # Enable colors
-prompt() {
-PS1="Dir: %~ $"
-}
-precmd_functions+=(prompt)

--- a/pkg/virtualenv/testdata/zshrc_custom_ps1_with_env.golden
+++ b/pkg/virtualenv/testdata/zshrc_custom_ps1_with_env.golden
@@ -1,6 +1,0 @@
-setopt PROMPT_SUBST
-autoload -U colors && colors # Enable colors
-prompt() {
-PS1="Dir: %~ | \$(venv_ps1 myenv) \$"
-}
-precmd_functions+=(prompt)

--- a/pkg/virtualenv/testdata/zshrc_existing_zshrc.golden
+++ b/pkg/virtualenv/testdata/zshrc_existing_zshrc.golden
@@ -1,6 +1,0 @@
-setopt PROMPT_SUBST
-autoload -U colors && colors # Enable colors
-prompt() {
-PS1="%F{red}%~ %f%F{blue}($(venv_ps1 myenv)%f) $ "
-}
-precmd_functions+=(prompt)

--- a/pkg/virtualenv/testdata/zshrc_no_existing_zshrc.golden
+++ b/pkg/virtualenv/testdata/zshrc_no_existing_zshrc.golden
@@ -1,6 +1,0 @@
-setopt PROMPT_SUBST
-autoload -U colors && colors # Enable colors
-prompt() {
-PS1="%F{red}%~ %f%F{blue}($(venv_ps1 myenv)%f) $ "
-}
-precmd_functions+=(prompt)

--- a/pkg/virtualenv/testhelper_test.go
+++ b/pkg/virtualenv/testhelper_test.go
@@ -66,13 +66,6 @@ func (h *testHelper) createUserDirStorage(basepath string) *userDirStorage {
 	}
 }
 
-func (h *testHelper) createTmpStorage() *storage.EphemeralStorage {
-	s := storage.NewEphemeralStorage()
-	s.BasePath = h.tmpBasedir
-
-	return s
-}
-
 func (h *testHelper) createUserHomeDirStorage(createZshrcFile bool) (*storage.EphemeralStorage, error) {
 	s := storage.NewEphemeralStorage()
 

--- a/pkg/virtualenv/testhelper_test.go
+++ b/pkg/virtualenv/testhelper_test.go
@@ -66,24 +66,6 @@ func (h *testHelper) createUserDirStorage(basepath string) *userDirStorage {
 	}
 }
 
-func (h *testHelper) createUserHomeDirStorage(createZshrcFile bool) (*storage.EphemeralStorage, error) {
-	s := storage.NewEphemeralStorage()
-
-	if createZshrcFile {
-		file, err := s.Create(".", ".zshrc", 0o644)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't create .zshrc file: %w", err)
-		}
-
-		err = file.Close()
-		if err != nil {
-			return nil, fmt.Errorf("couldn't close .zshrc file: %w", err)
-		}
-	}
-
-	return s, nil
-}
-
 func (h *testHelper) toSlice(m map[string]string) []string {
 	s := make([]string, 0)
 

--- a/pkg/virtualenv/virtualenv.go
+++ b/pkg/virtualenv/virtualenv.go
@@ -13,6 +13,7 @@ type VirtualEnvironment struct {
 	env          map[string]string
 	Warning      string
 	ShellCommand string
+	ShellArgs    []string
 }
 
 // Environ returns all environment variables in the virtual environment, on the form
@@ -54,5 +55,6 @@ func CreateVirtualEnvironment(opts commandlineprompter.CommandLinePromptOpts) (*
 		env:          commandLinePrompt.Env,
 		Warning:      commandLinePrompt.Warning,
 		ShellCommand: shell.Command,
+		ShellArgs:    shell.Args,
 	}, nil
 }

--- a/pkg/virtualenv/virtualenv_test.go
+++ b/pkg/virtualenv/virtualenv_test.go
@@ -196,15 +196,12 @@ func TestCreateVirtualEnvironment(t *testing.T) {
 
 			userDirStorage := testHelper.createUserDirStorage(fmt.Sprintf("/home/%s/.okctl", testHelper.currentUsername))
 
-			tmpStorage := testHelper.createTmpStorage()
-
 			opts := commandlineprompter.CommandLinePromptOpts{
 				Os:                   tc.os,
 				MacOsUserShellGetter: testHelper.NewTestMacOsLoginShellGetter(),
 				OsEnvVars:            tc.osEnvVars,
 				EtcStorage:           etcStorage,
 				UserDirStorage:       userDirStorage.storage,
-				TmpStorage:           tmpStorage,
 				ClusterName:          "myenv",
 				CurrentUsername:      testHelper.currentUsername,
 			}


### PR DESCRIPTION
Fix a bug where setting the AWS_PROFILE would be overridden by the value set in the user's shell config files (`.zshrc` / `.bashrc`).

## Description

Instead of creating a local copy of the .zshrc config file to override "standard" environment variables like PS1 and AWS_PROFILE, we prevent the shell from reading the user configuration files by using the `-f` flag (and similarly `--norc` and `--noprofile` for bash).

## Motivation and Context

Fixes https://trello.com/c/MMGaZQZa/532-okctl-venv-sets-wrong-awsprofile

## How to prove the effect of this PR?

- Set the AWS_PROFILE variable to some value in `.zshrc` / `.bashrc`
- Set a different value for AWS_PROFILE in the current shell
- Run `okctl venv -a aws-profile`
- Observe that the value for AWS_PROFILE in the virtual environment is the same as set in the shell, and not in `.zshrc` / `.bashrc`

## Additional info

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
