### PR TITLE
KM615 🐛 Fix kubeconfig not using absolute path to aws-iam-authenticator

### DIFF
--- a/docs/release_notes/0.0.93.md
+++ b/docs/release_notes/0.0.93.md
@@ -6,6 +6,8 @@ KM303 ✅ Add delete application (#910)
 
 ## Bugfixes
 
+KM615 🐛 Fix kubeconfig not using absolute path to aws-iam-authenticator (#924)
+
 ## Changes
 
 ## Other

--- a/pkg/api/core/run/cluster_run.go
+++ b/pkg/api/core/run/cluster_run.go
@@ -94,7 +94,7 @@ func (c *clusterRun) CreateCluster(opts api.ClusterCreateOpts) (*api.Cluster, er
 		return nil, fmt.Errorf("creating the cluster: %w", err)
 	}
 
-	kubeConf, err := kubeconfig.New(cfg, c.cloud).Get()
+	kubeConf, err := kubeconfig.New(a.BinaryPath, cfg, c.cloud).Get()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -41,6 +41,8 @@ func testConfig(t *testing.T) *v1alpha5.ClusterConfig {
 	return conf
 }
 
+const mockawsIAMAuthenticatorPath = "/home/mockuser/.okctl/binaries/aws-iam-authenticator/0.5.3/aws-iam-authenticator"
+
 func TestCreate(t *testing.T) {
 	testCases := []struct {
 		name   string
@@ -58,7 +60,7 @@ func TestCreate(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := clientcmd.Write(kubeconfig.Create("someuser", tc.cfg))
+			got, err := clientcmd.Write(kubeconfig.Create(mockawsIAMAuthenticatorPath, "someuser", tc.cfg))
 			assert.NoError(t, err)
 
 			g := goldie.New(t)
@@ -88,7 +90,7 @@ func TestNew(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := kubeconfig.New(tc.cfg, tc.provider).Get()
+			got, err := kubeconfig.New(mockawsIAMAuthenticatorPath, tc.cfg, tc.provider).Get()
 			if tc.expectErr {
 				assert.Nil(t, got)
 				assert.Error(t, err)

--- a/pkg/kubeconfig/testdata/kubeconf.golden
+++ b/pkg/kubeconfig/testdata/kubeconf.golden
@@ -21,7 +21,7 @@ users:
       - token
       - -i
       - okctl-pro
-      command: aws-iam-authenticator
+      command: /home/mockuser/.okctl/binaries/aws-iam-authenticator/0.5.3/aws-iam-authenticator
       env:
       - name: AWS_STS_REGIONAL_ENDPOINTS
         value: regional

--- a/pkg/kubeconfig/testdata/valid-config.golden
+++ b/pkg/kubeconfig/testdata/valid-config.golden
@@ -21,7 +21,7 @@ users:
       - token
       - -i
       - okctl-pro
-      command: aws-iam-authenticator
+      command: /home/mockuser/.okctl/binaries/aws-iam-authenticator/0.5.3/aws-iam-authenticator
       env:
       - name: AWS_STS_REGIONAL_ENDPOINTS
         value: regional

--- a/pkg/okctl/okctl.go
+++ b/pkg/okctl/okctl.go
@@ -400,6 +400,7 @@ func (o *Okctl) KubeConfigStore() (api.KubeConfigStore, error) {
 
 	return filesystem.NewKubeConfigStore(
 		o.CloudProvider,
+		o.BinariesProvider,
 		constant.DefaultClusterKubeConfig,
 		path.Join(appDir, constant.DefaultCredentialsDirName, o.Declaration.Metadata.Name),
 		o.StateHandlers(o.StateNodes()).Cluster,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Passes the binary provider to the kubeconfig creator and ensures the absolute
    path is used in kubeconfig

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[KM615](https://trello.com/c/y73zZoxa)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
1. `mv ~/.okctl/credentials/<cluster name>/kubeconig{,.old}`
2. Run a command that triggers kubeconfig creation, f.ex `okctl apply cluster`
3. Verify that `~/.okctl/credentials/<cluster name>/kubeconfig`
   `users[].user.exec.command` contains the absolute path to  aws-iam-authenticator.
	It should be something like
	`~/.okctl/binaries/aws-iam-authenticator/0.5.3/aws-iam-authenticator`
	Compare it with `kubeconfig.old` to see the difference.

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
