### PR TITLE
22Q2-2 🐛 Fix setup MFA breaking due to grafana client ssm parameter

### DIFF
--- a/pkg/cognito/mfa_test.go
+++ b/pkg/cognito/mfa_test.go
@@ -1,0 +1,82 @@
+package cognito
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRelevantUserPoolClient(t *testing.T) {
+	testCases := []struct {
+		name         string
+		withClients  []string
+		expectClient string
+	}{
+		{
+			name: "Should return the argocd client in an expected okctl setup",
+			withClients: []string{
+				"okctl-mock-cluster-argocd",
+				"okctl-mock-cluster-grafana",
+			},
+			expectClient: "okctl-mock-cluster-argocd",
+		},
+		{
+			name: "Should return the argocd client in a strange setup with a gazzilion clients",
+			withClients: []string{
+				"okctl-mock-cluster-client1",
+				"okctl-mock-cluster-grafana",
+				"okctl-mock-cluster-client2",
+				"okctl-mock-cluster-client3",
+				"okctl-mock-cluster-argocd",
+				"okctl-mock-cluster-client4",
+				"okctl-mock-cluster-client5",
+			},
+			expectClient: "okctl-mock-cluster-argocd",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := getRelevantUserPoolClient(
+				context.Background(),
+				&mockCognitoIdentityProviderAPI{clients: tc.withClients},
+				"mock-userpool-id",
+			)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.expectClient, *result.ClientName)
+		})
+	}
+}
+
+type mockCognitoIdentityProviderAPI struct {
+	clients []string
+}
+
+func (m mockCognitoIdentityProviderAPI) ListUserPoolClientsWithContext(
+	_ aws.Context,
+	_ *cognitoidentityprovider.ListUserPoolClientsInput,
+	_ ...request.Option,
+) (*cognitoidentityprovider.ListUserPoolClientsOutput, error) {
+	clients := make([]*cognitoidentityprovider.UserPoolClientDescription, len(m.clients))
+
+	for index, name := range m.clients {
+		clients[index] = &cognitoidentityprovider.UserPoolClientDescription{
+			ClientId:   aws.String(name),
+			ClientName: aws.String(name),
+			UserPoolId: aws.String("mock-user-pool-id"),
+		}
+	}
+
+	return &cognitoidentityprovider.ListUserPoolClientsOutput{
+		UserPoolClients: clients,
+	}, nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Ensures that the user pool client used to setup the MFA device is the ArgoCD
    client

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The ArgoCD user pool client secret uses a 
`/okctl/cluster name/component/client_secret` format, but the Grafana user
pool client secret uses a `/okctl/cluster name/client-secret` format. This
inconsistency breaks retrieving a random client secret from the parameter store.

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
First, verify that the `setup-mfa` command runs successfully with only the
ArgoCD user pool client by:
1. Disable Grafana by setting `integrations.kubePromStack` to false and running
    `okctl apply cluster`
2. Verify that `okctl setup-mfa` works as expected.

Then verify that it breaks when ArgoCD user pool client is not available by:
1. Set `integrations.argocd` to false, and run `okctl apply cluster`. 
2. Verify that `okctl setup-mfa` breaks 

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
