### PR TITLE
22Q2-55 ✅ Use TLS 1.2 only for ingresses made by apply application

### DIFF
--- a/docs/release_notes/0.0.104.md
+++ b/docs/release_notes/0.0.104.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+22Q2-55 ✅ Replace TLS 1.0/11 with 1.2 in apply application
+
 ## Bugfixes
 
 ## Changes

--- a/pkg/client/core/testdata/ingress.yaml.golden
+++ b/pkg/client/core/testdata/ingress.yaml.golden
@@ -6,6 +6,7 @@ metadata:
       { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
     kubernetes.io/ingress.class: alb
   name: my-app
   namespace: okctl

--- a/pkg/scaffold/resources/ingress.go
+++ b/pkg/scaffold/resources/ingress.go
@@ -24,6 +24,11 @@ func CreateOkctlIngress(app v1alpha1.Application) (networkingv1beta1.Ingress, er
 	ingress.Annotations["alb.ingress.kubernetes.io/actions.ssl-redirect"] =
 		`{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}`
 
+	// Disable SSL 1.0 and 1.1
+	// https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/ingress/annotations/#ssl-policy
+	// https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html
+	ingress.Annotations["alb.ingress.kubernetes.io/ssl-policy"] = "ELBSecurityPolicy-TLS-1-2-2017-01"
+
 	redirectPath := networkingv1beta1.HTTPIngressPath{
 		Path: "/*",
 		Backend: networkingv1beta1.IngressBackend{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Do not allow TLS 1.0 and 1.1 for ingresses made apply application, by adjusting ingress metadata.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[22Q2-55](https://trello.com/c/MbM4lznT/55-fjerne-tls-10-and-11-for-alb-er)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

* Run `okctl apply application` to create or update an application
* Inspect `ingress.yaml` and verify that it contains the line

```
alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
```
* git commit and push
* apply the k8s manifest (via argocd or manualy)
* Open the ALB in AWS, go to Listeners, and verify that the "Security policy" field contains "ELBSecurityPolicy-TLS-1-2-2017-01".
* Verify that the ingress actually is TLS 1.2 only by installing `sslscan` and run

```sh
sslscan https://my-app.my-cluster.oslo.systems
```

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
