### PR TITLE
KM646 🐛 Fix getting token when using SSO authentication

### DIFF
--- a/docs/release_notes/0.0.94.md
+++ b/docs/release_notes/0.0.94.md
@@ -4,6 +4,8 @@
 
 ## Bugfixes
 
+KM646 🐛 Fix getting token when using SSO authentication
+
 ## Changes
 KM556 👌 Reworking how PersistentPreRunE() is done (#912)
 

--- a/pkg/clients/kubectl/binary/helpers.go
+++ b/pkg/clients/kubectl/binary/helpers.go
@@ -110,6 +110,7 @@ func (c client) generateEnv() ([]string, error) {
 			constant.DefaultClusterKubeConfig,
 		),
 		"PATH": strings.Join(generatedPaths, ":"),
+		"HOME": homeDir,
 	})
 
 	env = append(env, awsEnvCredentials...)


### PR DESCRIPTION
Add HOME to environment variables when running kubectl.

## Description

When running kubectl, aws-iam-authenticator was unable to find the
AWS configuration files since HOME was not set in the subprocess.

## Motivation and Context

Fixes KM646

## How to prove the effect of this PR?

Set up a new cluster when using AWS SSO for authentication.

## Additional info

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
