### PR TITLE
KM416 - set correct file permission on kuebconfig file

### DIFF
--- a/docs/release_notes/0.0.90.md
+++ b/docs/release_notes/0.0.90.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Bugfixes
+KM416  -🐛 set correct file permission on kuebconfig file (#909)
 
 ## Changes
 KM321 - 👌 ensure database name is valid as early as possible before setting up postgres forward (#907)

--- a/pkg/api/core/store/filesystem/kubeconfig_filesystem.go
+++ b/pkg/api/core/store/filesystem/kubeconfig_filesystem.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/oslokommune/okctl/pkg/config/constant"
+
 	"github.com/oslokommune/okctl/pkg/client"
 
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
@@ -32,7 +34,7 @@ func (k *kubeConfig) SaveKubeConfig(config *kubeconfig.Config) error {
 	}
 
 	_, err = store.NewFileSystem(k.kubeConfigBaseDir, k.fs).
-		StoreBytes(k.kubeConfigFileName, cfg).
+		StoreBytes(k.kubeConfigFileName, cfg, store.WithFilePermissionsMode(constant.DefaultClusterKubePermission)).
 		Do()
 	if err != nil {
 		return fmt.Errorf("storing kubeconfig: %w", err)

--- a/pkg/config/constant/api.go
+++ b/pkg/config/constant/api.go
@@ -49,6 +49,7 @@ const (
 
 	DefaultClusterConfig         = "cluster.yml"
 	DefaultClusterKubeConfig     = "kubeconfig"
+	DefaultClusterKubePermission = 0o600
 	DefaultClusterAwsConfig      = "aws-config"
 	DefaultClusterAwsCredentials = "aws-credentials"
 	DefaultClusterBaseDir        = "cluster"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`kubectl` will complain if `kubeconfig` is group/world readable, this sets
the filepermission to 0o600

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When starting up `venv` and kubectl is reading the `kubeconfig` file, it will emit a warning to the user. This patch will supress this warning for new clusters that are created

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
Create a new cluster, run `venv` with the cluster manifest and you should not see any warnings in the console

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
