### PR TITLE
okctl1020 👌 Move disable early TCP demux functionality to cluster reconciliation

### DIFF
--- a/cmd/okctl/apply_cluster.go
+++ b/cmd/okctl/apply_cluster.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"path"
 
+	"github.com/oslokommune/okctl/pkg/api/core"
+	"github.com/oslokommune/okctl/pkg/api/core/run"
 	"github.com/oslokommune/okctl/pkg/metrics"
 
 	"github.com/oslokommune/okctl/cmd/okctl/hooks"
@@ -118,6 +120,8 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 				return fmt.Errorf("error getting services: %w", err)
 			}
 
+			kubeService := core.NewKubeService(run.NewKubeRun(o.CloudProvider, o.CredentialsProvider.Aws()))
+
 			schedulerOpts := common.SchedulerOpts{
 				Out:                             o.Out,
 				Spinner:                         spin,
@@ -143,7 +147,7 @@ func buildApplyClusterCommand(o *okctl.Okctl) *cobra.Command {
 				reconciliation.NewTempoReconciler(services.Monitoring),
 				reconciliation.NewKubePrometheusStackReconciler(services.Monitoring),
 				reconciliation.NewUsersReconciler(services.IdentityManager),
-				reconciliation.NewPostgresReconciler(services.Component),
+				reconciliation.NewPostgresReconciler(kubeService, services.Component),
 				reconciliation.NewCleanupSGReconciler(o.CloudProvider),
 			)
 

--- a/cmd/okctl/delete_cluster.go
+++ b/cmd/okctl/delete_cluster.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/oslokommune/okctl/cmd/okctl/hooks"
+	"github.com/oslokommune/okctl/pkg/api/core"
+	"github.com/oslokommune/okctl/pkg/api/core/run"
 	"github.com/oslokommune/okctl/pkg/controller/cluster/reconciliation"
 	common "github.com/oslokommune/okctl/pkg/controller/common/reconciliation"
 	"github.com/oslokommune/okctl/pkg/metrics"
@@ -60,6 +62,8 @@ func buildDeleteClusterCommand(o *okctl.Okctl) *cobra.Command {
 				return fmt.Errorf("error getting services: %w", err)
 			}
 
+			kubeService := core.NewKubeService(run.NewKubeRun(o.CloudProvider, o.CredentialsProvider.Aws()))
+
 			schedulerOpts := common.SchedulerOpts{
 				Out:                             o.Out,
 				Spinner:                         spin,
@@ -86,7 +90,7 @@ func buildDeleteClusterCommand(o *okctl.Okctl) *cobra.Command {
 				reconciliation.NewTempoReconciler(services.Monitoring),
 				reconciliation.NewKubePrometheusStackReconciler(services.Monitoring),
 				reconciliation.NewUsersReconciler(services.IdentityManager),
-				reconciliation.NewPostgresReconciler(services.Component),
+				reconciliation.NewPostgresReconciler(kubeService, services.Component),
 				reconciliation.NewCleanupSGReconciler(o.CloudProvider),
 			)
 

--- a/docs/release_notes/0.0.105.md
+++ b/docs/release_notes/0.0.105.md
@@ -6,5 +6,7 @@
 
 ## Changes
 
+👌 Move disable early TCP demux functionality to cluster reconciliation
+
 ## Other
 

--- a/docs/release_notes/0.0.105.md
+++ b/docs/release_notes/0.0.105.md
@@ -6,7 +6,7 @@
 
 ## Changes
 
-👌 Move disable early TCP demux functionality to cluster reconciliation
+#1035 👌 Move disable early TCP demux functionality to cluster reconciliation
 
 ## Other
 

--- a/pkg/api/kube_api.go
+++ b/pkg/api/kube_api.go
@@ -235,8 +235,14 @@ func (o ScaleDeploymentOpts) Validate() error {
 	)
 }
 
+// EarlyTCPDemuxDisabler defines functionality required to disable Early TCP demux in an EKS cluster
+type EarlyTCPDemuxDisabler interface {
+	DisableEarlyDEMUX(ctx context.Context, clusterID ID) error
+}
+
 // KubeService provides kube deployment service layer
 type KubeService interface {
+	EarlyTCPDemuxDisabler
 	CreateExternalDNSKubeDeployment(ctx context.Context, opts CreateExternalDNSKubeDeploymentOpts) (*ExternalDNSKube, error)
 	DeleteNamespace(ctx context.Context, opts DeleteNamespaceOpts) error
 	CreateStorageClass(ctx context.Context, opts CreateStorageClassOpts) (*StorageClassKube, error)
@@ -246,11 +252,11 @@ type KubeService interface {
 	DeleteConfigMap(ctx context.Context, opts DeleteConfigMapOpts) error
 	ScaleDeployment(ctx context.Context, opts ScaleDeploymentOpts) error
 	CreateNamespace(ctx context.Context, opts CreateNamespaceOpts) (*Namespace, error)
-	DisableEarlyDEMUX(ctx context.Context, clusterID ID) error
 }
 
 // KubeRun provides kube deployment run layer
 type KubeRun interface {
+	EarlyTCPDemuxDisabler
 	CreateExternalDNSKubeDeployment(opts CreateExternalDNSKubeDeploymentOpts) (*ExternalDNSKube, error)
 	DeleteNamespace(opts DeleteNamespaceOpts) error
 	CreateStorageClass(opts CreateStorageClassOpts) (*StorageClassKube, error)
@@ -260,5 +266,4 @@ type KubeRun interface {
 	DeleteConfigMap(opts DeleteConfigMapOpts) error
 	ScaleDeployment(opts ScaleDeploymentOpts) error
 	CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error)
-	DisableEarlyDEMUX(ctx context.Context, clusterID ID) error
 }

--- a/pkg/client/application_postgres_client.go
+++ b/pkg/client/application_postgres_client.go
@@ -3,8 +3,6 @@ package client
 import (
 	"context"
 
-	"github.com/oslokommune/okctl/pkg/api"
-
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 )
 
@@ -37,9 +35,4 @@ type ApplicationPostgresService interface {
 	AddPostgresToApplication(ctx context.Context, opts AddPostgresToApplicationOpts) error
 	RemovePostgresFromApplication(ctx context.Context, opts RemovePostgresFromApplicationOpts) error
 	HasPostgresIntegration(ctx context.Context, opts HasPostgresIntegrationOpts) (bool, error)
-}
-
-// ApplicationPostgresAPI defines the
-type ApplicationPostgresAPI interface {
-	DisableEarlyTCPDemux(context.Context, api.ID) error
 }

--- a/pkg/client/core/service_application_postgres_client.go
+++ b/pkg/client/core/service_application_postgres_client.go
@@ -75,11 +75,6 @@ func (a *applicationPostgresService) AddPostgresToApplication(ctx context.Contex
 		return fmt.Errorf("creating security group policy: %w", err)
 	}
 
-	err = a.disableEarlyTCPDemux(ctx, clusterID)
-	if err != nil {
-		return fmt.Errorf("disabling early demux: %w", err)
-	}
-
 	return nil
 }
 
@@ -274,11 +269,6 @@ func (a *applicationPostgresService) newSecurityGroupPatchOperations(
 			Value: appSecurityGroup.ID,
 		},
 	}
