### PR TITLE
KM321 - 👌 ensure database name is valid as early as possible before setting up postgres forward

### DIFF
--- a/cmd/okctl/forward_postgres.go
+++ b/cmd/okctl/forward_postgres.go
@@ -78,11 +78,8 @@ func buildForwardPostgres(o *okctl.Okctl) *cobra.Command {
 			hooks.InitializeOkctl(o),
 			hooks.DownloadState(o, false),
 			hooks.VerifyClusterExistsInState(o),
+			hooks.ValidatePostgresApplicationName(o, &opts.ApplicationName),
 			func(_ *cobra.Command, _ []string) error {
-				if len(opts.ApplicationName) == 0 {
-					return fmt.Errorf("missing database instance name")
-				}
-
 				err := commands.ValidateBinaryVersionNotLessThanClusterVersion(o)
 				if err != nil {
 					return err

--- a/cmd/okctl/hooks/postgres.go
+++ b/cmd/okctl/hooks/postgres.go
@@ -1,0 +1,46 @@
+package hooks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/spf13/cobra"
+)
+
+// ValidatePostgresApplicationName ensures that applicationName matches an existing database
+func ValidatePostgresApplicationName(o *okctl.Okctl, applicationName *string) RunEer {
+	return func(cmd *cobra.Command, args []string) error {
+		databaseName := *applicationName
+		if len(databaseName) == 0 {
+			return fmt.Errorf("missing database instance name")
+		}
+
+		var existingDatabaseNames []string
+
+		dbs, _ := o.StateHandlers(o.StateNodes()).Component.GetPostgresDatabases()
+		for _, db := range dbs {
+			existingDatabaseNames = append(existingDatabaseNames, db.ApplicationName)
+		}
+
+		if !databaseNameExists(databaseName, existingDatabaseNames) {
+			return fmt.Errorf(
+				"database name '%s' is not valid. The following datbases are available: [%s]",
+				databaseName,
+				strings.Join(existingDatabaseNames, ", "),
+			)
+		}
+
+		return nil
+	}
+}
+
+func databaseNameExists(databaseName string, existingDatabaseNames []string) bool {
+	for _, b := range existingDatabaseNames {
+		if b == databaseName {
+			return true
+		}
+	}
+
+	return false
+}

--- a/docs/release_notes/0.0.90.md
+++ b/docs/release_notes/0.0.90.md
@@ -5,6 +5,7 @@
 ## Bugfixes
 
 ## Changes
+KM321 - 👌 ensure database name is valid as early as possible before setting up postgres forward
 
 ## Other
 

--- a/docs/release_notes/0.0.90.md
+++ b/docs/release_notes/0.0.90.md
@@ -5,7 +5,7 @@
 ## Bugfixes
 
 ## Changes
-KM321 - 👌 ensure database name is valid as early as possible before setting up postgres forward
+KM321 - 👌 ensure database name is valid as early as possible before setting up postgres forward (#907)
 
 ## Other
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently you would not be notified before pgbouncer is set up and
trying to connect to the datbase. All databases are available in
the state: we now check against one of these before setting up the
pgbouncer


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When validating the database as early as possible we save time and frustration for the user.


## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
Run 
```
okctl forward postgres --cluster-declaration cluster.yaml --name notexistingdatabase --username bob --password-file secret/tmp.password
```
and get a error stating that the name is not valid. In addition a list of available databases will be printed to the user.

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
