### PR TITLE
KM483 🐛 Write kubeconfig on okctl upgrade

### DIFF
--- a/cmd/okctl/hooks/kubeconfig.go
+++ b/cmd/okctl/hooks/kubeconfig.go
@@ -15,6 +15,7 @@ func WriteKubeConfig(o *okctl.Okctl) RunEer {
 			return fmt.Errorf("getting kubeconfig store: %w", err)
 		}
 
+		// GetKubeConfig actually writes the config to disk
 		_, err = kubeconfigStore.GetKubeConfig(o.Declaration.Metadata.Name)
 		if err != nil {
 			return fmt.Errorf("getting kubeconfig: %w", err)

--- a/cmd/okctl/hooks/kubeconfig.go
+++ b/cmd/okctl/hooks/kubeconfig.go
@@ -1,0 +1,25 @@
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/oslokommune/okctl/pkg/okctl"
+	"github.com/spf13/cobra"
+)
+
+// WriteKubeConfig writes the Kubernetes configuration to disk
+func WriteKubeConfig(o *okctl.Okctl) RunEer {
+	return func(_ *cobra.Command, _ []string) error {
+		kubeconfigStore, err := o.KubeConfigStore()
+		if err != nil {
+			return fmt.Errorf("getting kubeconfig store: %w", err)
+		}
+
+		_, err = kubeconfigStore.GetKubeConfig(o.Declaration.Metadata.Name)
+		if err != nil {
+			return fmt.Errorf("getting kubeconfig: %w", err)
+		}
+
+		return nil
+	}
+}

--- a/cmd/okctl/upgrade.go
+++ b/cmd/okctl/upgrade.go
@@ -49,6 +49,7 @@ binaries used by okctl (kubectl, etc), and internal state.`,
 			hooks.AcquireStateLock(o),
 			hooks.DownloadState(o, true),
 			hooks.VerifyClusterExistsInState(o),
+			hooks.WriteKubeConfig(o),
 			func(cmd *cobra.Command, args []string) error {
 				okctlEnvironment, err := commands.GetOkctlEnvironment(o, declarationPath)
 				if err != nil {

--- a/cmd/okctl/venv.go
+++ b/cmd/okctl/venv.go
@@ -6,15 +6,12 @@ import (
 	osPkg "os"
 	"os/exec"
 	"os/user"
-	"path"
 	"strings"
 
 	"github.com/oslokommune/okctl/cmd/okctl/hooks"
 	"github.com/oslokommune/okctl/pkg/metrics"
 
-	"github.com/oslokommune/okctl/pkg/config/constant"
 	"github.com/oslokommune/okctl/pkg/config/state"
-	"github.com/oslokommune/okctl/pkg/kubeconfig"
 	"github.com/oslokommune/okctl/pkg/virtualenv/shellgetter"
 
 	"github.com/oslokommune/okctl/pkg/virtualenv/commandlineprompter"
@@ -47,6 +44,7 @@ func buildVenvCommand(o *okctl.Okctl) *cobra.Command { //nolint: funlen
 			hooks.InitializeOkctl(o),
 			hooks.DownloadState(o, false),
 			hooks.VerifyClusterExistsInState(o),
+			hooks.WriteKubeConfig(o),
 			func(_ *cobra.Command, args []string) error {
 				e, err := venvPreRunE(o)
 				if err != nil {
@@ -64,40 +62,6 @@ func buildVenvCommand(o *okctl.Okctl) *cobra.Command { //nolint: funlen
 			},
 		),
 		RunE: func(_ *cobra.Command, args []string) error {
-			handlers := o.StateHandlers(o.StateNodes())
-
-			cluster, err := handlers.Cluster.GetCluster(o.Declaration.Metadata.Name)
-			if err != nil {
-				return err
-			}
-
-			cfg, err := kubeconfig.New(cluster.Config, o.CloudProvider).Get()
-			if err != nil {
-				return fmt.Errorf("creating kubconfig: %w", err)
-			}
-
-			data, err := cfg.Bytes()
-			if err != nil {
-				return err
-			}
-
-			appDir, err := o.GetUserDataDir()
-			if err != nil {
-				return err
-			}
-
-			kubeConfigFile := path.Join(appDir, constant.DefaultCredentialsDirName, okctlEnvironment.ClusterName, constant.DefaultClusterKubeConfig)
-
-			err = o.FileSystem.MkdirAll(path.Dir(kubeConfigFile), 0o700)
-			if err != nil {
-				return err
-			}
-
-			err = o.FileSystem.WriteFile(kubeConfigFile, data, 0o640)
-			if err != nil {
-				return err
-			}
-
 			return venvRunE(o, okctlEnvironment)
 		},
 		PostRunE: hooks.RunECombinator(

--- a/docs/release_notes/0.0.90.md
+++ b/docs/release_notes/0.0.90.md
@@ -4,6 +4,8 @@
 
 ## Bugfixes
 
+KM483 🐛 Write kubeconfig on okctl upgrade (#908)
+
 ## Changes
 
 ## Other


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Write kubeconfig when running `okctl upgrade`.

## Description
<!--- Describe your changes in detail -->

Also removed duplication using a WriteKubeConfig hook.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://trello.com/c/W2rTY7In/483-write-kubeconfig-before-running-upgrades

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

*  `rm ~/.okctl/credentials/clusterName/kubeconfig`
* Run `okctl upgrade`
* Verify that there is no error
* Verifiy that `ls ~/.okctl/credentials/clusterName/kubeconfig` now returns a file

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
