### PR TITLE
🐛 Fix broken SSM parameter path construction

### DIFF
--- a/docs/release_notes/0.0.105.md
+++ b/docs/release_notes/0.0.105.md
@@ -4,6 +4,8 @@
 
 ## Bugfixes
 
+🐛 Fix broken SSM parameter path construction
+
 ## Changes
 
 ## Other

--- a/docs/release_notes/0.0.105.md
+++ b/docs/release_notes/0.0.105.md
@@ -4,7 +4,7 @@
 
 ## Bugfixes
 
-🐛 Fix broken SSM parameter path construction
+#1034 🐛 Fix broken SSM parameter path construction
 
 ## Changes
 

--- a/pkg/cognito/mfa.go
+++ b/pkg/cognito/mfa.go
@@ -26,7 +26,6 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
-	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider/cognitoidentityprovideriface"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 )
 
@@ -94,7 +93,7 @@ func acquireSession(opts RegisterMFADeviceOpts) (string, error) {
 	return *initiateAuthResult.Session, nil
 }
 
-func getCognitoClientForCluster(ctx context.Context, provider cognitoidentityprovideriface.CognitoIdentityProviderAPI, cluster v1alpha1.Cluster) (userPoolClient, error) {
+func getCognitoClientForCluster(ctx context.Context, provider userpoolAPI, cluster v1alpha1.Cluster) (userPoolClient, error) {
 	relevantUserPoolID, err := getRelevantUserPoolID(ctx, provider, cluster)
 	if err != nil {
 		return userPoolClient{}, fmt.Errorf("getting relevant user pool ID: %w", err)
@@ -114,7 +113,7 @@ func getCognitoClientForCluster(ctx context.Context, provider cognitoidentitypro
 	return userPoolClient{Name: clientName, ID: *relevantUserPoolClient.ClientId}, nil
 }
 
-func getRelevantUserPoolID(ctx context.Context, provider cognitoidentityprovideriface.CognitoIdentityProviderAPI, cluster v1alpha1.Cluster) (string, error) {
+func getRelevantUserPoolID(ctx context.Context, provider userpoolLister, cluster v1alpha1.Cluster) (string, error) {
 	var nextToken *string
 
 	for {
@@ -280,4 +279,17 @@ type userpoolClientsLister interface {
 		*cognitoidentityprovider.ListUserPoolClientsInput,
 		...request.Option,
 	) (*cognitoidentityprovider.ListUserPoolClientsOutput, error)
+}
+
+type userpoolLister interface {
+	ListUserPoolsWithContext(
+		context.Context,
+		*cognitoidentityprovider.ListUserPoolsInput,
+		...request.Option,
+	) (*cognitoidentityprovider.ListUserPoolsOutput, error)
+}
+
+type userpoolAPI interface {
+	userpoolLister
+	userpoolClientsLister
 }

--- a/pkg/cognito/mfa.go
+++ b/pkg/cognito/mfa.go
@@ -54,7 +54,12 @@ func acquireSession(opts RegisterMFADeviceOpts) (string, error) {
 		return "", fmt.Errorf("acquiring Cognito client ID: %w", err)
 	}
 
-	clientSecret, err := getCognitoClientSecretForClient(opts.Ctx, opts.ParameterStoreProvider, cognitoUserPoolclient.Name)
+	clientSecret, err := getCognitoClientSecretForClient(
+		opts.Ctx,
+		opts.ParameterStoreProvider,
+		opts.Cluster.Metadata.Name,
+		cognitoUserPoolclient.Name,
+	)
 	if err != nil {
 		return "", fmt.Errorf("acquiring Cognito client secret: %w", err)
 	}
@@ -100,7 +105,13 @@ func getCognitoClientForCluster(ctx context.Context, provider cognitoidentitypro
 		return userPoolClient{}, fmt.Errorf("getting relevant user pool client: %w", err)
 	}
 
-	return userPoolClient{Name: *relevantUserPoolClient.ClientName, ID: *relevantUserPoolClient.ClientId}, nil
+	clientName := strings.ReplaceAll(
+		*relevantUserPoolClient.ClientName,
+		fmt.Sprintf("okctl-%s-", cluster.Metadata.Name),
+		"",
+	)
+
+	return userPoolClient{Name: clientName, ID: *relevantUserPoolClient.ClientId}, nil
 }
 
 func getRelevantUserPoolID(ctx context.Context, provider cognitoidentityprovideriface.CognitoIdentityProviderAPI, cluster v1alpha1.Cluster) (string, error) {
@@ -166,15 +177,15 @@ func getRelevantUserPoolClient(ctx context.Context, provider userpoolClientsList
 	return cognitoidentityprovider.UserPoolClientDescription{}, fmt.Errorf("no clients found for user pool %s", userPoolID)
 }
 
-func getCognitoClientSecretForClient(ctx context.Context, provider ssmiface.SSMAPI, clientName string) (string, error) {
-	parameterPath := fmt.Sprintf("/%s/client_secret", strings.ReplaceAll(clientName, "-", "/"))
+func getCognitoClientSecretForClient(ctx context.Context, provider ssmiface.SSMAPI, clusterName string, clientName string) (string, error) {
+	parameterPath := path.Join("/", "okctl", clusterName, clientName, "client_secret")
 
 	getParameterResult, err := provider.GetParameterWithContext(ctx, &ssm.GetParameterInput{
 		Name:           aws.String(parameterPath),
 		WithDecryption: aws.Bool(true),
 	})
 	if err != nil {
-		return "", fmt.Errorf("retrieving parameter: %w", err)
+		return "", fmt.Errorf("retrieving parameter \"%s\": %w", parameterPath, err)
 	}
 
 	return *getParameterResult.Parameter.Value, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Removes magic from SSM parameter path construction

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Turns out the original method did not support cluster names containing a dash

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

### Prove bug

1. Run `okctl setup-mfa` with an okctl version without this fix on a cluster
    containing a dash in the name
2. Verify that it is unable to retrieve the relevant SSM parameter

### Prove fix

1. Run `okctl setup-mfa` on the same cluster with this PR
2. Verify that it is now able to retrieve the relevant SSM parameter

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