-}
-
-// ref: https://aws.amazon.com/blogs/containers/introducing-security-groups-for-pods/
-func (a *applicationPostgresService) disableEarlyTCPDemux(ctx context.Context, clusterID api.ID) error {
-	return a.kubeService.DisableEarlyDEMUX(ctx, clusterID)
 }
 
 func (a *applicationPostgresService) removeSecurityGroupPolicy(

--- a/pkg/controller/cluster/reconciliation/postgres_reconciler_test.go
+++ b/pkg/controller/cluster/reconciliation/postgres_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/oslokommune/okctl/pkg/api"
 	"github.com/oslokommune/okctl/pkg/apis/okctl.io/v1alpha1"
 	"github.com/oslokommune/okctl/pkg/client"
 	clientCore "github.com/oslokommune/okctl/pkg/client/core"
@@ -94,10 +95,10 @@ func TestPostgresReconciler(t *testing.T) {
 			creations := 0
 			deletions := 0
 
-			reconciler := NewPostgresReconciler(&mockPostgresService{
-				creationBump: func() { creations++ },
-				deletionBump: func() { deletions++ },
-			})
+			reconciler := NewPostgresReconciler(
+				mockEarlyTCPDemuxDisabler{},
+				&mockPostgresService{creationBump: func() { creations++ }, deletionBump: func() { deletions++ }},
+			)
 
 			meta := reconciliation.Metadata{
 				ClusterDeclaration: &v1alpha1.Cluster{
@@ -117,6 +118,12 @@ func TestPostgresReconciler(t *testing.T) {
 			assert.Equal(t, tc.expectDeletions, deletions)
 		})
 	}
+}
+
+type mockEarlyTCPDemuxDisabler struct{}
+
+func (mockEarlyTCPDemuxDisabler) DisableEarlyDEMUX(_ context.Context, _ api.ID) error {
+	return nil
 }
 
 type mockPostgresService struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- ✅ Add disable early TCP demux to cluster
- 👌 Remove disable TCP early demux from application reconciliation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#1020

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

1. Run `kubectl -n kube-system get daemonsets.apps aws-node -o yaml | yq eval '.spec.template.spec.initContainers[0].env' | grep -i -a1 demux` and verify that the value is "false". If it is
    true, edit it with `kubectl -n kube-system edit daemonsets.apps aws-node`
	and set it to "false"
2. Run `okctl apply cluster`
3. Run `kubectl -n kube-system get daemonsets.apps aws-node -o yaml | yq eval '.spec.template.spec.initContainers[0].env' | grep -i -a1 demux` and verify that the value is true

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the release notes (for the next release).
