### PR TITLE
#1065 🐛 Fix using deprecated fargate resource quota

### DIFF
--- a/docs/release_notes/0.0.106.md
+++ b/docs/release_notes/0.0.106.md
@@ -4,6 +4,8 @@
 
 ## Bugfixes
 
+#1065 🐛 Fix using deprecated fargate resource quota (#1066) 
+
 ## Changes
 
 ## Other

--- a/pkg/config/constant/api.go
+++ b/pkg/config/constant/api.go
@@ -96,8 +96,8 @@ const (
 	// DefaultRequiredIgws number of internet gateways required for cluster creation
 	DefaultRequiredIgws = 1
 
-	// DefaultRequiredFargateOnDemandPods is the minimum number of fargate pods that should be available
-	DefaultRequiredFargateOnDemandPods = 50
+	// DefaultRequiredFargateVCPUOnDemandResourceCount is the minimum amount of Fargate vCPU units that should be available
+	DefaultRequiredFargateVCPUOnDemandResourceCount = 6
 
 	// DefaultMaxReconciliationRequeues defines the maximum allowed times a reconciliation can be requeued
 	DefaultMaxReconciliationRequeues = 3

--- a/pkg/controller/cluster/reconciliation/cluster_reconciler.go
+++ b/pkg/controller/cluster/reconciliation/cluster_reconciler.go
@@ -149,7 +149,7 @@ func (z *clusterReconciler) hasCreateDependenciesMet(meta reconciliation.Metadat
 	}
 
 	err = servicequota.CheckQuotas(
-		servicequota.NewFargateCheck(constant.DefaultRequiredFargateOnDemandPods, z.cloudProvider),
+		servicequota.NewFargateCheck(constant.DefaultRequiredFargateVCPUOnDemandResourceCount, z.cloudProvider),
 	)
 	if err != nil {
 		return false, fmt.Errorf("checking service quotas: %w", err)

--- a/pkg/servicequota/fargatecheck.go
+++ b/pkg/servicequota/fargatecheck.go
@@ -29,15 +29,15 @@ func NewFargateCheck(required int, provider v1alpha1.CloudProvider) *FargateChec
 	}
 }
 
-// CheckAvailability determines if you have sufficient fargate pods
+// CheckAvailability determines if you have sufficient fargate vCPU resource count
 // nolint: funlen
 func (e *FargateCheck) CheckAvailability() (*Result, error) {
 	q, err := e.provider.ServiceQuotas().GetServiceQuota(&servicequotas.GetServiceQuotaInput{
-		QuotaCode:   aws.String("L-790AF391"),
+		QuotaCode:   aws.String("L-3032A538"),
 		ServiceCode: aws.String("fargate"),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("getting fargate on-demand pods quotas: %w", err)
+		return nil, fmt.Errorf("getting fargate on-demand vCPU resource count: %w", err)
 	}
 
 	now := time.Now()
@@ -69,11 +69,11 @@ func (e *FargateCheck) CheckAvailability() (*Result, error) {
 			},
 			{
 				Name:  aws.String("Resource"),
-				Value: aws.String("OnDemand"),
+				Value: aws.String("vCPU"),
 			},
 			{
 				Name:  aws.String("Class"),
-				Value: aws.String("None"),
+				Value: aws.String("Standard/OnDemand"),
 			},
 		},
 		EndTime:    aws.Time(end),
@@ -86,7 +86,7 @@ func (e *FargateCheck) CheckAvailability() (*Result, error) {
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("getting fargate on-demand pods utilisation: %w", err)
+		return nil, fmt.Errorf("getting Fargate vCPU on-demand resource utilisation: %w", err)
 	}
 
 	quota := int(*q.Quota.Value)
@@ -101,6 +101,6 @@ func (e *FargateCheck) CheckAvailability() (*Result, error) {
 		Required:    e.required,
 		Available:   available,
 		HasCapacity: e.required <= available,
-		Description: "Fargate On-Demand Pods",
+		Description: "Fargate On-Demand vCPU resource count",
 	}, nil
 }

--- a/pkg/servicequota/fargatecheck.go
+++ b/pkg/servicequota/fargatecheck.go
@@ -30,6 +30,7 @@ func NewFargateCheck(required int, provider v1alpha1.CloudProvider) *FargateChec
 }
 
 // CheckAvailability determines if you have sufficient fargate vCPU resource count
+// See: https://docs.aws.amazon.com/general/latest/gr/ecs-service.html#service-quotas-fargate
 // nolint: funlen
 func (e *FargateCheck) CheckAvailability() (*Result, error) {
 	q, err := e.provider.ServiceQuotas().GetServiceQuota(&servicequotas.GetServiceQuotaInput{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Changes Fargate quota resource code in quota check from `L-790AF391`(number of pods) to `L-3032A538`(number of virtual
    CPU units)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1065

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

## Verify the bug

1. Verify that the AWS account you are using has `0 applied quota` Fargate On-Demand resource count by going to 
    `AWS Console -> Service Quotas -> AWS Services -> AWS Fargate -> Fargate On-Demand resource count`
2. Try to create a new cluster (It's the cluster reconciler that has the check) with the latest okctl
3. Verify that the process fails due to lack of available Fargate pods

## Verify the fix

1. Try to create a new cluster with this PR on the same AWS account as above
2. Verify that the process does not fail due to lack of available Fargate Pods

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the release notes (for the next release).
