### PR TITLE
22Q2-55 ✅  Use TLS 1.2 only in ArgoCD and Grafana

### DIFF
--- a/pkg/helm/charts/argocd/testdata/argocd-values.yaml.golden
+++ b/pkg/helm/charts/argocd/testdata/argocd-values.yaml.golden
@@ -888,6 +888,7 @@ server:
       alb.ingress.kubernetes.io/healthcheck-path: /healthz
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
       alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Port":"443","StatusCode":"HTTP_301"}}'
+      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
       alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:eu-west-1:123456789012/certificate/12345abc
     # -- Additional ingress labels
     labels: { }

--- a/pkg/helm/charts/argocd/values-template.yaml
+++ b/pkg/helm/charts/argocd/values-template.yaml
@@ -888,6 +888,7 @@ server:
       alb.ingress.kubernetes.io/healthcheck-path: /healthz
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
       alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Port":"443","StatusCode":"HTTP_301"}}'
+      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
       alb.ingress.kubernetes.io/certificate-arn: {{ .CertificateARN }}
     # -- Additional ingress labels
     labels: { }

--- a/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
+++ b/pkg/helm/charts/kubepromstack/testdata/values.yml.golden
@@ -625,6 +625,7 @@ grafana:
       alb.ingress.kubernetes.io/healthcheck-path: /api/health
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
       alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
       alb.ingress.kubernetes.io/certificate-arn: arn::1234567890/certificate/fake
 
     ## Labels to be added to the Ingress

--- a/pkg/helm/charts/kubepromstack/values.yaml
+++ b/pkg/helm/charts/kubepromstack/values.yaml
@@ -625,6 +625,7 @@ grafana:
       alb.ingress.kubernetes.io/healthcheck-path: /api/health
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
       alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
       alb.ingress.kubernetes.io/certificate-arn: {{.GrafanaCertificateARN}}
 
     ## Labels to be added to the Ingress


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Disables TLS 1.0 and 1.1 in ArgoCD and Grafana, leaving 1.2 to be used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[22Q2-55](https://trello.com/c/MbM4lznT/55-fjerne-tls-10-and-11-for-alb-er)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

Fire up a new cluster. Verify that endpoints for argocd and grafana only supports TLS 1.2. See steps here for sslscan to figure out how: #1003 

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
