### PR TITLE
KM303 ✅ Add delete applications in delete cluster

### DIFF
--- a/cmd/okctl/apply_cluster.go
+++ b/cmd/okctl/apply_cluster.go
@@ -160,6 +160,7 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 				reconciliation.NewUsersReconciler(services.IdentityManager),
 				reconciliation.NewPostgresReconciler(services.Component),
 				reconciliation.NewCleanupSGReconciler(o.CloudProvider),
+				reconciliation.NewApplicationReconciler(),
 			)
 
 			_, err = scheduler.Run(o.Ctx, state)

--- a/cmd/okctl/apply_cluster.go
+++ b/cmd/okctl/apply_cluster.go
@@ -160,7 +160,7 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 				reconciliation.NewUsersReconciler(services.IdentityManager),
 				reconciliation.NewPostgresReconciler(services.Component),
 				reconciliation.NewCleanupSGReconciler(o.CloudProvider),
-				reconciliation.NewApplicationReconciler(),
+				reconciliation.NewApplicationReconciler(services),
 			)
 
 			_, err = scheduler.Run(o.Ctx, state)

--- a/cmd/okctl/delete.go
+++ b/cmd/okctl/delete.go
@@ -110,6 +110,7 @@ func buildDeleteClusterCommand(o *okctl.Okctl) *cobra.Command {
 				reconciliation.NewUsersReconciler(services.IdentityManager),
 				reconciliation.NewPostgresReconciler(services.Component),
 				reconciliation.NewCleanupSGReconciler(o.CloudProvider),
+				reconciliation.NewApplicationReconciler(services),
 			)
 
 			ready, err := checkIfReady(o.Declaration.Metadata.Name, o, opts.Confirm)

--- a/cmd/okctl/handlers/application.go
+++ b/cmd/okctl/handlers/application.go
@@ -48,7 +48,7 @@ func HandleApplication(opts *HandleApplicationOpts) RunEHandler { //nolint:funle
 			return fmt.Errorf("error creating spinner: %w", err)
 		}
 
