### PR TITLE
👌 Use AWS-managed policy for Lambda VPC access

### DIFF
--- a/pkg/cfn/components/composer.go
+++ b/pkg/cfn/components/composer.go
@@ -1348,6 +1348,7 @@ const (
 	// - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html
 	amazonRDSEnhancedMonitoringRole = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 	awsLambdaBasicExecutionRole     = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+	awsLambdaVPCAccessExecutionRole = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 )
 
 // CloudFormationResourceName returns the CF logical name
@@ -1471,7 +1472,7 @@ func (c *RDSPostgresComposer) Compose() (*cfn.Composition, error) {
 		c.PhysicalName("RDSPGRotaterRole"),
 		c.CloudFormationResourceName("RDSPGRotaterRole"),
 		v1alpha1.PermissionsBoundaryARN(c.AWSAccountID),
-		[]string{awsLambdaBasicExecutionRole},
+		[]string{awsLambdaBasicExecutionRole, awsLambdaVPCAccessExecutionRole},
 		policydocument.PolicyDocument{
 			Version: policydocument.Version,
 			Statement: []policydocument.StatementEntry{
@@ -1494,17 +1495,6 @@ func (c *RDSPostgresComposer) Compose() (*cfn.Composition, error) {
 						Effect: policydocument.EffectTypeAllow,
 						Action: []string{
 							"secretsmanager:GetRandomPassword",
-						},
-						Resource: []string{
-							"*",
-						},
-					},
-					{
-						Effect: policydocument.EffectTypeAllow,
-						Action: []string{
-							"ec2:CreateNetworkInterface",
-							"ec2:DeleteNetworkInterface",
-							"ec2:DescribeNetworkInterfaces",
 						},
 						Resource: []string{
 							"*",

--- a/pkg/cfn/testdata/rds-postgres.yaml.golden
+++ b/pkg/cfn/testdata/rds-postgres.yaml.golden
@@ -194,19 +194,13 @@ Resources:
         Version: 2012-10-17
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
       PermissionsBoundary: arn:aws:iam::123456789012:policy/oslokommune/oslokommune-boundary
       Policies:
       - PolicyDocument:
           Statement:
           - Action:
             - secretsmanager:GetRandomPassword
-            Effect: Allow
-            Resource:
-            - '*'
-          - Action:
-            - ec2:CreateNetworkInterface
-            - ec2:DeleteNetworkInterface
-            - ec2:DescribeNetworkInterfaces
             Effect: Allow
             Resource:
             - '*'


### PR DESCRIPTION
Replace local policy definition with AWS-managed policy for giving RDS password rotator Lambda function the necessary permissions to run in VPC.

## Description

Internal refactoring, no changes in behavior.

## Motivation and Context

Use AWS-managed policy instead of maintaining our own.

## How to prove the effect of this PR?

## Additional info

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