-		scheduler := createScheduler(createSchedulerOpts{
+		scheduler := CreateScheduler(CreateSchedulerOpts{
 			Out:                 opts.Out,
 			Services:            opts.Services,
 			State:               opts.State,
@@ -68,7 +68,8 @@ func HandleApplication(opts *HandleApplicationOpts) RunEHandler { //nolint:funle
 	}
 }
 
-func createScheduler(opts createSchedulerOpts) common.Scheduler {
+// CreateScheduler knows how to create a complete application reconciliation scheduler
+func CreateScheduler(opts CreateSchedulerOpts) common.Scheduler {
 	schedulerOpts := common.SchedulerOpts{
 		Out:                             opts.Out,
 		Spinner:                         opts.Spinner,
@@ -168,7 +169,8 @@ func deleteApplicationReadyCheck(out io.Writer, application v1alpha1.Application
 	return ready, nil
 }
 
-type createSchedulerOpts struct {
+// CreateSchedulerOpts defines necessary data to create an application reconciliation scheduler
+type CreateSchedulerOpts struct {
 	Out io.Writer
 
 	Services *core.Services

--- a/pkg/apis/okctl.io/v1alpha1/application_v1alpha1.go
+++ b/pkg/apis/okctl.io/v1alpha1/application_v1alpha1.go
@@ -170,9 +170,10 @@ func (a Application) URL() (url.URL, error) {
 // NewApplication returns an initialized application definition
 func NewApplication(cluster Cluster) Application {
 	return Application{
-		TypeMeta: ApplicationTypeMeta(),
-		Image:    ApplicationImage{},
-		Replicas: defaultReplicas,
-		cluster:  cluster,
+		TypeMeta:    ApplicationTypeMeta(),
+		Replicas:    defaultReplicas,
+		Environment: make(map[string]string),
+		Volumes:     make([]map[string]string, 0),
+		cluster:     cluster,
 	}
 }

--- a/pkg/client/application_client.go
+++ b/pkg/client/application_client.go
@@ -93,3 +93,17 @@ type ApplicationService interface {
 	// HasArgoCDIntegration implements functionality for verifying if there is an existing ArgoCD integration for the app
 	HasArgoCDIntegration(context.Context, HasArgoCDIntegrationOpts) (bool, error)
 }
+
+// ApplicationState defines operations done on application state
+type ApplicationState interface {
+	// Put knows how to upsert application state
+	Put(v1alpha1.Application) error
+	// Get knows how to retrieve application state
+	Get(name string) (v1alpha1.Application, error)
+	// Delete knows how to remove application state
+	Delete(name string) error
+	// List knows how to retrieve all application state stored
+	List() ([]v1alpha1.Application, error)
+	// Initialize knows how to do required setup for state to work
+	Initialize() error
+}

--- a/pkg/client/application_client.go
+++ b/pkg/client/application_client.go
@@ -105,5 +105,5 @@ type ApplicationState interface {
 	// List knows how to retrieve all application state stored
 	List() ([]v1alpha1.Application, error)
 	// Initialize knows how to do required setup for state to work
-	Initialize() error
+	Initialize(clusterManifest v1alpha1.Cluster, absoluteIACRepositoryRootDirectory string) error
 }

--- a/pkg/client/core/handler_client.go
+++ b/pkg/client/core/handler_client.go
@@ -53,6 +53,7 @@ type StateHandlers struct {
 	ExternalSecrets           client.ExternalSecretsState
 	Upgrade                   client.UpgradeState
 	Kubernetes                client.KubernetesState
+	Application               client.ApplicationState
 }
 
 // Services contains all client-side services

--- a/pkg/client/core/service_application_client.go
+++ b/pkg/client/core/service_application_client.go
@@ -149,7 +149,7 @@ func (s *applicationService) DeleteArgoCDApplicationManifest(opts client.DeleteA
 		return fmt.Errorf("generating ArgoCD application manifest: %w", err)
 	}
 
-	err = s.kubectl.Delete(manifest)
+	err = s.kubectl.DeleteByManifest(manifest)
 	if err != nil {
 		if !stderrors.Is(err, kubectl.ErrNotFound) {
 			return fmt.Errorf("deleting ArgoCD application manifest from cluster: %w", err)

--- a/pkg/client/core/service_application_client_test.go
+++ b/pkg/client/core/service_application_client_test.go
@@ -191,10 +191,12 @@ func generateMockClusterManifest() v1alpha1.Cluster {
 
 type mockKubectlClient struct{}
 
-func (m mockKubectlClient) Apply(_ io.Reader) error                 { panic("implement me") }
-func (m mockKubectlClient) Delete(_ io.Reader) error                { panic("implement me") }
-func (m mockKubectlClient) Patch(_ kubectl.PatchOpts) error         { panic("implement me") }
-func (m mockKubectlClient) Exists(_ kubectl.Resource) (bool, error) { panic("implement me") }
+func (m mockKubectlClient) Get(kubectl.Resource) (io.Reader, error) { panic("implement me") }
+func (m mockKubectlClient) Apply(io.Reader) error                   { panic("implement me") }
+func (m mockKubectlClient) DeleteByManifest(io.Reader) error        { panic("implement me") }
+func (m mockKubectlClient) DeleteByResource(kubectl.Resource) error { panic("implement me") }
+func (m mockKubectlClient) Patch(kubectl.PatchOpts) error           { panic("implement me") }
+func (m mockKubectlClient) Exists(kubectl.Resource) (bool, error)   { panic("implement me") }
 
 const (
 	defaultMockARN  = "arn:which:isnt:an:arn"

--- a/pkg/client/core/service_application_manifest_client.go
+++ b/pkg/client/core/service_application_manifest_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sort"
 	"strings"
 
 	merrors "github.com/mishudark/errors"
@@ -52,6 +53,7 @@ func (a *applicationManifestService) SaveManifest(_ context.Context, opts client
 	}
 
 	kustomizationManifest.AddResource(opts.Filename)
+	sort.Strings(kustomizationManifest.Resources)
 
 	rawKustomizationManifest, err := yaml.Marshal(kustomizationManifest)
 	if err != nil {

--- a/pkg/client/core/state/crd/application-crd-template.yaml
+++ b/pkg/client/core/state/crd/application-crd-template.yaml
@@ -1,0 +1,18 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.okctl.io
+spec:
+  group: okctl.io
+  scope: Namespaced
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    singular: application
+  subresources:
+    status: {}
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/pkg/client/core/state/crd/application.go
+++ b/pkg/client/core/state/crd/application.go
@@ -1,0 +1,138 @@
+package crd
+
+import (
+	"bytes"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/client"
+	"github.com/oslokommune/okctl/pkg/clients/kubectl"
+	"github.com/oslokommune/okctl/pkg/logging"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Put adds an application manifest to etcd
+func (a applicationState) Put(application v1alpha1.Application) error {
+	rawApplication, err := yaml.Marshal(application)
+	if err != nil {
+		return fmt.Errorf("marshalling: %w", err)
+	}
+
+	err = a.kubectl.Apply(bytes.NewReader(rawApplication))
+	if err != nil {
+		return fmt.Errorf("applying: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves an application manifest from etcd
+func (a applicationState) Get(name string) (v1alpha1.Application, error) {
+	resource, err := a.kubectl.Get(kubectl.Resource{
+		Name:      name,
+		Namespace: "okctl",
+	})
+	if err != nil {
+		return v1alpha1.Application{}, fmt.Errorf("retrieving resource: %w", err)
+	}
+
+	rawResource, err := io.ReadAll(resource)
+	if err != nil {
+		return v1alpha1.Application{}, fmt.Errorf("buffering: %w", err)
+	}
+
+	var appManifest v1alpha1.Application
+
+	err = yaml.Unmarshal(rawResource, &appManifest)
+	if err != nil {
+		return v1alpha1.Application{}, fmt.Errorf("unmarshalling app manifest: %w", err)
+	}
+
+	return appManifest, nil
+}
+
+// Delete removes an application manifest from etcd
+func (a applicationState) Delete(name string) error {
+	err := a.kubectl.DeleteByResource(kubectl.Resource{
+		Name:      name,
+		Kind:      "application.okctl.io",
+		Namespace: "okctl",
+	})
+	if err != nil {
+		return fmt.Errorf("deleting: %w", err)
+	}
+
+	return nil
+}
+
+// List returns all application manifests in etcd
+func (a applicationState) List() ([]v1alpha1.Application, error) {
+	resources, err := a.kubectl.Get(kubectl.Resource{
+		Namespace: "okctl",
+		Kind:      "application.okctl.io",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("retrieving: %w", err)
+	}
+
+	rawResources, err := io.ReadAll(resources)
+	if err != nil {
+		return nil, fmt.Errorf("buffering: %w", err)
+	}
+
+	var manifests []v1alpha1.Application
+
+	err = yaml.Unmarshal(rawResources, &manifests)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling: %w", err)
+	}
+
+	return manifests, nil
+}
+
+// Initialize knows how to apply the CustomResourceDefinition, so we can store application manifests in etcd
+func (a applicationState) Initialize() error {
+	log := logging.GetLogger("applicationState", "Initialize")
+
+	_, err := a.kubectl.Get(kubectl.Resource{
+		Name:      "applications.okctl.io",
+		Namespace: "okctl",
+		Kind:      "CustomResourceDefinition",
+	})
+	if err == nil {
+		log.Debug("Found existing custom resource definition")
+
+		return nil
+	}
+
+	if err != nil && !errors.Is(err, kubectl.ErrNotFound) {
+		return fmt.Errorf("retrieving application CRD: %w", err)
+	}
+
+	log.Debug("No existing custom resource definition found, creating.")
+
+	err = a.kubectl.Apply(bytes.NewReader(applicationCRDTemplate))
+	if err != nil {
+		return fmt.Errorf("applying application custom resource definition: %w", err)
+	}
+
+	return nil
+}
+
+// NewApplicationState returns an initialized application state instance
+func NewApplicationState(kubectlClient kubectl.Client) client.ApplicationState {
+	return &applicationState{
+		kubectl: kubectlClient,
+	}
+}
+
+type applicationState struct {
+	kubectl kubectl.Client
+}
+
+//go:embed application-crd-template.yaml
+var applicationCRDTemplate []byte

--- a/pkg/client/core/state/crd/application.go
+++ b/pkg/client/core/state/crd/application.go
@@ -3,6 +3,7 @@ package crd
 import (
 	"bytes"
 	_ "embed"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -72,6 +73,10 @@ func (a applicationState) Delete(name string) error {
 		Namespace: defaultAppManifestNamespace,
 	})
 	if err != nil {
+		if errors.Is(err, kubectl.ErrNotFound) {
+			return nil
+		}
+
 		return fmt.Errorf("deleting: %w", err)
 	}
 

--- a/pkg/client/core/state/crd/application.go
+++ b/pkg/client/core/state/crd/application.go
@@ -98,14 +98,14 @@ func (a applicationState) List() ([]v1alpha1.Application, error) {
 		return nil, fmt.Errorf("buffering: %w", err)
 	}
 
-	var manifests []v1alpha1.Application
+	var manifestList listApplicationsKind
 
-	err = yaml.Unmarshal(rawResources, &manifests)
+	err = yaml.Unmarshal(rawResources, &manifestList)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshalling: %w", err)
 	}
 
-	return manifests, nil
+	return manifestList.Items, nil
 }
 
 // Initialize knows how to apply the CustomResourceDefinition, so we can store application manifests in etcd
@@ -189,6 +189,10 @@ type applicationState struct {
 
 //go:embed application-crd-template.yaml
 var applicationCRDTemplate []byte
+
+type listApplicationsKind struct {
+	Items []v1alpha1.Application `json:"items"`
+}
 
 const (
 	defaultAppManifestNamespace                                   = "okctl"

--- a/pkg/client/core/state/crd/application_test.go
+++ b/pkg/client/core/state/crd/application_test.go
@@ -1,0 +1,59 @@
+package crd
+
+import (
+	"io"
+	"path"
+	"testing"
+
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+	"github.com/oslokommune/okctl/pkg/clients/kubectl"
+	"github.com/oslokommune/okctl/pkg/lib/paths"
+	"github.com/sebdah/goldie/v2"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitializeState(t *testing.T) {
+	fs := &afero.Afero{Fs: afero.NewMemMapFs()}
+	clusterManifest := v1alpha1.NewCluster()
+	absoluteIACRepositoryRootDirectory := "/"
+
+	clusterManifest.Metadata.Name = "mock-cluster"
+	clusterManifest.Github.Repository = "mock-repo"
+
+	state := NewApplicationState(fs, &mockKubectl{})
+
+	err := state.Initialize(clusterManifest, absoluteIACRepositoryRootDirectory)
+	assert.NoError(t, err)
+
+	okctlConfigDir := path.Join(
+		absoluteIACRepositoryRootDirectory,
+		paths.GetRelativeClusterOkctlConfigurationDirectory(clusterManifest),
+	)
+
+	applicationsDir := path.Join(
+		absoluteIACRepositoryRootDirectory,
+		paths.GetRelativeClusterApplicationsDirectory(clusterManifest),
+	)
+
+	g := goldie.New(t)
+
+	assertExistence(t, g, fs, "application-crd", path.Join(okctlConfigDir, defaultApplicationCustomResourceDefinitionFilename))
+	assertExistence(t, g, fs, "okctl-config-argoapp", path.Join(applicationsDir, defaultOkctlConfigurationDirArgoCDApplicationManifestFilename))
+}
+
+func assertExistence(t *testing.T, g *goldie.Goldie, fs *afero.Afero, name string, path string) {
+	raw, err := fs.ReadFile(path)
+	assert.NoError(t, err)
+
+	g.Assert(t, name, raw)
+}
+
+type mockKubectl struct{}
+
+func (m mockKubectl) Get(kubectl.Resource) (io.Reader, error) { panic("implement me") }
+func (m mockKubectl) Apply(io.Reader) error                   { panic("implement me") }
+func (m mockKubectl) DeleteByManifest(io.Reader) error        { panic("implement me") }
+func (m mockKubectl) DeleteByResource(kubectl.Resource) error { panic("implement me") }
+func (m mockKubectl) Patch(kubectl.PatchOpts) error           { panic("implement me") }
+func (m mockKubectl) Exists(kubectl.Resource) (bool, error)   { panic("implement me") }

--- a/pkg/client/core/state/crd/doc.go
+++ b/pkg/client/core/state/crd/doc.go
@@ -1,0 +1,2 @@
+// Package crd defines state clients build for handling store in etcd
+package crd

--- a/pkg/client/core/state/crd/testdata/application-crd.golden
+++ b/pkg/client/core/state/crd/testdata/application-crd.golden
@@ -1,0 +1,18 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.okctl.io
+spec:
+  group: okctl.io
+  scope: Namespaced
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    singular: application
+  subresources:
+    status: {}
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/pkg/client/core/state/crd/testdata/okctl-config-argoapp.golden
+++ b/pkg/client/core/state/crd/testdata/okctl-config-argoapp.golden
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: okctl-config
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: infrastructure/mock-cluster/okctl
+    repoURL: git@github.com:oslokommune/mock-repo
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false
+
+---
+

--- a/pkg/client/core/testdata/kustomization-base.yaml.golden
+++ b/pkg/client/core/testdata/kustomization-base.yaml.golden
@@ -1,7 +1,7 @@
 resources:
-- volumes.yaml
-- service.yaml
-- ingress.yaml
-- service-monitor.yaml
-- namespace.yaml
 - deployment.yaml
+- ingress.yaml
+- namespace.yaml
+- service-monitor.yaml
+- service.yaml
+- volumes.yaml

--- a/pkg/clients/kubectl/binary/api.go
+++ b/pkg/clients/kubectl/binary/api.go
@@ -36,11 +36,17 @@ func (c client) Apply(manifest io.Reader) error {
 
 // Get runs kubectl get to retrieve resources as yaml
 func (c *client) Get(resource kubectl.Resource) (io.Reader, error) {
-	output, err := c.runKubectlCommand("get",
+	args := []string{
 		namespaceFlag, resource.Namespace,
-		"get", resource.Kind, resource.Name,
 		"--output", "yaml",
-	)
+		"get", resource.Kind,
+	}
+
+	if resource.Name != "" {
+		args = append(args, resource.Name)
+	}
+
+	output, err := c.runKubectlCommand("get", args...)
 	if err != nil {
 		return nil, fmt.Errorf("running command: %w", err)
 	}

--- a/pkg/clients/kubectl/binary/api.go
+++ b/pkg/clients/kubectl/binary/api.go
@@ -37,7 +37,7 @@ func (c client) Apply(manifest io.Reader) error {
 // Get runs kubectl get to retrieve resources as yaml
 func (c *client) Get(resource kubectl.Resource) (io.Reader, error) {
 	output, err := c.runKubectlCommand("get",
-		"--namespace", resource.Namespace,
+		namespaceFlag, resource.Namespace,
 		"get", resource.Kind, resource.Name,
 		"--output", "yaml",
 	)
@@ -51,7 +51,7 @@ func (c *client) Get(resource kubectl.Resource) (io.Reader, error) {
 // DeleteByResource deletes resources based on values
 func (c *client) DeleteByResource(resource kubectl.Resource) error {
 	_, err := c.runKubectlCommand("delete",
-		"--namespace", resource.Namespace,
+		namespaceFlag, resource.Namespace,
 		"delete", resource.Kind, resource.Name,
 	)
 	if err != nil {
@@ -88,7 +88,7 @@ func (c client) Patch(opts kubectl.PatchOpts) error {
 	}
 
 	_, err = c.runKubectlCommand("patch",
-		"--namespace", opts.Namespace,
+		namespaceFlag, opts.Namespace,
 		"patch",
 		opts.Kind, opts.Name,
 		"--patch", string(rawPatch),
@@ -104,7 +104,7 @@ func (c client) Patch(opts kubectl.PatchOpts) error {
 // Exists returns true if resource is found, false if not
 func (c client) Exists(resource kubectl.Resource) (bool, error) {
 	_, err := c.runKubectlCommand("exists",
-		"--namespace", resource.Namespace,
+		namespaceFlag, resource.Namespace,
 		"get",
 		resource.Kind,
 		resource.Name,
@@ -129,3 +129,5 @@ func New(fs *afero.Afero, binaryProvider binaries.Provider, credentialsProvider 
 		cluster:             cluster,
 	}
 }
+
+const namespaceFlag = "--namespace"

--- a/pkg/clients/kubectl/types.go
+++ b/pkg/clients/kubectl/types.go
@@ -21,10 +21,14 @@ type PatchOpts struct {
 
 // Client defines functionality expected of a kubectl client
 type Client interface {
+	// Get knows how to retrieve an applied manifest
+	Get(Resource) (io.Reader, error)
 	// Apply knows how to apply a manifest
 	Apply(manifest io.Reader) error
-	// Delete knows how to delete a manifest
-	Delete(manifest io.Reader) error
+	// DeleteByManifest knows how to delete a manifest based on a manifest
+	DeleteByManifest(manifest io.Reader) error
+	// DeleteByResource knows how to delete a manifest based on values
+	DeleteByResource(Resource) error
 	// Patch knows how to patch resources
 	Patch(PatchOpts) error
 	// Exists knows how to check the existence of a resource

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,8 +12,6 @@ import (
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 	"github.com/oslokommune/okctl/pkg/logging"
 
-	"github.com/rancher/k3d/v3/cmd/util"
-
 	"github.com/oslokommune/okctl/pkg/config/constant"
 
 	"github.com/oslokommune/okctl/pkg/client/store"
@@ -45,31 +43,17 @@ type Config struct {
 
 	Declaration *v1alpha1.Cluster
 
-	Destination   string
-	ServerURL     string
-	ServerBaseURL string
-
 	homeDir string
 	repoDir string
 }
 
 // New Config initialises a default okctl configuration
 func New() *Config {
-	port, err := util.GetFreePort()
-	if err != nil {
-		port = 8085
-	}
-
-	dest := fmt.Sprintf("127.0.0.1:%d", port)
-
 	return &Config{
 		Context:        context.New(),
 		UserDataLoader: NoopDataLoader,
 		UserState:      &state.User{},
 		RepoDataLoader: NoopDataLoader,
-		Destination:    dest,
-		ServerURL:      fmt.Sprintf("http://%s/v1/", dest),
-		ServerBaseURL:  fmt.Sprintf("http://%s/", dest),
 	}
 }
 

--- a/pkg/controller/cluster/reconciliation/application_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/application_reconciler.go
@@ -3,6 +3,7 @@ package reconciliation
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/oslokommune/okctl/cmd/okctl/handlers"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
@@ -70,7 +71,7 @@ type deleteApplicationOpts struct {
 }
 
 func deleteApplication(opts deleteApplicationOpts) error {
-	spin, err := spinner.New("deleting", opts.Meta.Out)
+	spin, err := spinner.New("", io.Discard)
 	if err != nil {
 		return fmt.Errorf("creating spinner: %w", err)
 	}

--- a/pkg/controller/cluster/reconciliation/application_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/application_reconciler.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/oslokommune/okctl/pkg/logging"
+
 	"github.com/oslokommune/okctl/cmd/okctl/handlers"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 	"github.com/oslokommune/okctl/pkg/spinner"
@@ -17,6 +19,8 @@ import (
 
 // Reconcile knows how to do what is necessary to ensure the desired state is achieved
 func (c applicationReconciler) Reconcile(ctx context.Context, meta reconciliation.Metadata, state *clientCore.StateHandlers) (reconciliation.Result, error) {
+	log := logging.GetLogger("reconciler/application", "Reconcile")
+
 	action, err := c.determineAction(meta, state)
 	if err != nil {
 		return reconciliation.Result{}, fmt.Errorf("determining course of action: %w", err)
@@ -40,6 +44,8 @@ func (c applicationReconciler) Reconcile(ctx context.Context, meta reconciliatio
 		if err != nil {
 			return reconciliation.Result{}, fmt.Errorf("listing applications: %w", err)
 		}
+
+		log.Debug(fmt.Sprintf("Found %d applications to delete (%+v)", len(applications), applications))
 
 		for _, app := range applications {
 			err = deleteApplication(deleteApplicationOpts{

--- a/pkg/controller/cluster/reconciliation/application_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/application_reconciler.go
@@ -1,0 +1,77 @@
+package reconciliation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oslokommune/okctl/pkg/lib/paths"
+
+	clientCore "github.com/oslokommune/okctl/pkg/client/core"
+	"github.com/oslokommune/okctl/pkg/controller/common/reconciliation"
+)
+
+// Reconcile knows how to do what is necessary to ensure the desired state is achieved
+func (c applicationReconciler) Reconcile(_ context.Context, meta reconciliation.Metadata, state *clientCore.StateHandlers) (reconciliation.Result, error) {
+	action, err := c.determineAction(meta, state)
+	if err != nil {
+		return reconciliation.Result{}, fmt.Errorf("determining course of action: %w", err)
+	}
+
+	switch action {
+	case reconciliation.ActionCreate:
+		absoluteIACRepositoryRootDirectoryPath, err := paths.GetAbsoluteIACRepositoryRootDirectory()
+		if err != nil {
+			return reconciliation.Result{}, fmt.Errorf("acquiring absolute IAC repository directory path: %w", err)
+		}
+
+		err = state.Application.Initialize(*meta.ClusterDeclaration, absoluteIACRepositoryRootDirectoryPath)
+		if err != nil {
+			return reconciliation.Result{}, fmt.Errorf("initializing applications state: %w", err)
+		}
+
+		return reconciliation.Result{Requeue: false}, nil
+	case reconciliation.ActionDelete:
+		return reconciliation.Result{Requeue: false}, nil
+	}
+
+	return reconciliation.NoopWaitIndecisiveHandler(action)
+}
+
+// determineAction knows how to determine if a resource should be created, deleted or updated
+func (c applicationReconciler) determineAction(meta reconciliation.Metadata, state *clientCore.StateHandlers) (reconciliation.Action, error) {
+	userIndication := reconciliation.DetermineUserIndication(meta, true)
+
+	hasCluster, err := state.Cluster.HasCluster(meta.ClusterDeclaration.Metadata.Name)
+	if err != nil {
+		return "", fmt.Errorf("checking cluster existence: %w", err)
+	}
+
+	switch userIndication {
+	case reconciliation.ActionCreate:
+		if !hasCluster {
+			return reconciliation.ActionWait, nil
+		}
+
+		return reconciliation.ActionCreate, nil
+	case reconciliation.ActionDelete:
+		if !hasCluster {
+			return reconciliation.ActionNoop, nil
+		}
+
+		return reconciliation.ActionDelete, nil
+	}
+
+	return "", reconciliation.ErrIndecisive
+}
+
+// String returns a descriptive identifier of the domain that this reconciler represents
+func (c applicationReconciler) String() string {
+	return "Applications"
+}
+
+// NewApplicationReconciler returns an initialized application reconciler
+func NewApplicationReconciler() reconciliation.Reconciler {
+	return &applicationReconciler{}
+}
+
+type applicationReconciler struct{}

--- a/pkg/controller/cluster/reconciliation/argocd_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/argocd_reconciler.go
@@ -142,6 +142,17 @@ func (z *argocdReconciler) determineAction(meta reconciliation.Metadata, state *
 			return reconciliation.ActionNoop, nil
 		}
 
+		ok, err := reconciliation.AssertDependencyExistence(false,
+			generateHasApplicationsTest(state),
+		)
+		if err != nil {
+			return "", fmt.Errorf("checking dependencies: %w", err)
+		}
+
+		if !ok {
+			return reconciliation.ActionWait, nil
+		}
+
 		return reconciliation.ActionDelete, nil
 	}
 

--- a/pkg/controller/cluster/reconciliation/argocd_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/argocd_reconciler_test.go
@@ -2,6 +2,7 @@ package reconciliation
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/oslokommune/okctl/pkg/github"
@@ -115,6 +116,7 @@ func TestArgocdReconciler_Reconcile(t *testing.T) {
 					exists:      tc.withPrimaryHostedZoneExists,
 					isDelegated: tc.withPrimaryHostedZoneDelegated,
 				},
+				Application: &mockApplicationState{existingApplications: 0},
 			}
 
 			reconciler := NewArgocdReconciler(
@@ -223,4 +225,27 @@ func (m mockArgoIdentityManagerState) GetIdentityPoolUser(_ string) (*client.Ide
 func (m mockArgoIdentityManagerState) RemoveIdentityPoolUser(_ string) error { panic("implement me") }
 func (m mockArgoIdentityManagerState) GetIdentityPoolUsers() ([]client.IdentityPoolUser, error) {
 	panic("implement me")
+}
+
+type mockApplicationState struct {
+	existingApplications int
+}
+
+func (m mockApplicationState) Put(v1alpha1.Application) error            { panic("implement me") }
+func (m mockApplicationState) Get(string) (v1alpha1.Application, error)  { panic("implement me") }
+func (m mockApplicationState) Delete(string) error                       { panic("implement me") }
+func (m mockApplicationState) Initialize(v1alpha1.Cluster, string) error { panic("implement me") }
+
+func (m mockApplicationState) List() ([]v1alpha1.Application, error) {
+	apps := make([]v1alpha1.Application, m.existingApplications)
+
+	for i := 0; i < m.existingApplications; i++ {
+		apps[i] = v1alpha1.Application{
+			Metadata: v1alpha1.ApplicationMeta{
+				Name: fmt.Sprintf("mockApp%d", i+1),
+			},
+		}
+	}
+
+	return apps, nil
 }

--- a/pkg/controller/cluster/reconciliation/argocd_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/argocd_reconciler_test.go
@@ -22,6 +22,7 @@ func TestArgocdReconciler_Reconcile(t *testing.T) {
 		withClusterExists              bool
 		withPrimaryHostedZoneExists    bool
 		withPrimaryHostedZoneDelegated bool
+		withApplications               int
 		expectCreations                int
 		expectDeletions                int
 		withPurge                      bool
@@ -97,6 +98,17 @@ func TestArgocdReconciler_Reconcile(t *testing.T) {
 			expectCreations:                0,
 			expectDeletions:                1,
 		},
+		{
+			name:                           "Should do nothing when applications exist",
+			withApplications:               1,
+			withPurge:                      true,
+			withAlreadyExists:              true,
+			withClusterExists:              true,
+			withPrimaryHostedZoneExists:    true,
+			withPrimaryHostedZoneDelegated: true,
+			expectCreations:                0,
+			expectDeletions:                0,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -116,7 +128,7 @@ func TestArgocdReconciler_Reconcile(t *testing.T) {
 					exists:      tc.withPrimaryHostedZoneExists,
 					isDelegated: tc.withPrimaryHostedZoneDelegated,
 				},
-				Application: &mockApplicationState{existingApplications: 0},
+				Application: &mockApplicationState{existingApplications: tc.withApplications},
 			}
 
 			reconciler := NewArgocdReconciler(

--- a/pkg/controller/cluster/reconciliation/awsloadbalancercontroller_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/awsloadbalancercontroller_reconciler.go
@@ -106,6 +106,7 @@ func (z *awsLoadBalancerControllerReconciler) determineAction(
 		dependenciesReady, err := reconciliation.AssertDependencyExistence(false,
 			state.ArgoCD.HasArgoCD,
 			state.Monitoring.HasKubePromStack,
+			generateHasApplicationsTest(state),
 		)
 		if err != nil {
 			return reconciliation.ActionNoop, fmt.Errorf("checking deletion dependencies: %w", err)

--- a/pkg/controller/cluster/reconciliation/awsloadbalancercontroller_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/awsloadbalancercontroller_reconciler_test.go
@@ -91,6 +91,7 @@ func TestAWSLoadBalancerControllerReconciler(t *testing.T) {
 				AWSLoadBalancerController: &mockAWSLoadBalancerState{exists: tc.withComponentExists},
 				ArgoCD:                    &mockArgoCDState{exists: !tc.withDeleteDependenciesMet},
 				Monitoring:                &mockMonitoringState{exists: !tc.withDeleteDependenciesMet},
+				Application:               &mockApplicationState{existingApplications: 0},
 			}
 
 			reconciler := NewAWSLoadBalancerControllerReconciler(&mockAWSLoadBalancerControllerService{

--- a/pkg/controller/cluster/reconciliation/awsloadbalancercontroller_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/awsloadbalancercontroller_reconciler_test.go
@@ -20,6 +20,7 @@ func TestAWSLoadBalancerControllerReconciler(t *testing.T) {
 		withComponentExists       bool
 		withCreateDependenciesMet bool
 		withDeleteDependenciesMet bool
+		withApplications          int
 		expectCreations           int
 		expectDeletions           int
 	}{
@@ -74,6 +75,17 @@ func TestAWSLoadBalancerControllerReconciler(t *testing.T) {
 			expectCreations:           0,
 			expectDeletions:           1,
 		},
+		{
+			name:                      "Should do nothing if applications exist",
+			withApplications:          1,
+			withPurge:                 true,
+			withComponentFlag:         true,
+			withComponentExists:       true,
+			withCreateDependenciesMet: true,
+			withDeleteDependenciesMet: true,
+			expectCreations:           0,
+			expectDeletions:           0,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -91,7 +103,7 @@ func TestAWSLoadBalancerControllerReconciler(t *testing.T) {
 				AWSLoadBalancerController: &mockAWSLoadBalancerState{exists: tc.withComponentExists},
 				ArgoCD:                    &mockArgoCDState{exists: !tc.withDeleteDependenciesMet},
 				Monitoring:                &mockMonitoringState{exists: !tc.withDeleteDependenciesMet},
-				Application:               &mockApplicationState{existingApplications: 0},
+				Application:               &mockApplicationState{existingApplications: tc.withApplications},
 			}
 
 			reconciler := NewAWSLoadBalancerControllerReconciler(&mockAWSLoadBalancerControllerService{

--- a/pkg/controller/cluster/reconciliation/blockstorage_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/blockstorage_reconciler.go
@@ -90,6 +90,17 @@ func (z *blockstorageReconciler) determineAction(_ context.Context, meta reconci
 			return reconciliation.ActionNoop, nil
 		}
 
+		ok, err := reconciliation.AssertDependencyExistence(false,
+			generateHasApplicationsTest(state),
+		)
+		if err != nil {
+			return "", fmt.Errorf("checking dependencies: %w", err)
+		}
+
+		if !ok {
+			return reconciliation.ActionWait, nil
+		}
+
 		return reconciliation.ActionDelete, nil
 	}
 

--- a/pkg/controller/cluster/reconciliation/blockstorage_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/blockstorage_reconciler_test.go
@@ -77,6 +77,7 @@ func TestBlockstorageReconciler(t *testing.T) {
 			state := &clientCore.StateHandlers{
 				Cluster:      &mockClusterState{exists: tc.withDependenciesMet},
 				Blockstorage: &mockBlockstorageState{exists: tc.withComponentExists},
+				Application:  &mockApplicationState{existingApplications: 0},
 			}
 
 			reconciler := NewBlockstorageReconciler(&mockBlockstorageService{

--- a/pkg/controller/cluster/reconciliation/blockstorage_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/blockstorage_reconciler_test.go
@@ -63,6 +63,16 @@ func TestBlockstorageReconciler(t *testing.T) {
 			expectCreations:     0,
 			expectDeletions:     1,
 		},
+		{
+			name:                "Should do nothing if applications exist during purge",
+			withApplications:    1,
+			withPurge:           true,
+			withComponentFlag:   true,
+			withComponentExists: true,
+			withDependenciesMet: true,
+			expectCreations:     0,
+			expectDeletions:     0,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -77,7 +87,7 @@ func TestBlockstorageReconciler(t *testing.T) {
 			state := &clientCore.StateHandlers{
 				Cluster:      &mockClusterState{exists: tc.withDependenciesMet},
 				Blockstorage: &mockBlockstorageState{exists: tc.withComponentExists},
-				Application:  &mockApplicationState{existingApplications: 0},
+				Application:  &mockApplicationState{existingApplications: tc.withApplications},
 			}
 
 			reconciler := NewBlockstorageReconciler(&mockBlockstorageService{

--- a/pkg/controller/cluster/reconciliation/cluster_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/cluster_reconciler.go
@@ -170,6 +170,7 @@ func (z *clusterReconciler) hasDeleteDependenciesMet(state *clientCore.StateHand
 		state.Loki.HasLoki,
 		state.Promtail.HasPromtail,
 		state.Tempo.HasTempo,
+		generateHasApplicationsTest(state),
 	)
 	if err != nil {
 		return false, fmt.Errorf("asserting existence: %w", err)

--- a/pkg/controller/cluster/reconciliation/cluster_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/cluster_reconciler_test.go
@@ -28,6 +28,7 @@ func TestClusterReconciler(t *testing.T) {
 		withCreationDependenciesMet bool
 		withDeletionDependenciesMet bool
 		withComponentExists         bool
+		withApplications            int
 
 		expectCreations int
 		expectDeletions int
@@ -66,6 +67,16 @@ func TestClusterReconciler(t *testing.T) {
 			expectCreations:             0,
 			expectDeletions:             0,
 		},
+		{
+			name: "Should wait when purge and applications exist",
+
+			withApplications:            1,
+			withPurge:                   true,
+			withComponentExists:         true,
+			withDeletionDependenciesMet: true,
+			expectCreations:             0,
+			expectDeletions:             0,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -93,7 +104,7 @@ func TestClusterReconciler(t *testing.T) {
 				Loki:                      &mockLokiState{exists: !tc.withDeletionDependenciesMet},
 				Promtail:                  &mockPromtailState{exists: !tc.withDeletionDependenciesMet},
 				Tempo:                     &mockTempoState{exists: !tc.withDeletionDependenciesMet},
-				Application:               &mockApplicationState{existingApplications: 0},
+				Application:               &mockApplicationState{existingApplications: tc.withApplications},
 			}
 
 			reconciler := NewClusterReconciler(

--- a/pkg/controller/cluster/reconciliation/cluster_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/cluster_reconciler_test.go
@@ -93,6 +93,7 @@ func TestClusterReconciler(t *testing.T) {
 				Loki:                      &mockLokiState{exists: !tc.withDeletionDependenciesMet},
 				Promtail:                  &mockPromtailState{exists: !tc.withDeletionDependenciesMet},
 				Tempo:                     &mockTempoState{exists: !tc.withDeletionDependenciesMet},
+				Application:               &mockApplicationState{existingApplications: 0},
 			}
 
 			reconciler := NewClusterReconciler(

--- a/pkg/controller/cluster/reconciliation/externaldns_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/externaldns_reconciler.go
@@ -113,6 +113,7 @@ func (z *externalDNSReconciler) determineAction(meta reconciliation.Metadata, st
 		dependenciesReady, err := reconciliation.AssertDependencyExistence(false,
 			state.ArgoCD.HasArgoCD,
 			state.Monitoring.HasKubePromStack,
+			generateHasApplicationsTest(state),
 		)
 		if err != nil {
 			return reconciliation.ActionNoop, fmt.Errorf("checking dependencies: %w", err)

--- a/pkg/controller/cluster/reconciliation/externaldns_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/externaldns_reconciler_test.go
@@ -105,6 +105,7 @@ func TestExternalDNSReconciler(t *testing.T) {
 
 				Cluster:     &mockClusterState{exists: tc.withClusterExists},
 				ExternalDNS: &mockExternalDNSState{exists: tc.withComponentExists},
+				Application: &mockApplicationState{existingApplications: 0},
 				Domain: &mockDomainState{
 					exists:      tc.withCreateDependenciesMet,
 					isDelegated: tc.withCreateDependenciesMet,

--- a/pkg/controller/cluster/reconciliation/externaldns_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/externaldns_reconciler_test.go
@@ -15,6 +15,7 @@ import (
 func TestExternalDNSReconciler(t *testing.T) {
 	testCases := []struct {
 		name                      string
+		withApplications          int
 		withPurge                 bool
 		withComponentFlag         bool
 		withComponentExists       bool
@@ -88,6 +89,17 @@ func TestExternalDNSReconciler(t *testing.T) {
 			expectCreations:           0,
 			expectDeletions:           0,
 		},
+		{
+			name:                      "Should wait on purge and applications exist",
+			withPurge:                 true,
+			withApplications:          1,
+			withComponentExists:       true,
+			withComponentFlag:         true,
+			withDeleteDependenciesMet: true,
+			withClusterExists:         true,
+			expectCreations:           0,
+			expectDeletions:           0,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -105,7 +117,7 @@ func TestExternalDNSReconciler(t *testing.T) {
 
 				Cluster:     &mockClusterState{exists: tc.withClusterExists},
 				ExternalDNS: &mockExternalDNSState{exists: tc.withComponentExists},
-				Application: &mockApplicationState{existingApplications: 0},
+				Application: &mockApplicationState{existingApplications: tc.withApplications},
 				Domain: &mockDomainState{
 					exists:      tc.withCreateDependenciesMet,
 					isDelegated: tc.withCreateDependenciesMet,

--- a/pkg/controller/cluster/reconciliation/postgres_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/postgres_reconciler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/oslokommune/okctl/pkg/config/constant"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
@@ -96,7 +98,7 @@ func TestPostgresReconciler(t *testing.T) {
 
 			reconciler := NewPostgresReconciler(&mockPostgresService{
 				creationBump: func() { creations++ },
-				deletionBump: func() { deletions++ },
+				deletionBump: func(string) { deletions++ },
 			})
 
 			meta := reconciliation.Metadata{
@@ -120,9 +122,165 @@ func TestPostgresReconciler(t *testing.T) {
 	}
 }
 
+//nolint:funlen
+func TestDeletePostgresWithExistingApp(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		withApplications []v1alpha1.Application
+		withExistingDBs  []v1alpha1.ClusterDatabasesPostgres
+
+		expectDeletions int
+	}{
+		{
+			name: "Should do nothing with one application depending on one database",
+
+			withApplications: []v1alpha1.Application{
+				{
+					Postgres: "mockdb",
+				},
+			},
+			withExistingDBs: []v1alpha1.ClusterDatabasesPostgres{
+				{
+					Name:      "mockdb",
+					User:      "postgres",
+					Namespace: "dbdetails",
+				},
+			},
+			expectDeletions: 0,
+		},
+		{
+			name: "Should delete one database when two are configured and only one dependecy",
+
+			withApplications: []v1alpha1.Application{
+				{
+					Postgres: "mockdb",
+				},
+				{
+					Postgres: "",
+				},
+			},
+			withExistingDBs: []v1alpha1.ClusterDatabasesPostgres{
+				{
+					Name:      "mockdb",
+					User:      "postgres",
+					Namespace: "dbdetails",
+				},
+				{
+					Name:      "secondmockdb",
+					User:      "postgres",
+					Namespace: "dbdetails",
+				},
+			},
+			expectDeletions: 1,
+		},
+		{
+			name: "Should delete everything if no apps are dependent",
+
+			withApplications: []v1alpha1.Application{
+				{
+					Postgres: "",
+				},
+				{
+					Postgres: "",
+				},
+			},
+			withExistingDBs: []v1alpha1.ClusterDatabasesPostgres{
+				{
+					Name:      "mockdb",
+					User:      "postgres",
+					Namespace: "dbdetails",
+				},
+				{
+					Name:      "mockdb2",
+					User:      "postgres",
+					Namespace: "dbdetails",
+				},
+				{
+					Name:      "mockdb3",
+					User:      "postgres",
+					Namespace: "dbdetails",
+				},
+			},
+			expectDeletions: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			deletions := 0
+
+			meta := reconciliation.Metadata{
+				Purge: true,
+				ClusterDeclaration: &v1alpha1.Cluster{
+					Databases: &v1alpha1.ClusterDatabases{Postgres: tc.withExistingDBs},
+				},
+			}
+
+			existingDbs := make([]*client.PostgresDatabase, len(tc.withExistingDBs))
+
+			for index, db := range tc.withExistingDBs {
+				existingDbs[index] = &client.PostgresDatabase{
+					ApplicationName: db.Name,
+					UserName:        db.User,
+					Namespace:       db.Namespace,
+				}
+			}
+
+			state := &clientCore.StateHandlers{
+				Vpc:         &mockVPCState{exists: true},
+				Component:   &mockComponentState{databases: existingDbs},
+				Application: &mockPgAppState{applications: tc.withApplications},
+			}
+
+			reconciler := NewPostgresReconciler(&mockPostgresService{
+				deletionBump: func(name string) {
+					newExistingDbs := make([]*client.PostgresDatabase, 0)
+
+					for _, db := range existingDbs {
+						if db.ApplicationName != name {
+							newExistingDbs = append(newExistingDbs, db)
+						} else {
+							deletions++
+						}
+					}
+
+					existingDbs = newExistingDbs
+				},
+			})
+
+			for i := 0; i < constant.DefaultMaxReconciliationRequeues; i++ {
+				result, err := reconciler.Reconcile(context.Background(), meta, state)
+				assert.NoError(t, err)
+
+				if result.Requeue == false {
+					break
+				}
+			}
+
+			assert.Equal(t, tc.expectDeletions, deletions)
+		})
+	}
+}
+
+type mockPgAppState struct {
+	applications []v1alpha1.Application
+}
+
+func (m mockPgAppState) Initialize(v1alpha1.Cluster, string) error { panic("implement me") }
+func (m mockPgAppState) Put(v1alpha1.Application) error            { panic("implement me") }
+func (m mockPgAppState) Get(string) (v1alpha1.Application, error)  { panic("implement me") }
+func (m mockPgAppState) Delete(string) error                       { panic("implement me") }
+func (m mockPgAppState) List() ([]v1alpha1.Application, error) {
+	return m.applications, nil
+}
+
 type mockPostgresService struct {
 	creationBump func()
-	deletionBump func()
+	deletionBump func(string)
 }
 
 func (m mockPostgresService) CreatePostgresDatabase(_ context.Context, _ client.CreatePostgresDatabaseOpts) (*client.PostgresDatabase, error) {
@@ -131,8 +289,8 @@ func (m mockPostgresService) CreatePostgresDatabase(_ context.Context, _ client.
 	return nil, nil
 }
 
-func (m mockPostgresService) DeletePostgresDatabase(_ context.Context, _ client.DeletePostgresDatabaseOpts) error {
-	m.deletionBump()
+func (m mockPostgresService) DeletePostgresDatabase(_ context.Context, opts client.DeletePostgresDatabaseOpts) error {
+	m.deletionBump(opts.ApplicationName)
 
 	return nil
 }

--- a/pkg/controller/cluster/reconciliation/postgres_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/postgres_reconciler_test.go
@@ -106,8 +106,9 @@ func TestPostgresReconciler(t *testing.T) {
 			}
 
 			state := &clientCore.StateHandlers{
-				Vpc:       &mockVPCState{exists: tc.withVPCExists},
-				Component: &mockComponentState{databases: tc.withExistingDBs},
+				Vpc:         &mockVPCState{exists: tc.withVPCExists},
+				Component:   &mockComponentState{databases: tc.withExistingDBs},
+				Application: &mockApplicationState{existingApplications: 0},
 			}
 
 			_, err := reconciler.Reconcile(context.Background(), meta, state)

--- a/pkg/controller/cluster/reconciliation/test_helpers.go
+++ b/pkg/controller/cluster/reconciliation/test_helpers.go
@@ -24,6 +24,7 @@ type generalizedTestCase struct {
 	withComponentFlag   bool
 	withComponentExists bool
 	withDependenciesMet bool
+	withApplications    int
 	expectCreations     int
 	expectDeletions     int
 }

--- a/pkg/controller/common/reconciliation/helpers.go
+++ b/pkg/controller/common/reconciliation/helpers.go
@@ -30,3 +30,15 @@ func DetermineUserIndication(metadata Metadata, componentFlag bool) Action {
 func DefaultDelayFunction() {
 	time.Sleep(constant.DefaultReconciliationLoopDelayDuration)
 }
+
+// NoopWaitIndecisiveHandler handles NOOP, Wait and indecisiveness in a streamlined way
+func NoopWaitIndecisiveHandler(action Action) (Result, error) {
+	switch action {
+	case ActionWait:
+		return Result{Requeue: true}, nil
+	case ActionNoop:
+		return Result{Requeue: false}, nil
+	default:
+		return Result{}, ErrIndecisive
+	}
+}

--- a/pkg/lib/doc.go
+++ b/pkg/lib/doc.go
@@ -1,0 +1,4 @@
+/*
+Package lib contains standalone packages used in more than one feature
+*/
+package lib

--- a/pkg/lib/paths/api.go
+++ b/pkg/lib/paths/api.go
@@ -1,0 +1,57 @@
+/*
+Package paths api.go exposes commonly used paths throughout okctl.
+
+If you require the absolute path to somewhere, combine the relative helper with GetABsoluteIACRepositoryRootDirectory
+using path.Join.
+*/
+package paths
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path"
+
+	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
+)
+
+// GetAbsoluteIACRepositoryRootDirectory returns the absolute path of the repository root no matter what the current
+// working directory of the repository the user is in
+// I.e.: /home/olly/.../team-iac/
+func GetAbsoluteIACRepositoryRootDirectory() (string, error) {
+	result, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("getting repository root directory: %w", err)
+	}
+
+	pathAsString := string(bytes.Trim(result, "\n"))
+
+	return pathAsString, nil
+}
+
+// GetRelativeClusterOutputDirectory returns the relative path of the cluster output directory
+// I.e.: /<output directory>/<cluster name>/
+func GetRelativeClusterOutputDirectory(clusterManifest v1alpha1.Cluster) string {
+	return path.Join(clusterManifest.Github.OutputPath, clusterManifest.Metadata.Name)
+}
+
+// GetRelativeClusterApplicationsDirectory returns the relative path of the cluster specific ArgoCD applications
+// manifest directory
+// I.e.: /<output directory>/<cluster name>/argocd/applications/
+func GetRelativeClusterApplicationsDirectory(clusterManifest v1alpha1.Cluster) string {
+	return path.Join(
+		GetRelativeClusterOutputDirectory(clusterManifest),
+		DefaultClusterArgoCDConfigDirectoryName,
+		DefaultClusterArgoCDApplicationsDirectoryName,
+	)
+}
+
+// GetRelativeClusterOkctlConfigurationDirectory returns the relative path of the okctl configuration directory. This is
+// the directory where we place configuration applied to the environment that okctl manage.
+// I.e.: /<output directory>/<cluster name>/okctl/
+func GetRelativeClusterOkctlConfigurationDirectory(clusterManifest v1alpha1.Cluster) string {
+	return path.Join(
+		GetRelativeClusterOutputDirectory(clusterManifest),
+		DefaultClusterOkctlConfigurationDirectoryName,
+	)
+}

--- a/pkg/lib/paths/constants.go
+++ b/pkg/lib/paths/constants.go
@@ -1,0 +1,20 @@
+package paths
+
+const (
+	// DefaultFilePermissions defines the default permission bits for okctl created files.
+	// 0o600 means read and write for the file/folder owner only.
+	DefaultFilePermissions = 0o600
+	// DefaultDirectoryPermissions defines the default permission bits for okctl created directories.
+	// 0o700 means read, write and execute for the file/folder owner only. Execute as a directory permission means
+	// traverse the files and folders inside.
+	DefaultDirectoryPermissions = 0o700
+	// DefaultClusterArgoCDConfigDirectoryName defines the name of the directory where we configure ArgoCD for a
+	// specific environment
+	DefaultClusterArgoCDConfigDirectoryName = "argocd"
+	// DefaultClusterArgoCDApplicationsDirectoryName defines the name of the directory where we place all ArgoCD
+	// application manifests that should be automatically applied
+	DefaultClusterArgoCDApplicationsDirectoryName = "applications"
+	// DefaultClusterOkctlConfigurationDirectoryName defines the name of the directory where we place configuration files
+	// that okctl manage
+	DefaultClusterOkctlConfigurationDirectoryName = "okctl"
+)

--- a/pkg/lib/paths/doc.go
+++ b/pkg/lib/paths/doc.go
@@ -1,0 +1,4 @@
+/*
+Package paths knows how to consistently generate commonly used paths for files and folders
+*/
+package paths

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -171,7 +171,7 @@ func (o *Okctl) StateHandlers(nodes *clientCore.StateNodes) *clientCore.StateHan
 		Blockstorage:              direct.NewBlockstorageState(o.Declaration.Metadata, o.toolChain.Helm),
 		ExternalSecrets:           direct.NewExternalSecretsState(o.Declaration.Metadata, o.toolChain.Helm),
 		Upgrade:                   storm.NewUpgradesState(nodes.Upgrade),
-		Application:               crd.NewApplicationState(kubectlClient),
+		Application:               crd.NewApplicationState(o.FileSystem, kubectlClient),
 	}
 }
 
@@ -441,11 +441,6 @@ func (o *Okctl) initialise() error {
 		return err
 	}
 
-	err = o.initializeState()
-	if err != nil {
-		return fmt.Errorf("initializing state: %w", err)
-	}
-
 	return nil
 }
 
@@ -623,18 +618,6 @@ func (o *Okctl) initialiseProviders() error {
 	err = o.newCloudProvider()
 	if err != nil {
 		return err
-	}
-
-	return nil
-}
-
-// initializeState knows how to ensure state is initialized
-func (o *Okctl) initializeState() error {
-	stateHandlers := o.StateHandlers(o.StateNodes())
-
-	err := stateHandlers.Application.Initialize()
-	if err != nil {
-		return fmt.Errorf("initializing application state: %w", err)
 	}
 
 	return nil

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -339,6 +339,7 @@ func (o *Okctl) ClientServices(handlers *clientCore.StateHandlers) (*clientCore.
 
 	applicationService := clientCore.NewApplicationService(
 		o.FileSystem,
+		handlers.Application,
 		o.toolChain.Kubectl,
 		applicationManifestService,
 		absoluteRepositoryPath,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR contains primarily two additions;

### A way to track applications
- Adds a state client to handle CRUD for application custom resource definitions
- Adds a `/infrastructure/<cluster>/okctl` dir and an accompanying argo app manifest to track the folder so we can add okctl managed stuff there
- Adds an application CRD in the `/infrastructure/<cluster/okctl` dir which allows for `kubectl apply -f` on okctl application manifests

### A way to delete applications
- Adds an application reconciler to the cluster reconciliation scheduler which initialises state and handles listing and deleting applications

### Bonus:
- Fixes base kustomization.yaml resources list often changing order for list elements
- Removes some leftover things from http server removal

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM303](https://trello.com/c/aTG8Bdgr)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
To test everything but reconciler dependencies, you can:
1. Go to line 144 in `cmd/okctl/apply_cluster.go` and delete all reconcilers except ApplicationReconciler
2. Go to line 94 in `cmd/okctl/delete.go` and delete all reconcilers except ApplicationReconciler
3. Go to line 111 in `cmd/okctl/delete.go` and delete the `PurgeRemoteState` call
4. Run `okctl apply cluster` to set up the CRD and initialize state
5. Add a few apps with `okctl apply application`
6. (with all reconcilers except ApplicationReconciler disabled) Run `okctl delete cluster`
7. Verify all apps are deleted

To include reconciler dependencies, do everything mentioned above except #1-3. This **will** delete your cluster

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
